### PR TITLE
feat(netbox): add opt-in GraphQL search backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,9 @@ MCP prompts are later. See `docs/MCP.md`.
   (`nbox config token set`) → none. Env always overrides the keyring. Inspect the
   active source with `nbox config token status` (never prints the token). Select a
   profile with `--profile <name>` or set the active one.
+- Backend: REST is the default. A profile may set `backend = "graphql"` to use
+  GraphQL for `search`; nbox probes `/graphql/` and adapts to NetBox 4.2, 4.3,
+  and 4.5+ filter/pagination shapes. Non-search operations remain REST-backed.
 - Logging: quiet by default (warnings to stderr). `--log-level` / `NBOX_LOG` /
   `RUST_LOG` set verbosity; `--log-file <PATH>` (or config `log_file`) also tees
   `tracing` output to a file. stdout stays data-only on every path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adapts to NetBox 4.2 unpaginated list fields, NetBox 4.3+ offset pagination,
   and NetBox 4.5+ lookup-wrapper filters for IDs/enums. Probed capabilities are
   cached per client and shared across clones, so repeated TUI searches do not
-  re-run introspection.
+  re-run introspection. GraphQL pagination is capped at NetBox's maximum page
+  size, and list decode errors include the GraphQL list name for easier debugging.
 
 ## [0.2.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Profile-level GraphQL search backend. Set `backend = "graphql"` on a profile to
+  run `nbox search` through NetBox's `/graphql/` endpoint while keeping REST as
+  the default and as the backend for detail lookups, journals, raw reads, and
+  available-IP/prefix commands. The GraphQL path probes the schema at runtime and
+  adapts to NetBox 4.2 unpaginated list fields, NetBox 4.3+ offset pagination,
+  and NetBox 4.5+ lookup-wrapper filters for IDs/enums.
+
 ## [0.2.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default and as the backend for detail lookups, journals, raw reads, and
   available-IP/prefix commands. The GraphQL path probes the schema at runtime and
   adapts to NetBox 4.2 unpaginated list fields, NetBox 4.3+ offset pagination,
-  and NetBox 4.5+ lookup-wrapper filters for IDs/enums.
+  and NetBox 4.5+ lookup-wrapper filters for IDs/enums. Probed capabilities are
+  cached per client and shared across clones, so repeated TUI searches do not
+  re-run introspection.
 
 ## [0.2.0] - 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ confirm_writes = true
 url = "https://netbox.example.com"
 token_env = "NETBOX_TOKEN"
 auth_scheme = "auto"          # auto | bearer | token
+backend = "rest"              # rest | graphql (GraphQL currently backs search)
 verify_tls = true
 timeout_secs = 15
 page_size = 100
@@ -464,8 +465,11 @@ raw escape-hatch tool come later.
 - Targets the NetBox **REST API** (`/api/`) as the primary integration path.
 - Auto-detects **v2 API tokens** (NetBox 4.5+, `Authorization: Bearer nbt_…`) and
   legacy **v1 tokens** (`Authorization: Token …`); force one with `auth_scheme`.
-- Optional, read-only **GraphQL** (`/graphql/`) for nested detail views is on the
-  roadmap (later).
+- Optional, read-only **GraphQL** (`/graphql/`) search backend is available per
+  profile with `backend = "graphql"`. It probes the schema so NetBox 4.2, 4.3,
+  and 4.5+ filter/pagination differences are handled without hard-coding a
+  version. REST remains the default and continues to power detail lookups, raw,
+  journals, and available-IP/prefix operations.
 
 ## Documentation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,8 +98,14 @@ Consolidated future scope:
   list/preview split.
 - ☐ VRF-pivoted navigation in the TUI (a dedicated VRF view) — the `--vrf` filter, VRF-scoped prefix
   sections, and exact VRF-by-RD lookup already ship; this is the navigation layer on top.
-- ☐ Device detail via a read-only GraphQL query as an alternative to the REST fan-out (currently REST;
-  only pursue if the fan-out becomes a latency problem — don't build both).
+- ☐ GraphQL detail views after the TUI detail experience settles — start with device detail as a
+  read-only GraphQL query alternative to the REST fan-out; only pursue if the fan-out becomes a
+  latency problem, and don't build both surfaces indefinitely.
+- ☐ GraphQL backend cleanup once PR #11 has review miles: table-driven search descriptors for the
+  repeated search branches, shared kind→web-path mapping, and less boilerplate around row IDs.
+- ☐ GraphQL capability probing v2 if schema churn demands it: dynamic `*Filter` discovery and/or a
+  short TTL cache keyed by instance/profile to avoid re-probing when users bounce between profiles
+  pointing at the same NetBox.
 - ☐ Batch queries from a file (audits).
 - ☐ Configurable client concurrency for very large instances — `search` is a bounded fan-out and
   `list_all` is `max`-capped today; expose tuning only if a real instance needs it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,13 +6,19 @@ TUI, so output is consistent across both.
 
 ## Layers
 
-- **`netbox/`** — the REST client and wire types.
+- **`netbox/`** — NetBox clients and wire types. REST is canonical; GraphQL is an
+  opt-in search backend.
   - `client.rs` — auth, paging, timeouts; retries HTTP 429 (`Retry-After` +
     backoff); maps statuses to typed errors (401→auth, 403→perms, 404→not-found).
+    The same authenticated client owns `/graphql/` POSTs when a profile selects
+    `backend = "graphql"`.
   - `endpoints.rs` — endpoint paths.
   - `pagination.rs` — `Page<T>`, offset paging (`list` / `list_all`).
   - `query.rs` — per-object resolvers (`*_by_ref`, candidates, scope labels).
-  - `search.rs` — parallel `q=` fan-out → ranked, deduped `SearchOutcome`.
+  - `graphql.rs` — schema capability probing for the GraphQL search backend
+    (filter input shapes and pagination support across NetBox 4.2/4.3/4.5+).
+  - `search.rs` — parallel `q=` fan-out → ranked, deduped `SearchOutcome`;
+    branches to GraphQL only when the active profile asks for it.
   - `models/` — permissive wire structs (`dcim`, `ipam`, `circuits`, `extras`,
     `tenancy`, `common`). Nullable, brief/complete, unknown fields ignored.
 - **`domain/`** — flattened view models, one per object (`device_detail`,
@@ -32,6 +38,8 @@ TUI, so output is consistent across both.
 
 ```
 CLI args ─► lib::run ─► query/search ─► netbox::client ─► NetBox REST
+                                             │
+                                             └──► NetBox GraphQL (search only, opt-in)
                           │
                           ▼
                   domain view model ─► output::emit (plain | json | csv)
@@ -47,5 +55,6 @@ Stable contract (also in AGENTS.md): `0` success · `1` generic · `2` usage ·
 
 ## Locked decisions
 
-NetBox 4.2+ (polymorphic `scope`) · `reqwest` 0.12 · `q=`-primary search ·
-spawned TUI commands · centralized API→web URL conversion · tokens never logged.
+NetBox 4.2+ (polymorphic `scope`) · `reqwest` 0.12 · REST default with opt-in
+schema-probed GraphQL search · `q=`-primary search · spawned TUI commands ·
+centralized API→web URL conversion · tokens never logged.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,6 +25,7 @@ confirm_writes = true
 url = "https://netbox.example.com"
 token_env = "NETBOX_TOKEN"
 auth_scheme = "auto"          # auto | bearer | token
+backend = "rest"              # rest | graphql
 verify_tls = true
 timeout_secs = 15
 page_size = 100
@@ -75,6 +76,26 @@ dependency.)
 Bearer`) versus legacy v1 tokens (`Authorization: Token`). Force one with
 `bearer` or `token`. The token is never logged — request logging shows only the
 scheme marker.
+
+## Backend
+
+`backend = "rest"` is the default and full-coverage path. It uses NetBox's REST
+API for search, detail lookups, journals, raw reads, and available IP/prefix
+queries.
+
+`backend = "graphql"` opts that profile into the GraphQL search backend. nbox
+posts to `/graphql/`, probes the schema, and shapes filters from the advertised
+input types so NetBox 4.2, 4.3, and 4.5+ differences are handled:
+
+- NetBox 4.2 list fields without a `pagination` argument are queried without
+  pagination.
+- NetBox 4.3+ list fields with `pagination` use offset pagination.
+- NetBox 4.5+ ID/enum lookup inputs use equality lookups such as
+  `status: { exact: STATUS_ACTIVE }`.
+
+REST remains the default fallback for non-search operations. Leave the key out,
+or set `backend = "rest"`, unless you specifically want to exercise GraphQL
+search on a profile.
 
 ## UI settings
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -59,6 +59,15 @@ orthogonal to the scope filters above — both may be set, and NetBox ANDs them 
 prefixes. An unknown VRF is a not-found error (exit `4`), not a silent empty
 result.
 
+Profiles can opt search into NetBox GraphQL with `backend = "graphql"`.
+GraphQL search returns the same normalized `SearchResult` shape and keeps the
+same fail-closed/`--partial` behavior. nbox probes `/graphql/` at runtime and
+adapts to the schema: NetBox 4.2's unpaginated list fields, NetBox 4.3+'s offset
+pagination, and NetBox 4.5+'s lookup-wrapper filters are all shaped from
+introspection rather than version strings. REST remains the default backend and
+still powers detail lookups, raw reads, journals, and available-IP/prefix
+commands.
+
 ## Output
 
 Every data command takes `-o plain|json` (`--json` is shorthand). JSON adds

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -22,6 +22,7 @@ confirm_writes = true      # reserved for v0.2 writes
 url = "https://netbox.example.com"
 token_env = "NETBOX_TOKEN"   # nbox reads the token from this env var
 auth_scheme = "auto"         # auto | bearer | token (auto-detects v2 nbt_ tokens)
+backend = "rest"             # rest | graphql (GraphQL currently backs search)
 verify_tls = true
 timeout_secs = 15
 page_size = 100

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ open_browser_command = ""
 url = "https://netbox.example.com"
 token_env = "NETBOX_TOKEN"
 auth_scheme = "auto"        # auto | bearer | token
+backend = "rest"            # rest | graphql
 verify_tls = true
 timeout_secs = 15
 page_size = 100
@@ -184,6 +185,9 @@ pub struct ProfileConfig {
     pub auth_scheme: Option<AuthScheme>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend: Option<BackendKind>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verify_tls: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -194,6 +198,25 @@ pub struct ProfileConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_config_context: Option<bool>,
+}
+
+/// Which NetBox read backend a profile should prefer.
+///
+/// REST remains the default and full-coverage backend. GraphQL is opt-in and may
+/// fall back to REST for operations NetBox does not expose through GraphQL.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKind {
+    #[default]
+    Rest,
+    Graphql,
+}
+
+impl ProfileConfig {
+    #[must_use]
+    pub fn backend(&self) -> BackendKind {
+        self.backend.unwrap_or_default()
+    }
 }
 
 fn default_theme() -> String {
@@ -948,6 +971,7 @@ theme = "nord"
 url = "https://netbox.example.com"
 token_env = "NETBOX_TOKEN"
 auth_scheme = "bearer"
+backend = "graphql"
 page_size = 250
 "#;
 
@@ -961,8 +985,15 @@ page_size = 250
         let work = &cfg.profiles["work"];
         assert_eq!(work.url, "https://netbox.example.com");
         assert_eq!(work.auth_scheme, Some(AuthScheme::Bearer));
+        assert_eq!(work.backend(), BackendKind::Graphql);
         assert_eq!(work.page_size, Some(250));
         assert_eq!(work.verify_tls, None);
+    }
+
+    #[test]
+    fn profile_backend_defaults_to_rest() {
+        let profile: ProfileConfig = toml::from_str("url = \"https://nb.example\"").unwrap();
+        assert_eq!(profile.backend(), BackendKind::Rest);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 tag,
                 vrf,
             };
-            run_search(&ctx, &query, limit, filters, cols, partial).await
+            Box::pin(run_search(&ctx, &query, limit, filters, cols, partial)).await
         }
         Some(Command::Device {
             value,
@@ -844,13 +844,12 @@ async fn run_search(
     partial: bool,
 ) -> Result<()> {
     let client = connect(ctx)?;
-    let outcome = client
-        .search(SearchRequest {
-            query: query.to_string(),
-            limit,
-            filters,
-        })
-        .await?;
+    let outcome = Box::pin(client.search(SearchRequest {
+        query: query.to_string(),
+        limit,
+        filters,
+    }))
+    .await?;
 
     // Fail closed by default: if some endpoints failed, don't present partial
     // results as if they were complete. `--partial` opts into a best-effort run.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -408,25 +408,23 @@ impl NboxMcp {
         &self,
         Parameters(args): Parameters<SearchArgs>,
     ) -> Result<Json<SearchReport>, ErrorData> {
-        let outcome = self
-            .client
-            .search(SearchRequest {
-                query: args.query,
-                limit: args.limit.unwrap_or(25),
-                filters: SearchFilters {
-                    status: args.status,
-                    site: args.site,
-                    region: args.region,
-                    site_group: args.site_group,
-                    location: args.location,
-                    tenant: args.tenant,
-                    role: args.role,
-                    tag: args.tag,
-                    vrf: args.vrf,
-                },
-            })
-            .await
-            .map_err(to_mcp_error)?;
+        let outcome = Box::pin(self.client.search(SearchRequest {
+            query: args.query,
+            limit: args.limit.unwrap_or(25),
+            filters: SearchFilters {
+                status: args.status,
+                site: args.site,
+                region: args.region,
+                site_group: args.site_group,
+                location: args.location,
+                tenant: args.tenant,
+                role: args.role,
+                tag: args.tag,
+                vrf: args.vrf,
+            },
+        }))
+        .await
+        .map_err(to_mcp_error)?;
 
         // Fail-closed reporting: surface partial-failure endpoints alongside the
         // results so the agent can decide whether the set is trustworthy.

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -8,10 +8,12 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use reqwest::Url;
-use reqwest::header::{ACCEPT, AUTHORIZATION};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 
-use crate::config::ProfileConfig;
+use crate::config::{BackendKind, ProfileConfig};
 use crate::error::NboxError;
 use crate::netbox::auth::AuthScheme;
 use crate::netbox::endpoints::Endpoint;
@@ -34,6 +36,7 @@ pub struct NetBoxClient {
     http: reqwest::Client,
     page_size: usize,
     exclude_config_context: bool,
+    backend: BackendKind,
 }
 
 impl NetBoxClient {
@@ -74,7 +77,13 @@ impl NetBoxClient {
             http,
             page_size,
             exclude_config_context: profile.exclude_config_context.unwrap_or(true),
+            backend: profile.backend(),
         })
+    }
+
+    /// The preferred read backend for this client/profile.
+    pub fn backend(&self) -> BackendKind {
+        self.backend
     }
 
     /// The effective page size sent as `limit` (clamped into `1..=MAX_PAGE_SIZE`).
@@ -191,6 +200,84 @@ impl NetBoxClient {
         self.get(endpoint.path(), &params).await
     }
 
+    /// Perform an authenticated GraphQL POST and deserialize the `data` object.
+    ///
+    /// GraphQL rides the same NetBox base URL, auth header, TLS settings, timeout,
+    /// and 429 retry policy as REST. GraphQL-level errors are mapped to the
+    /// generic API exit-code bucket; HTTP 401/403/404 keep the stable status
+    /// mapping from REST.
+    pub(crate) async fn graphql<T, V>(&self, query: &str, variables: V) -> Result<T>
+    where
+        T: DeserializeOwned,
+        V: Serialize,
+    {
+        const MAX_RETRIES: u32 = 3;
+        let url = self.url_for("/graphql/")?;
+        let body = json!({
+            "query": query,
+            "variables": variables,
+        });
+
+        match self.masked_authorization() {
+            Some(auth) => tracing::debug!(url = %url, auth = %auth, "GraphQL POST"),
+            None => tracing::debug!(url = %url, "GraphQL POST (unauthenticated)"),
+        }
+
+        let mut attempt = 0;
+        loop {
+            let mut req = self
+                .http
+                .post(url.clone())
+                .header(ACCEPT, "application/json")
+                .header(CONTENT_TYPE, "application/json")
+                .json(&body);
+            if let Some(token) = &self.token {
+                req = req.header(AUTHORIZATION, self.auth_scheme.header_value(token));
+            }
+
+            let res = req
+                .send()
+                .await
+                .context("sending GraphQL request to NetBox")?;
+            if res.status() == reqwest::StatusCode::TOO_MANY_REQUESTS && attempt < MAX_RETRIES {
+                let wait = parse_retry_after(
+                    res.headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(|v| v.to_str().ok()),
+                )
+                .unwrap_or_else(|| backoff(attempt));
+                tracing::warn!("NetBox GraphQL rate limited (429); retrying in {wait:?}");
+                tokio::time::sleep(wait).await;
+                attempt += 1;
+                continue;
+            }
+
+            return Self::decode_graphql(res).await;
+        }
+    }
+
+    async fn decode_graphql<T: DeserializeOwned>(res: reqwest::Response) -> Result<T> {
+        let status = res.status();
+        if !status.is_success() {
+            let body = res.text().await.unwrap_or_default();
+            return Err(status_error(status, &body).into());
+        }
+
+        let envelope: GraphqlEnvelope<T> = res.json().await.context("decoding GraphQL response")?;
+        if !envelope.errors.is_empty() {
+            let body = envelope
+                .errors
+                .into_iter()
+                .map(|e| e.message)
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(NboxError::Api { status: 200, body }.into());
+        }
+        envelope
+            .data
+            .context("GraphQL response did not include data")
+    }
+
     /// Page through a list endpoint, collecting up to `max` objects.
     pub async fn list_all<T>(
         &self,
@@ -230,6 +317,18 @@ impl NetBoxClient {
         out.truncate(max);
         Ok(out)
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlEnvelope<T> {
+    data: Option<T>,
+    #[serde(default)]
+    errors: Vec<GraphqlError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
 }
 
 /// Parse a `Retry-After` header value (delay in seconds; HTTP-date form is not

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -4,6 +4,7 @@
 //! the per-profile config-context optimization. Tokens are never logged — debug
 //! logging emits a redacted scheme marker only (see [`NetBoxClient::masked_authorization`]).
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -17,6 +18,7 @@ use crate::config::{BackendKind, ProfileConfig};
 use crate::error::NboxError;
 use crate::netbox::auth::AuthScheme;
 use crate::netbox::endpoints::Endpoint;
+use crate::netbox::graphql::GraphqlCapabilities;
 use crate::netbox::pagination::Page;
 
 /// NetBox's default list page size when no `limit` is sent.
@@ -37,6 +39,7 @@ pub struct NetBoxClient {
     page_size: usize,
     exclude_config_context: bool,
     backend: BackendKind,
+    graphql_capabilities: Arc<tokio::sync::OnceCell<GraphqlCapabilities>>,
 }
 
 impl NetBoxClient {
@@ -78,12 +81,17 @@ impl NetBoxClient {
             page_size,
             exclude_config_context: profile.exclude_config_context.unwrap_or(true),
             backend: profile.backend(),
+            graphql_capabilities: Arc::new(tokio::sync::OnceCell::new()),
         })
     }
 
     /// The preferred read backend for this client/profile.
     pub fn backend(&self) -> BackendKind {
         self.backend
+    }
+
+    pub(crate) fn graphql_capability_cache(&self) -> &tokio::sync::OnceCell<GraphqlCapabilities> {
+        &self.graphql_capabilities
     }
 
     /// The effective page size sent as `limit` (clamped into `1..=MAX_PAGE_SIZE`).

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -27,7 +27,7 @@ const DEFAULT_PAGE_SIZE: usize = 100;
 /// NetBox caps `limit` at `MAX_PAGE_SIZE` server-side; sending more is silently
 /// reduced to this, so we clamp at construction to keep `limit`/`offset` windows
 /// aligned (see `list_all`).
-const MAX_PAGE_SIZE: usize = 1000;
+pub(crate) const MAX_PAGE_SIZE: usize = 1000;
 
 /// An HTTP client bound to a single NetBox instance/profile.
 #[derive(Clone)]

--- a/src/netbox/graphql.rs
+++ b/src/netbox/graphql.rs
@@ -1,0 +1,427 @@
+//! GraphQL schema capability helpers.
+//!
+//! NetBox's GraphQL surface has changed across the 4.x line: 4.2 list fields
+//! have no pagination argument, 4.3 adds offset pagination, and 4.5 requires
+//! lookup objects for ID/enum filters. Rather than branching solely on the
+//! version string, nbox probes the schema and shapes filters from the advertised
+//! input types.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::netbox::client::NetBoxClient;
+
+const QUERY_INTROSPECTION: &str = r"
+query {
+  __schema {
+    queryType {
+      fields {
+        name
+        args {
+          name
+          type { kind name ofType { kind name ofType { kind name ofType { kind name } } } }
+        }
+      }
+    }
+  }
+}
+";
+
+const FILTER_INTROSPECTION_A: &str = r#"
+query {
+  device: __type(name: "DeviceFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  site: __type(name: "SiteFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  ip: __type(name: "IPAddressFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  prefix: __type(name: "PrefixFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  vlan: __type(name: "VLANFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  circuit: __type(name: "CircuitFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  aggregate: __type(name: "AggregateFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+}
+"#;
+
+const FILTER_INTROSPECTION_B: &str = r#"
+query {
+  asn: __type(name: "ASNFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  ipRange: __type(name: "IPRangeFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  tenant: __type(name: "TenantFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  contact: __type(name: "ContactFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  provider: __type(name: "ProviderFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  virtualMachine: __type(name: "VirtualMachineFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  cluster: __type(name: "ClusterFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+}
+"#;
+
+#[derive(Debug, Clone, Default)]
+pub struct GraphqlCapabilities {
+    list_fields: HashMap<String, ListField>,
+    filters: HashMap<String, HashMap<String, FilterField>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListField {
+    filter_type: Option<String>,
+    pagination_arg: Option<String>,
+}
+
+impl ListField {
+    #[must_use]
+    pub fn filter_type(&self) -> Option<&str> {
+        self.filter_type.as_deref()
+    }
+
+    #[must_use]
+    pub fn has_pagination(&self) -> bool {
+        self.pagination_arg.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilterShape {
+    Scalar,
+    List,
+    Lookup,
+}
+
+impl GraphqlCapabilities {
+    #[must_use]
+    pub fn list(&self, name: &str) -> Option<&ListField> {
+        self.list_fields.get(name)
+    }
+
+    #[must_use]
+    pub fn filter_shape(&self, filter_type: &str, name: &str) -> Option<FilterShape> {
+        self.filters
+            .get(filter_type)
+            .and_then(|fields| fields.get(name).map(|field| field.shape))
+    }
+
+    /// Shape a filter value for the current NetBox schema.
+    ///
+    /// Pre-4.5 schemas often expose IDs/enums as scalars or string lists, while
+    /// 4.5+ exposes lookup input objects. For lookup inputs, `exact` preserves the
+    /// old equality semantics.
+    #[must_use]
+    pub fn filter_value(&self, filter_type: &str, name: &str, value: Value) -> Option<Value> {
+        let field = self.filters.get(filter_type)?.get(name)?;
+        let value = normalize_filter_value(name, value, field);
+        match field.shape {
+            FilterShape::Scalar => Some(value),
+            FilterShape::List => Some(Value::Array(vec![coerce_list_item(value)])),
+            FilterShape::Lookup => Some(json!({ "exact": value })),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FilterField {
+    shape: FilterShape,
+    named_type: Option<String>,
+}
+
+impl NetBoxClient {
+    pub async fn graphql_capabilities(&self) -> Result<GraphqlCapabilities> {
+        let schema: SchemaResponse = self.graphql(QUERY_INTROSPECTION, json!({})).await?;
+        let first: FilterResponse = self.graphql(FILTER_INTROSPECTION_A, json!({})).await?;
+        let second: FilterResponse = self.graphql(FILTER_INTROSPECTION_B, json!({})).await?;
+        Ok(GraphqlCapabilities::from_parts(
+            schema.schema,
+            [first, second],
+        ))
+    }
+}
+
+fn coerce_list_item(value: Value) -> Value {
+    match value {
+        Value::Number(n) => Value::String(n.to_string()),
+        other => other,
+    }
+}
+
+fn normalize_filter_value(name: &str, value: Value, field: &FilterField) -> Value {
+    if name != "status" || field.named_type.as_deref() == Some("String") {
+        return value;
+    }
+    let Value::String(status) = value else {
+        return value;
+    };
+    if status.starts_with("STATUS_") {
+        Value::String(status)
+    } else {
+        Value::String(format!(
+            "STATUS_{}",
+            status
+                .chars()
+                .map(|c| if c == '-' {
+                    '_'
+                } else {
+                    c.to_ascii_uppercase()
+                })
+                .collect::<String>()
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SchemaResponse {
+    #[serde(rename = "__schema")]
+    schema: Schema,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilterResponse {
+    device: Option<InputType>,
+    site: Option<InputType>,
+    ip: Option<InputType>,
+    prefix: Option<InputType>,
+    vlan: Option<InputType>,
+    circuit: Option<InputType>,
+    aggregate: Option<InputType>,
+    asn: Option<InputType>,
+    ip_range: Option<InputType>,
+    tenant: Option<InputType>,
+    contact: Option<InputType>,
+    provider: Option<InputType>,
+    virtual_machine: Option<InputType>,
+    cluster: Option<InputType>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Schema {
+    query_type: QueryType,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryType {
+    fields: Vec<QueryField>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryField {
+    name: String,
+    args: Vec<QueryArg>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryArg {
+    name: String,
+    #[serde(rename = "type")]
+    type_: TypeRef,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InputType {
+    input_fields: Option<Vec<InputField>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InputField {
+    name: String,
+    #[serde(rename = "type")]
+    type_: TypeRef,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct TypeRef {
+    kind: String,
+    name: Option<String>,
+    #[serde(rename = "ofType")]
+    of_type: Option<Box<TypeRef>>,
+}
+
+impl TypeRef {
+    fn named(&self) -> Option<&str> {
+        self.name
+            .as_deref()
+            .or_else(|| self.of_type.as_ref()?.named())
+    }
+
+    fn outer_kind(&self) -> &str {
+        if self.kind == "NON_NULL" {
+            self.of_type
+                .as_ref()
+                .map_or(self.kind.as_str(), |inner| inner.outer_kind())
+        } else {
+            &self.kind
+        }
+    }
+
+    fn shape(&self) -> FilterShape {
+        match self.outer_kind() {
+            "LIST" => FilterShape::List,
+            "INPUT_OBJECT" => FilterShape::Lookup,
+            _ => FilterShape::Scalar,
+        }
+    }
+}
+
+impl GraphqlCapabilities {
+    fn from_parts<const N: usize>(schema: Schema, batches: [FilterResponse; N]) -> Self {
+        let mut list_fields = HashMap::new();
+        for field in schema.query_type.fields {
+            if !field.name.ends_with("_list") {
+                continue;
+            }
+            let filter_type = field
+                .args
+                .iter()
+                .find(|arg| arg.name == "filters")
+                .and_then(|arg| arg.type_.named())
+                .map(str::to_string);
+            let pagination_arg = field
+                .args
+                .iter()
+                .find(|arg| arg.name == "pagination")
+                .map(|arg| arg.name.clone());
+            list_fields.insert(
+                field.name,
+                ListField {
+                    filter_type,
+                    pagination_arg,
+                },
+            );
+        }
+
+        let mut filters = HashMap::new();
+        for batch in batches {
+            for (name, input) in batch.inputs() {
+                let Some(input) = input else {
+                    continue;
+                };
+                let Some(fields) = input.input_fields else {
+                    continue;
+                };
+                filters.insert(
+                    name.to_string(),
+                    fields
+                        .into_iter()
+                        .map(|f| {
+                            (
+                                f.name,
+                                FilterField {
+                                    shape: f.type_.shape(),
+                                    named_type: f.type_.named().map(str::to_string),
+                                },
+                            )
+                        })
+                        .collect::<HashMap<_, _>>(),
+                );
+            }
+        }
+
+        Self {
+            list_fields,
+            filters,
+        }
+    }
+}
+
+impl FilterResponse {
+    fn inputs(self) -> [(&'static str, Option<InputType>); 14] {
+        [
+            ("DeviceFilter", self.device),
+            ("SiteFilter", self.site),
+            ("IPAddressFilter", self.ip),
+            ("PrefixFilter", self.prefix),
+            ("VLANFilter", self.vlan),
+            ("CircuitFilter", self.circuit),
+            ("AggregateFilter", self.aggregate),
+            ("ASNFilter", self.asn),
+            ("IPRangeFilter", self.ip_range),
+            ("TenantFilter", self.tenant),
+            ("ContactFilter", self.contact),
+            ("ProviderFilter", self.provider),
+            ("VirtualMachineFilter", self.virtual_machine),
+            ("ClusterFilter", self.cluster),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_filter_values_match_schema_shape() {
+        let mut caps = GraphqlCapabilities::default();
+        caps.filters.insert(
+            "DeviceFilter".into(),
+            HashMap::from([
+                (
+                    "q".into(),
+                    FilterField {
+                        shape: FilterShape::Scalar,
+                        named_type: Some("String".into()),
+                    },
+                ),
+                (
+                    "site_id".into(),
+                    FilterField {
+                        shape: FilterShape::List,
+                        named_type: None,
+                    },
+                ),
+                (
+                    "id".into(),
+                    FilterField {
+                        shape: FilterShape::Lookup,
+                        named_type: Some("IDFilterLookup".into()),
+                    },
+                ),
+            ]),
+        );
+
+        assert_eq!(
+            caps.filter_value("DeviceFilter", "q", json!("edge")),
+            Some(json!("edge"))
+        );
+        assert_eq!(
+            caps.filter_value("DeviceFilter", "site_id", json!(1)),
+            Some(json!(["1"]))
+        );
+        assert_eq!(
+            caps.filter_value("DeviceFilter", "id", json!(1)),
+            Some(json!({ "exact": 1 }))
+        );
+    }
+
+    #[test]
+    fn status_filter_keeps_legacy_string_but_normalizes_enum_schema() {
+        let mut caps = GraphqlCapabilities::default();
+        caps.filters.insert(
+            "LegacyFilter".into(),
+            HashMap::from([(
+                "status".into(),
+                FilterField {
+                    shape: FilterShape::Scalar,
+                    named_type: Some("String".into()),
+                },
+            )]),
+        );
+        caps.filters.insert(
+            "EnumFilter".into(),
+            HashMap::from([(
+                "status".into(),
+                FilterField {
+                    shape: FilterShape::Lookup,
+                    named_type: Some("StatusFilterLookup".into()),
+                },
+            )]),
+        );
+
+        assert_eq!(
+            caps.filter_value("LegacyFilter", "status", json!("active")),
+            Some(json!("active"))
+        );
+        assert_eq!(
+            caps.filter_value("EnumFilter", "status", json!("active")),
+            Some(json!({ "exact": "STATUS_ACTIVE" }))
+        );
+    }
+}

--- a/src/netbox/graphql.rs
+++ b/src/netbox/graphql.rs
@@ -123,6 +123,14 @@ struct FilterField {
 
 impl NetBoxClient {
     pub async fn graphql_capabilities(&self) -> Result<GraphqlCapabilities> {
+        let capabilities = self
+            .graphql_capability_cache()
+            .get_or_try_init(|| async { self.load_graphql_capabilities().await })
+            .await?;
+        Ok(capabilities.clone())
+    }
+
+    async fn load_graphql_capabilities(&self) -> Result<GraphqlCapabilities> {
         let schema: SchemaResponse = self.graphql(QUERY_INTROSPECTION, json!({})).await?;
         let first: FilterResponse = self.graphql(FILTER_INTROSPECTION_A, json!({})).await?;
         let second: FilterResponse = self.graphql(FILTER_INTROSPECTION_B, json!({})).await?;

--- a/src/netbox/graphql.rs
+++ b/src/netbox/graphql.rs
@@ -300,9 +300,17 @@ impl GraphqlCapabilities {
         for batch in batches {
             for (name, input) in batch.inputs() {
                 let Some(input) = input else {
+                    tracing::warn!(
+                        filter_type = name,
+                        "NetBox GraphQL filter type missing from introspection; filtered searches for this branch may be skipped"
+                    );
                     continue;
                 };
                 let Some(fields) = input.input_fields else {
+                    tracing::warn!(
+                        filter_type = name,
+                        "NetBox GraphQL filter type has no inputFields; filtered searches for this branch may be skipped"
+                    );
                     continue;
                 };
                 filters.insert(

--- a/src/netbox/mod.rs
+++ b/src/netbox/mod.rs
@@ -7,6 +7,7 @@
 pub mod auth;
 pub mod client;
 pub mod endpoints;
+pub mod graphql;
 pub mod models;
 pub mod pagination;
 pub mod query;

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -6,14 +6,14 @@
 
 use std::collections::HashSet;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
 use crate::config::BackendKind;
-use crate::netbox::client::NetBoxClient;
+use crate::netbox::client::{MAX_PAGE_SIZE, NetBoxClient};
 use crate::netbox::endpoints::Endpoint;
 use crate::netbox::graphql::GraphqlCapabilities;
 use crate::netbox::models::circuits::{Circuit, Provider};
@@ -261,6 +261,8 @@ impl NetBoxClient {
     /// [`SearchOutcome::errors`] for the caller to act on.
     pub async fn search(&self, req: SearchRequest) -> Result<SearchOutcome> {
         if self.backend() == BackendKind::Graphql {
+            // Keep the large GraphQL fan-out future boxed at this public entry
+            // point so spawned call sites can await `search()` normally.
             return Box::pin(self.search_graphql(req)).await;
         }
 
@@ -558,8 +560,9 @@ impl NetBoxClient {
         let Some(filter_type) = field.filter_type() else {
             return Ok(Vec::new());
         };
+        let page_limit = limit.clamp(1, MAX_PAGE_SIZE);
         let pagination = if field.has_pagination() {
-            format!(", pagination: {{offset: 0, limit: {}}}", limit.max(1))
+            format!(", pagination: {{offset: 0, limit: {page_limit}}}")
         } else {
             String::new()
         };
@@ -571,7 +574,8 @@ impl NetBoxClient {
             .get(list_name)
             .cloned()
             .unwrap_or_else(|| Value::Array(Vec::new()));
-        serde_json::from_value(rows).map_err(Into::into)
+        serde_json::from_value(rows)
+            .with_context(|| format!("deserializing GraphQL {list_name} rows"))
     }
 
     fn gql_filters(
@@ -836,6 +840,9 @@ impl NetBoxClient {
                 json!(scope.id),
             )
         {
+            // Prefer the friendly per-scope key when NetBox exposes one. The
+            // 4.2+ polymorphic shape instead exposes `scope_type`+`scope_id`,
+            // which preserves exact scope semantics across site/region/group/location.
             let added_type = Self::gql_add_filter(
                 caps,
                 "prefix_list",
@@ -1334,6 +1341,8 @@ impl NetBoxClient {
                 json!(scope.id),
             )
         {
+            // Prefer the friendly per-scope key when available; otherwise fall
+            // back to NetBox's polymorphic `scope_type`+`scope_id` filters.
             let added_type = Self::gql_add_filter(
                 caps,
                 "cluster_list",
@@ -1945,7 +1954,18 @@ trait GqlId {
     fn raw_id(&self) -> Option<&str>;
 
     fn id(&self) -> Option<u64> {
-        self.raw_id()?.parse().ok()
+        let raw_id = self.raw_id()?;
+        match raw_id.parse() {
+            Ok(id) => Some(id),
+            Err(error) => {
+                tracing::debug!(
+                    raw_id,
+                    error = %error,
+                    "dropping GraphQL search row with non-numeric id"
+                );
+                None
+            }
+        }
     }
 }
 

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -8,10 +8,14 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use schemars::JsonSchema;
-use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
 
+use crate::config::BackendKind;
 use crate::netbox::client::NetBoxClient;
 use crate::netbox::endpoints::Endpoint;
+use crate::netbox::graphql::GraphqlCapabilities;
 use crate::netbox::models::circuits::{Circuit, Provider};
 use crate::netbox::models::dcim::{Device, Site};
 use crate::netbox::models::ipam::{Aggregate, Asn, IpAddress, IpRange, Prefix, Vlan};
@@ -256,6 +260,10 @@ impl NetBoxClient {
     /// failure — some endpoints down, others returning data — is reported via
     /// [`SearchOutcome::errors`] for the caller to act on.
     pub async fn search(&self, req: SearchRequest) -> Result<SearchOutcome> {
+        if self.backend() == BackendKind::Graphql {
+            return Box::pin(self.search_graphql(req)).await;
+        }
+
         let q = req.query.trim().to_string();
         let f = &req.filters;
 
@@ -360,6 +368,94 @@ impl NetBoxClient {
         })
     }
 
+    async fn search_graphql(&self, req: SearchRequest) -> Result<SearchOutcome> {
+        let q = req.query.trim().to_string();
+        let f = &req.filters;
+        let scope = self.resolve_scope(f).await?;
+        let vrf_id = self.resolve_vrf(f).await?;
+        let caps = self.graphql_capabilities().await?;
+
+        let (
+            devices,
+            sites,
+            ips,
+            prefixes,
+            vlans,
+            circuits,
+            aggregates,
+            asns,
+            ip_ranges,
+            tenants,
+            contacts,
+            providers,
+            vms,
+            clusters,
+        ) = tokio::join!(
+            self.gql_search_devices(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_sites(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_ips(&caps, &q, f, scope.as_ref(), vrf_id, req.limit),
+            self.gql_search_prefixes(&caps, &q, f, scope.as_ref(), vrf_id, req.limit),
+            self.gql_search_vlans(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_circuits(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_aggregates(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_asns(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_ip_ranges(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_tenants(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_contacts(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_providers(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_vms(&caps, &q, f, scope.as_ref(), req.limit),
+            self.gql_search_clusters(&caps, &q, f, scope.as_ref(), req.limit),
+        );
+
+        let mut merged = Vec::new();
+        let mut errors = Vec::new();
+        let mut last_err = None;
+        for (name, branch) in [
+            ("devices", devices),
+            ("sites", sites),
+            ("ips", ips),
+            ("prefixes", prefixes),
+            ("vlans", vlans),
+            ("circuits", circuits),
+            ("aggregates", aggregates),
+            ("asns", asns),
+            ("ip-ranges", ip_ranges),
+            ("tenants", tenants),
+            ("contacts", contacts),
+            ("providers", providers),
+            ("vms", vms),
+            ("clusters", clusters),
+        ] {
+            match branch {
+                Ok(mut items) => merged.append(&mut items),
+                Err(e) => {
+                    tracing::warn!("GraphQL search branch '{name}' failed: {e:#}");
+                    errors.push(format!("{name}: {e:#}"));
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        if merged.is_empty()
+            && let Some(e) = last_err
+        {
+            return Err(e);
+        }
+
+        merged.sort_by(|a, b| {
+            b.score
+                .cmp(&a.score)
+                .then_with(|| a.display.cmp(&b.display))
+        });
+        let mut seen = HashSet::new();
+        merged.retain(|r| seen.insert((r.kind, r.id)));
+        merged.truncate(req.limit);
+        Ok(SearchOutcome {
+            results: merged,
+            errors,
+        })
+    }
+
     /// Resolve the (at most one) active scope filter to a content type + id.
     ///
     /// `--site`/`--region`/`--site-group`/`--location` are mutually exclusive: the
@@ -443,6 +539,843 @@ impl NetBoxClient {
             .await?
             .ok_or_else(|| not_found("VRF", reference))?;
         Ok(Some(v.id))
+    }
+
+    async fn graphql_list<T>(
+        &self,
+        caps: &GraphqlCapabilities,
+        list_name: &str,
+        filters: Value,
+        selection: &str,
+        limit: usize,
+    ) -> Result<Vec<T>>
+    where
+        T: DeserializeOwned,
+    {
+        let Some(field) = caps.list(list_name) else {
+            return Ok(Vec::new());
+        };
+        let Some(filter_type) = field.filter_type() else {
+            return Ok(Vec::new());
+        };
+        let pagination = if field.has_pagination() {
+            format!(", pagination: {{offset: 0, limit: {}}}", limit.max(1))
+        } else {
+            String::new()
+        };
+        let query = format!(
+            "query($filters: {filter_type}) {{ {list_name}(filters: $filters{pagination}) {{ {selection} }} }}"
+        );
+        let data: Map<String, Value> = self.graphql(&query, json!({ "filters": filters })).await?;
+        let rows = data
+            .get(list_name)
+            .cloned()
+            .unwrap_or_else(|| Value::Array(Vec::new()));
+        serde_json::from_value(rows).map_err(Into::into)
+    }
+
+    fn gql_filters(
+        caps: &GraphqlCapabilities,
+        list_name: &str,
+        q: &str,
+        f: &SearchFilters,
+        supported: &[&str],
+    ) -> Option<Map<String, Value>> {
+        let filter_type = caps.list(list_name)?.filter_type()?;
+        let mut filters = Map::new();
+        if let Some(v) = caps.filter_value(filter_type, "q", json!(q)) {
+            filters.insert("q".into(), v);
+        }
+
+        for (key, active) in [
+            ("status", &f.status),
+            ("tenant", &f.tenant),
+            ("role", &f.role),
+            ("tag", &f.tag),
+        ] {
+            let Some(value) = active else {
+                continue;
+            };
+            if !supported.contains(&key) {
+                return None;
+            }
+            let v = caps.filter_value(filter_type, key, json!(value))?;
+            filters.insert(key.into(), v);
+        }
+        Some(filters)
+    }
+
+    fn gql_add_filter(
+        caps: &GraphqlCapabilities,
+        list_name: &str,
+        filters: &mut Map<String, Value>,
+        key: &str,
+        value: Value,
+    ) -> bool {
+        let Some(filter_type) = caps.list(list_name).and_then(|field| field.filter_type()) else {
+            return false;
+        };
+        let Some(value) = caps.filter_value(filter_type, key, value) else {
+            return false;
+        };
+        filters.insert(key.into(), value);
+        true
+    }
+
+    fn gql_scope_filter_key(scope: &ResolvedScope) -> &'static str {
+        match scope.content_type {
+            "dcim.site" => "site_id",
+            "dcim.region" => "region_id",
+            "dcim.sitegroup" => "site_group_id",
+            "dcim.location" => "location_id",
+            _ => "scope_id",
+        }
+    }
+
+    fn gql_web_url(&self, kind: ObjectKind, id: u64) -> String {
+        let path = match kind {
+            ObjectKind::Device => format!("dcim/devices/{id}/"),
+            ObjectKind::Site => format!("dcim/sites/{id}/"),
+            ObjectKind::IpAddress => format!("ipam/ip-addresses/{id}/"),
+            ObjectKind::Prefix => format!("ipam/prefixes/{id}/"),
+            ObjectKind::Vlan => format!("ipam/vlans/{id}/"),
+            ObjectKind::Circuit => format!("circuits/circuits/{id}/"),
+            ObjectKind::Aggregate => format!("ipam/aggregates/{id}/"),
+            ObjectKind::Asn => format!("ipam/asns/{id}/"),
+            ObjectKind::IpRange => format!("ipam/ip-ranges/{id}/"),
+            ObjectKind::Tenant => format!("tenancy/tenants/{id}/"),
+            ObjectKind::Contact => format!("tenancy/contacts/{id}/"),
+            ObjectKind::Provider => format!("circuits/providers/{id}/"),
+            ObjectKind::Vm => format!("virtualization/virtual-machines/{id}/"),
+            ObjectKind::Cluster => format!("virtualization/clusters/{id}/"),
+        };
+        self.base_url()
+            .join(&path)
+            .map_or_else(|_| path, |url| url.to_string())
+    }
+
+    async fn gql_search_devices(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let Some(mut filters) = Self::gql_filters(
+            caps,
+            "device_list",
+            q,
+            f,
+            &["status", "tenant", "role", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        if let Some(scope) = scope
+            && !Self::gql_add_filter(
+                caps,
+                "device_list",
+                &mut filters,
+                Self::gql_scope_filter_key(scope),
+                json!(scope.id),
+            )
+        {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<GqlNamedSite> = self
+            .graphql_list(
+                caps,
+                "device_list",
+                Value::Object(filters),
+                "id name display site { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|d| {
+                let id = d.id()?;
+                let name = d.name.or(d.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Device,
+                    id,
+                    score: score_match(q, &name),
+                    subtitle: d.site.and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Device, id),
+                    display: name,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_sites(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) =
+            Self::gql_filters(caps, "site_list", q, f, &["status", "tenant", "tag"])
+        else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlSite> = self
+            .graphql_list(
+                caps,
+                "site_list",
+                Value::Object(filters),
+                "id name display slug",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|s| {
+                let id = s.id()?;
+                let display = s.name.or(s.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Site,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: s.slug,
+                    url: self.gql_web_url(ObjectKind::Site, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_ips(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        vrf_id: Option<u64>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(mut filters) = Self::gql_filters(
+            caps,
+            "ip_address_list",
+            q,
+            f,
+            &["status", "tenant", "role", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        if let Some(id) = vrf_id
+            && !Self::gql_add_filter(caps, "ip_address_list", &mut filters, "vrf_id", json!(id))
+        {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<GqlIpAddress> = self
+            .graphql_list(
+                caps,
+                "ip_address_list",
+                Value::Object(filters),
+                "id address display dns_name",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|ip| {
+                let id = ip.id()?;
+                let display = ip.address.or(ip.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::IpAddress,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: non_empty(ip.dns_name),
+                    url: self.gql_web_url(ObjectKind::IpAddress, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_prefixes(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        vrf_id: Option<u64>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let without_scope = SearchFilters {
+            site: None,
+            region: None,
+            site_group: None,
+            location: None,
+            ..f.clone()
+        };
+        let Some(mut filters) = Self::gql_filters(
+            caps,
+            "prefix_list",
+            q,
+            &without_scope,
+            &["status", "tenant", "role", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        if let Some(scope) = scope
+            && !Self::gql_add_filter(
+                caps,
+                "prefix_list",
+                &mut filters,
+                Self::gql_scope_filter_key(scope),
+                json!(scope.id),
+            )
+        {
+            let added_type = Self::gql_add_filter(
+                caps,
+                "prefix_list",
+                &mut filters,
+                "scope_type",
+                json!(scope.content_type),
+            );
+            let added_id = Self::gql_add_filter(
+                caps,
+                "prefix_list",
+                &mut filters,
+                "scope_id",
+                json!(scope.id),
+            );
+            if !(added_type && added_id) {
+                return Ok(Vec::new());
+            }
+        }
+        if let Some(id) = vrf_id
+            && !Self::gql_add_filter(caps, "prefix_list", &mut filters, "vrf_id", json!(id))
+        {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<GqlPrefix> = self
+            .graphql_list(
+                caps,
+                "prefix_list",
+                Value::Object(filters),
+                "id prefix display scope { ... on SiteType { id name display slug } ... on RegionType { id name display slug } ... on LocationType { id name display slug } ... on SiteGroupType { id name display slug } }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|p| {
+                let id = p.id()?;
+                let display = p.prefix.or(p.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Prefix,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: p.scope.and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Prefix, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_vlans(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_id_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(mut filters) = Self::gql_filters(
+            caps,
+            "vlan_list",
+            q,
+            f,
+            &["status", "tenant", "role", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        if let Some(scope) = scope
+            && !Self::gql_add_filter(caps, "vlan_list", &mut filters, "site_id", json!(scope.id))
+        {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<GqlVlan> = self
+            .graphql_list(
+                caps,
+                "vlan_list",
+                Value::Object(filters),
+                "id vid name display site { id name display slug } group { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|v| {
+                let id = v.id()?;
+                let name = v.name.or(v.display).unwrap_or_default();
+                let display = format!("{} {}", v.vid, name);
+                Some(SearchResult {
+                    kind: ObjectKind::Vlan,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: v.site.or(v.group).and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Vlan, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_circuits(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) =
+            Self::gql_filters(caps, "circuit_list", q, f, &["status", "tenant", "tag"])
+        else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlCircuit> = self
+            .graphql_list(
+                caps,
+                "circuit_list",
+                Value::Object(filters),
+                "id cid display provider { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|c| {
+                let id = c.id()?;
+                let display = c.cid.or(c.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Circuit,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: c.provider.and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Circuit, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_aggregates(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) = Self::gql_filters(caps, "aggregate_list", q, f, &["tenant", "tag"])
+        else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlPrefixLike> = self
+            .graphql_list(
+                caps,
+                "aggregate_list",
+                Value::Object(filters),
+                "id prefix display rir { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|a| {
+                let id = a.id()?;
+                let display = a.prefix.or(a.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Aggregate,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: a.rir.and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Aggregate, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_asns(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(mut filters) = Self::gql_filters(caps, "asn_list", q, f, &["tenant", "tag"])
+        else {
+            return Ok(Vec::new());
+        };
+        if let Ok(asn) = q.parse::<u32>() {
+            filters.remove("q");
+            if !Self::gql_add_filter(caps, "asn_list", &mut filters, "asn", json!(asn)) {
+                return Ok(Vec::new());
+            }
+        }
+        let rows: Vec<GqlAsn> = self
+            .graphql_list(
+                caps,
+                "asn_list",
+                Value::Object(filters),
+                "id asn display rir { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|a| {
+                let id = a.id()?;
+                let asn = a.asn?;
+                let display = format!("AS{asn}");
+                Some(SearchResult {
+                    kind: ObjectKind::Asn,
+                    id,
+                    score: score_match(q, &asn.to_string()),
+                    subtitle: a.rir.and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Asn, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_ip_ranges(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) = Self::gql_filters(
+            caps,
+            "ip_range_list",
+            q,
+            f,
+            &["status", "tenant", "role", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlIpRange> = self
+            .graphql_list(
+                caps,
+                "ip_range_list",
+                Value::Object(filters),
+                "id start_address end_address display vrf { id name display rd } role { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|r| {
+                let id = r.id()?;
+                let display = r
+                    .display
+                    .or_else(|| Some(format!("{}-{}", r.start_address?, r.end_address?)))?;
+                Some(SearchResult {
+                    kind: ObjectKind::IpRange,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: r.vrf.or(r.role).and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::IpRange, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_tenants(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) = Self::gql_filters(caps, "tenant_list", q, f, &["tag"]) else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlTenantLike> = self
+            .graphql_list(
+                caps,
+                "tenant_list",
+                Value::Object(filters),
+                "id name display slug group { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|t| {
+                let id = t.id()?;
+                let display = t.name.or(t.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Tenant,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: t.group.and_then(GqlBrief::label).or(t.slug),
+                    url: self.gql_web_url(ObjectKind::Tenant, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_contacts(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) = Self::gql_filters(caps, "contact_list", q, f, &["tag"]) else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlContact> = self
+            .graphql_list(
+                caps,
+                "contact_list",
+                Value::Object(filters),
+                "id name display email group { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|c| {
+                let id = c.id()?;
+                let display = c.name.or(c.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Contact,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: c
+                        .group
+                        .and_then(GqlBrief::label)
+                        .or_else(|| non_empty(c.email)),
+                    url: self.gql_web_url(ObjectKind::Contact, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_providers(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_any_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(filters) = Self::gql_filters(caps, "provider_list", q, f, &["tag"]) else {
+            return Ok(Vec::new());
+        };
+        let rows: Vec<GqlProvider> = self
+            .graphql_list(
+                caps,
+                "provider_list",
+                Value::Object(filters),
+                "id name display slug asns { id asn }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|p| {
+                let id = p.id()?;
+                let display = p.name.or(p.display)?;
+                let subtitle = p
+                    .asns
+                    .first()
+                    .and_then(|asn| asn.asn.map(|n| format!("AS{n}")))
+                    .or(p.slug);
+                Some(SearchResult {
+                    kind: ObjectKind::Provider,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle,
+                    url: self.gql_web_url(ObjectKind::Provider, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_vms(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        if skip_for_id_scope(scope) {
+            return Ok(Vec::new());
+        }
+        let Some(mut filters) = Self::gql_filters(
+            caps,
+            "virtual_machine_list",
+            q,
+            f,
+            &["status", "tenant", "role", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        if let Some(scope) = scope
+            && !Self::gql_add_filter(
+                caps,
+                "virtual_machine_list",
+                &mut filters,
+                "site_id",
+                json!(scope.id),
+            )
+        {
+            return Ok(Vec::new());
+        }
+        let rows: Vec<GqlVm> = self
+            .graphql_list(
+                caps,
+                "virtual_machine_list",
+                Value::Object(filters),
+                "id name display cluster { id name display } site { id name display slug }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|vm| {
+                let id = vm.id()?;
+                let display = vm.name.or(vm.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Vm,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: vm.cluster.or(vm.site).and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Vm, id),
+                    display,
+                })
+            })
+            .collect())
+    }
+
+    async fn gql_search_clusters(
+        &self,
+        caps: &GraphqlCapabilities,
+        q: &str,
+        f: &SearchFilters,
+        scope: Option<&ResolvedScope>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let without_scope = SearchFilters {
+            site: None,
+            region: None,
+            site_group: None,
+            location: None,
+            ..f.clone()
+        };
+        let Some(mut filters) = Self::gql_filters(
+            caps,
+            "cluster_list",
+            q,
+            &without_scope,
+            &["status", "tenant", "tag"],
+        ) else {
+            return Ok(Vec::new());
+        };
+        if let Some(scope) = scope
+            && !Self::gql_add_filter(
+                caps,
+                "cluster_list",
+                &mut filters,
+                Self::gql_scope_filter_key(scope),
+                json!(scope.id),
+            )
+        {
+            let added_type = Self::gql_add_filter(
+                caps,
+                "cluster_list",
+                &mut filters,
+                "scope_type",
+                json!(scope.content_type),
+            );
+            let added_id = Self::gql_add_filter(
+                caps,
+                "cluster_list",
+                &mut filters,
+                "scope_id",
+                json!(scope.id),
+            );
+            if !(added_type && added_id) {
+                return Ok(Vec::new());
+            }
+        }
+        let rows: Vec<GqlCluster> = self
+            .graphql_list(
+                caps,
+                "cluster_list",
+                Value::Object(filters),
+                "id name display type { id name display slug } scope { ... on SiteType { id name display slug } ... on RegionType { id name display slug } ... on LocationType { id name display slug } ... on SiteGroupType { id name display slug } }",
+                limit,
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .filter_map(|c| {
+                let id = c.id()?;
+                let display = c.name.or(c.display)?;
+                Some(SearchResult {
+                    kind: ObjectKind::Cluster,
+                    id,
+                    score: score_match(q, &display),
+                    subtitle: c.type_.or(c.scope).and_then(GqlBrief::label),
+                    url: self.gql_web_url(ObjectKind::Cluster, id),
+                    display,
+                })
+            })
+            .collect())
     }
 
     async fn search_devices(
@@ -986,6 +1919,238 @@ impl NetBoxClient {
                 display: c.name,
             })
             .collect())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlBrief {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    slug: Option<String>,
+    rd: Option<String>,
+}
+
+impl GqlBrief {
+    fn label(self) -> Option<String> {
+        self.display
+            .or(self.name)
+            .or(self.slug)
+            .or(self.rd)
+            .or(self.id)
+    }
+}
+
+trait GqlId {
+    fn raw_id(&self) -> Option<&str>;
+
+    fn id(&self) -> Option<u64> {
+        self.raw_id()?.parse().ok()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlNamedSite {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    site: Option<GqlBrief>,
+}
+
+impl GqlId for GqlNamedSite {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlSite {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    slug: Option<String>,
+}
+
+impl GqlId for GqlSite {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlIpAddress {
+    id: Option<String>,
+    address: Option<String>,
+    display: Option<String>,
+    dns_name: Option<String>,
+}
+
+impl GqlId for GqlIpAddress {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlPrefix {
+    id: Option<String>,
+    prefix: Option<String>,
+    display: Option<String>,
+    scope: Option<GqlBrief>,
+}
+
+impl GqlId for GqlPrefix {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlVlan {
+    id: Option<String>,
+    vid: u16,
+    name: Option<String>,
+    display: Option<String>,
+    site: Option<GqlBrief>,
+    group: Option<GqlBrief>,
+}
+
+impl GqlId for GqlVlan {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlCircuit {
+    id: Option<String>,
+    cid: Option<String>,
+    display: Option<String>,
+    provider: Option<GqlBrief>,
+}
+
+impl GqlId for GqlCircuit {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlPrefixLike {
+    id: Option<String>,
+    prefix: Option<String>,
+    display: Option<String>,
+    rir: Option<GqlBrief>,
+}
+
+impl GqlId for GqlPrefixLike {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlAsn {
+    id: Option<String>,
+    asn: Option<u32>,
+    rir: Option<GqlBrief>,
+}
+
+impl GqlId for GqlAsn {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlIpRange {
+    id: Option<String>,
+    start_address: Option<String>,
+    end_address: Option<String>,
+    display: Option<String>,
+    vrf: Option<GqlBrief>,
+    role: Option<GqlBrief>,
+}
+
+impl GqlId for GqlIpRange {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlTenantLike {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    slug: Option<String>,
+    group: Option<GqlBrief>,
+}
+
+impl GqlId for GqlTenantLike {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlContact {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    email: Option<String>,
+    group: Option<GqlBrief>,
+}
+
+impl GqlId for GqlContact {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlProvider {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    slug: Option<String>,
+    asns: Vec<GqlAsn>,
+}
+
+impl GqlId for GqlProvider {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlVm {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    cluster: Option<GqlBrief>,
+    site: Option<GqlBrief>,
+}
+
+impl GqlId for GqlVm {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlCluster {
+    id: Option<String>,
+    name: Option<String>,
+    display: Option<String>,
+    #[serde(rename = "type")]
+    type_: Option<GqlBrief>,
+    scope: Option<GqlBrief>,
+}
+
+impl GqlId for GqlCluster {
+    fn raw_id(&self) -> Option<&str> {
+        self.id.as_deref()
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -92,13 +92,12 @@ fn dispatch(command: AppCommand, client: NetBoxClient, tx: mpsc::Sender<AppEvent
     match command {
         AppCommand::Search { query, req } => {
             tokio::spawn(async move {
-                let result = client
-                    .search(SearchRequest {
-                        query,
-                        limit: 50,
-                        filters: SearchFilters::default(),
-                    })
-                    .await;
+                let result = Box::pin(client.search(SearchRequest {
+                    query,
+                    limit: 50,
+                    filters: SearchFilters::default(),
+                }))
+                .await;
                 // Echo the request id back so a stale (superseded) search result
                 // is dropped by the pure handler.
                 let _ = tx.send(AppEvent::SearchComplete { req, result }).await;

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1237,6 +1237,7 @@ impl App {
             config.timeout_secs = existing.config.timeout_secs;
             config.page_size = existing.config.page_size;
             config.exclude_config_context = existing.config.exclude_config_context;
+            config.backend = existing.config.backend;
         }
         self.upsert_live_profile(original.as_deref(), &name, config);
 

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -121,6 +121,15 @@ async fn mount_graphql_device_result(server: &MockServer) {
         .await;
 }
 
+fn graphql_request_query(request: &wiremock::Request) -> Option<String> {
+    request
+        .body_json::<serde_json::Value>()
+        .ok()?
+        .get("query")?
+        .as_str()
+        .map(str::to_string)
+}
+
 #[tokio::test]
 async fn search_merges_ranks_and_dedups_across_endpoints() {
     let server = MockServer::start().await;
@@ -233,6 +242,45 @@ async fn graphql_backend_search_shapes_lookup_filters_and_synthesizes_urls() {
         device_query["variables"]["filters"]["status"],
         json!({"exact": "STATUS_ACTIVE"})
     );
+}
+
+#[tokio::test]
+async fn graphql_backend_caches_capabilities_across_client_clones() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    mount_graphql_device_result(&server).await;
+
+    let client = graphql_client(&server);
+    let cloned = client.clone();
+    for client in [client, cloned] {
+        let results = client
+            .search(SearchRequest {
+                query: "edge".into(),
+                limit: 10,
+                filters: SearchFilters::default(),
+            })
+            .await
+            .unwrap()
+            .results;
+        assert_eq!(results.len(), 1);
+    }
+
+    let requests = server.received_requests().await.unwrap();
+    let queries: Vec<String> = requests.iter().filter_map(graphql_request_query).collect();
+    let introspection_queries = queries
+        .iter()
+        .filter(|query| query.contains("__schema") || query.contains("__type"))
+        .count();
+    let data_queries = queries
+        .iter()
+        .filter(|query| query.contains("device_list") && !query.contains("__schema"))
+        .count();
+
+    assert_eq!(
+        introspection_queries, 3,
+        "capability probes should run once and be shared by cloned clients: {queries:#?}"
+    );
+    assert_eq!(data_queries, 2, "each search still sends its data query");
 }
 
 #[tokio::test]

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -245,6 +245,97 @@ async fn graphql_backend_search_shapes_lookup_filters_and_synthesizes_urls() {
 }
 
 #[tokio::test]
+async fn graphql_backend_caps_pagination_limit_to_netbox_max() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    mount_graphql_device_result(&server).await;
+
+    let results = graphql_client(&server)
+        .search(SearchRequest {
+            query: "edge".into(),
+            limit: 5_000,
+            filters: SearchFilters::default(),
+        })
+        .await
+        .unwrap()
+        .results;
+
+    assert_eq!(results.len(), 1);
+    let requests = server.received_requests().await.unwrap();
+    let device_query = requests
+        .iter()
+        .filter_map(graphql_request_query)
+        .find(|query| query.contains("device_list"))
+        .expect("device_list query was sent");
+    assert!(
+        device_query.contains("pagination: {offset: 0, limit: 1000}"),
+        "GraphQL pagination should be capped to NetBox's max page size: {device_query}"
+    );
+}
+
+#[tokio::test]
+async fn graphql_backend_decode_errors_name_the_list() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("device_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "device_list": {
+                    "id": "7",
+                    "name": "edge01"
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let err = graphql_client(&server)
+        .search(SearchRequest {
+            query: "edge".into(),
+            limit: 10,
+            filters: SearchFilters::default(),
+        })
+        .await
+        .expect_err("malformed list payload should error");
+
+    assert!(
+        format!("{err:#}").contains("deserializing GraphQL device_list rows"),
+        "got: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn graphql_backend_propagates_graphql_errors() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("device_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": null,
+            "errors": [{"message": "field exploded"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let err = graphql_client(&server)
+        .search(SearchRequest {
+            query: "edge".into(),
+            limit: 10,
+            filters: SearchFilters::default(),
+        })
+        .await
+        .expect_err("GraphQL errors should fail the search branch");
+
+    assert!(
+        format!("{err:#}").contains("field exploded"),
+        "got: {err:#}"
+    );
+}
+
+#[tokio::test]
 async fn graphql_backend_caches_capabilities_across_client_clones() {
     let server = MockServer::start().await;
     mount_graphql_device_schema(&server).await;

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -1,15 +1,24 @@
 //! Integration tests for the multi-endpoint search fan-out.
 
-use nbox::config::ProfileConfig;
+use nbox::config::{BackendKind, ProfileConfig};
 use nbox::netbox::client::NetBoxClient;
 use nbox::netbox::search::{ObjectKind, SearchFilters, SearchRequest};
 use serde_json::json;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{body_string_contains, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn client(server: &MockServer) -> NetBoxClient {
     let profile = ProfileConfig {
         url: server.uri(),
+        ..Default::default()
+    };
+    NetBoxClient::new(&profile, None).unwrap()
+}
+
+fn graphql_client(server: &MockServer) -> NetBoxClient {
+    let profile = ProfileConfig {
+        url: server.uri(),
+        backend: Some(BackendKind::Graphql),
         ..Default::default()
     };
     NetBoxClient::new(&profile, None).unwrap()
@@ -23,6 +32,91 @@ async fn mount_empty(server: &MockServer, p: &str) {
     Mock::given(method("GET"))
         .and(path(p))
         .respond_with(ResponseTemplate::new(200).set_body_json(empty()))
+        .mount(server)
+        .await;
+}
+
+async fn mount_graphql_device_schema(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("__schema"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "__schema": {
+                    "queryType": {
+                        "fields": [{
+                            "name": "device_list",
+                            "args": [
+                                {
+                                    "name": "filters",
+                                    "type": {"kind": "INPUT_OBJECT", "name": "DeviceFilter"}
+                                },
+                                {
+                                    "name": "pagination",
+                                    "type": {"kind": "INPUT_OBJECT", "name": "PaginationInput"}
+                                }
+                            ]
+                        }]
+                    }
+                }
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("__type"))
+        .and(body_string_contains("DeviceFilter"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "device": {
+                    "inputFields": [
+                        {
+                            "name": "q",
+                            "type": {"kind": "SCALAR", "name": "String"}
+                        },
+                        {
+                            "name": "status",
+                            "type": {"kind": "INPUT_OBJECT", "name": "StringLookup"}
+                        }
+                    ]
+                }
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("__type"))
+        .and(body_string_contains("ASNFilter"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {}
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_graphql_device_result(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("device_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "device_list": [{
+                    "id": "7",
+                    "name": "edge01",
+                    "display": "edge01",
+                    "site": {
+                        "id": "9",
+                        "name": "iad1",
+                        "display": "iad1",
+                        "slug": "iad1"
+                    }
+                }]
+            }
+        })))
         .mount(server)
         .await;
 }
@@ -84,6 +178,103 @@ async fn search_merges_ranks_and_dedups_across_endpoints() {
     assert_eq!(results[0].url, "http://nb/dcim/devices/1/");
     // VLAN (partial match) ranks lower.
     assert_eq!(results[1].kind, ObjectKind::Vlan);
+}
+
+#[tokio::test]
+async fn graphql_backend_search_shapes_lookup_filters_and_synthesizes_urls() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    mount_graphql_device_result(&server).await;
+
+    let results = graphql_client(&server)
+        .search(SearchRequest {
+            query: "edge".into(),
+            limit: 10,
+            filters: SearchFilters {
+                status: Some("active".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap()
+        .results;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].kind, ObjectKind::Device);
+    assert_eq!(results[0].display, "edge01");
+    assert_eq!(results[0].subtitle.as_deref(), Some("iad1"));
+    assert_eq!(results[0].url, format!("{}/dcim/devices/7/", server.uri()));
+
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.url.path() == "/graphql/"),
+        "GraphQL backend should not hit REST search endpoints: {requests:#?}"
+    );
+    let device_query: serde_json::Value = requests
+        .iter()
+        .map(|request| request.body_json().unwrap())
+        .find(|body: &serde_json::Value| {
+            body.get("query")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|query| query.contains("device_list"))
+        })
+        .expect("device_list query was sent");
+    assert!(
+        device_query["query"]
+            .as_str()
+            .unwrap()
+            .contains("pagination: {offset: 0, limit: 10}"),
+        "query should use offset pagination when the schema advertises it: {device_query:#}"
+    );
+    assert_eq!(device_query["variables"]["filters"]["q"], "edge");
+    assert_eq!(
+        device_query["variables"]["filters"]["status"],
+        json!({"exact": "STATUS_ACTIVE"})
+    );
+}
+
+#[tokio::test]
+async fn graphql_backend_skips_scoped_branch_when_filter_is_not_in_schema() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    mount_graphql_device_result(&server).await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": 9, "url": "http://nb/api/dcim/sites/9/", "name": "iad1", "slug": "iad1"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let outcome = graphql_client(&server)
+        .search(SearchRequest {
+            query: "edge".into(),
+            limit: 10,
+            filters: SearchFilters {
+                site: Some("iad1".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap();
+
+    assert!(outcome.results.is_empty(), "got: {:?}", outcome.results);
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .filter_map(|request| request.body_json::<serde_json::Value>().ok())
+            .all(|body| body
+                .get("query")
+                .and_then(serde_json::Value::as_str)
+                .is_none_or(|query| !query.contains("device_list"))),
+        "device_list query should be skipped when site_id is not in DeviceFilter: {requests:#?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a profile-level backend setting, defaulting to REST, with backend = "graphql" enabling GraphQL-backed search
- add authenticated /graphql/ POST support plus schema capability probing for NetBox 4.2, 4.3, and 4.5+ filter/pagination shapes
- implement GraphQL search for the existing search kinds with normalized SearchResult output, synthesized web URLs, fail-closed filter handling, and REST retained for non-search operations
- document the backend setting in README, config docs, architecture/features docs, examples, AGENTS.md, and changelog

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo clippy --all-targets --no-default-features -- -D warnings
- cargo test --no-default-features
- live local Docker smoke: REST search, GraphQL search, and GraphQL --site scoped search against http://localhost:8000

## Notes
- REST remains the default and still backs detail lookups, journals, raw reads, and available IP/prefix commands.
- GraphQL compatibility is schema-probed rather than version-string based, covering 4.2 unpaginated lists, 4.3+ offset pagination, and 4.5+ lookup-wrapper filters.