### PR TITLE
fix(tui): refine footer navigation states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- TUI footer/navigation UX: theme changes now apply visually without replacing the
+  bottom navigation bar with a sticky `theme: ...` message. Live state now owns
+  the far-left footer slot (spinner, result counts, errors, theme notices), with
+  context-specific navigation hints following it; transient theme notices clear
+  back to the nav-only resting state.
+- TUI detail actions: `o` and `y` now target the loaded detail object on the
+  Detail screen instead of falling through to the hidden Home selection.
+
 ## [0.2.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the far-left footer slot (spinner, result counts, errors, theme notices), with
   context-specific navigation hints following it; transient theme notices clear
   back to the nav-only resting state.
+- TUI search/command line: the `/` and `:` input is now inset one column from
+  each edge, so its sigil aligns with the header and the `/ search` hint instead
+  of hugging the terminal's left edge.
 - TUI detail actions: `o` and `y` now target the loaded detail object on the
   Detail screen instead of falling through to the hidden Home selection.
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ auth/permission (401/403), `4` not found, `5` ambiguous reference. See
 | `PgUp` / `PgDn` | page up / down |
 | `Enter` | open selected object |
 | `o` | open in browser |
-| `y` | copy selected field |
+| `y` | copy current item label |
 | `t` | cycle theme |
 | `r` | refresh |
 | `P` / `Ctrl+P` | switch profile (cycle forward / backward) |

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -207,6 +207,9 @@ const PAGE_JUMP_FALLBACK: usize = 10;
 /// preview path's `(kind, id)` stale-response suppression, scoped per channel).
 pub type RequestId = u64;
 
+/// A short footer-notice expiry, driven by the 180ms `PreviewTick`.
+const TRANSIENT_STATUS_TICKS: u8 = 10;
+
 /// Side-effecting work the loop should spawn off the render thread.
 #[derive(Debug, Clone)]
 pub enum AppCommand {
@@ -375,6 +378,9 @@ pub struct App {
     /// [`Theme::message_style`]. Set in lockstep with `status` (see
     /// [`App::set_status`]); resets to `Info` whenever the status is cleared.
     pub status_severity: Severity,
+    /// Remaining fast UI ticks before the current status clears itself. `None`
+    /// means the message is sticky until another action replaces or clears it.
+    status_ttl: Option<u8>,
 
     /// The `/` search line editor. Text entry, backspace/delete, cursor
     /// movement and the visible cursor are delegated to the cheese-backed
@@ -503,6 +509,7 @@ impl App {
             history: Vec::new(),
             status: String::new(),
             status_severity: Severity::Info,
+            status_ttl: None,
             search_input: TextInput::new("search NetBox…"),
             command_input: TextInput::new("command (e.g. device edge01)"),
             last_query: None,
@@ -647,7 +654,9 @@ impl App {
                 if self.loading() {
                     self.spinner.tick();
                 }
-                self.on_preview_tick()
+                let commands = self.on_preview_tick();
+                self.tick_status_ttl();
+                commands
             }
             AppEvent::SearchComplete { req, result } => {
                 // A search result settles its in-flight fetch (clean or error),
@@ -952,16 +961,16 @@ impl App {
                 }
             }
             KeyCode::Char('o') => {
-                if let Some(r) = self.selected_result() {
+                if let Some(target) = self.action_target() {
                     return vec![AppCommand::OpenBrowser {
-                        url: r.url.clone(),
+                        url: target.url,
                         command: self.open_browser_command.clone(),
                     }];
                 }
             }
             KeyCode::Char('y') => {
-                if let Some(r) = self.selected_result() {
-                    return vec![AppCommand::Copy(r.display.clone())];
+                if let Some(target) = self.action_target() {
+                    return vec![AppCommand::Copy(target.label)];
                 }
             }
             KeyCode::Char(c @ ('i' | 'p' | 'c' | 'v' | 's')) if !ctrl => self.select_detail_tab(c),
@@ -1641,12 +1650,33 @@ impl App {
     fn set_status(&mut self, message: impl Into<String>, severity: Severity) {
         self.status = message.into();
         self.status_severity = severity;
+        self.status_ttl = None;
+    }
+
+    /// Set a status message that clears itself after a short run of UI ticks.
+    fn set_transient_status(&mut self, message: impl Into<String>, severity: Severity) {
+        self.status = message.into();
+        self.status_severity = severity;
+        self.status_ttl = Some(TRANSIENT_STATUS_TICKS);
     }
 
     /// Clear the status line back to its neutral resting state.
     fn clear_status(&mut self) {
         self.status.clear();
         self.status_severity = Severity::Info;
+        self.status_ttl = None;
+    }
+
+    /// Age a transient status by one fast UI tick, clearing it when its TTL ends.
+    fn tick_status_ttl(&mut self) {
+        let Some(remaining) = self.status_ttl else {
+            return;
+        };
+        if remaining <= 1 {
+            self.clear_status();
+        } else {
+            self.status_ttl = Some(remaining - 1);
+        }
     }
 
     /// Flip focus between the home split's list and preview panes. Switching to
@@ -1781,7 +1811,7 @@ impl App {
         let list = Theme::list();
         self.theme_index = (self.theme_index + 1) % list.len();
         self.theme = Theme::by_name(list[self.theme_index]);
-        self.set_status(format!("theme: {}", list[self.theme_index]), Severity::Info);
+        self.set_transient_status(format!("theme: {}", self.theme.name()), Severity::Info);
     }
 
     fn set_theme_by_name(&mut self, name: &str) {
@@ -1793,7 +1823,7 @@ impl App {
         }
         self.theme = Theme::by_name(name);
         self.theme_index = Theme::index_of(name);
-        self.set_status(format!("theme: {}", self.theme.name()), Severity::Info);
+        self.set_transient_status(format!("theme: {}", self.theme.name()), Severity::Info);
     }
 
     /// Shared NO_COLOR guard for both theme-change paths (`t` cycle and the
@@ -1957,6 +1987,22 @@ impl App {
         self.view
             .get(self.selected)
             .and_then(|&i| self.results.get(i))
+    }
+
+    /// The object that visible actions (`o` browser, `y` copy) should target. On
+    /// Home this is the highlighted result; on Detail it is the loaded detail
+    /// object, so actions never fall through to the hidden Home selection.
+    fn action_target(&self) -> Option<ActionTarget> {
+        match self.screen {
+            Screen::Home => self.selected_result().map(|r| ActionTarget {
+                label: r.display.clone(),
+                url: r.url.clone(),
+            }),
+            Screen::Detail => self.detail.as_ref().map(|d| ActionTarget {
+                label: d.title.clone(),
+                url: object_web_url(&self.base_url, d.kind, d.id),
+            }),
+        }
     }
 
     /// Switch the active detail tab by its key (`i`/`p`/`c`/`v`); pressing the
@@ -2323,6 +2369,44 @@ struct PreviewStub<'a> {
     display: &'a str,
     subtitle: Option<&'a str>,
     url: Option<&'a str>,
+}
+
+struct ActionTarget {
+    label: String,
+    url: String,
+}
+
+/// Build the NetBox web URL for a detail object from the active profile base URL.
+/// The base may itself live under a subpath (`https://host/netbox/`), matching the
+/// client URL-join behavior.
+fn object_web_url(base_url: &str, kind: ObjectKind, id: u64) -> String {
+    let path = match kind {
+        ObjectKind::Device => format!("dcim/devices/{id}/"),
+        ObjectKind::Site => format!("dcim/sites/{id}/"),
+        ObjectKind::IpAddress => format!("ipam/ip-addresses/{id}/"),
+        ObjectKind::Prefix => format!("ipam/prefixes/{id}/"),
+        ObjectKind::Vlan => format!("ipam/vlans/{id}/"),
+        ObjectKind::Circuit => format!("circuits/circuits/{id}/"),
+        ObjectKind::Aggregate => format!("ipam/aggregates/{id}/"),
+        ObjectKind::Asn => format!("ipam/asns/{id}/"),
+        ObjectKind::IpRange => format!("ipam/ip-ranges/{id}/"),
+        ObjectKind::Tenant => format!("tenancy/tenants/{id}/"),
+        ObjectKind::Contact => format!("tenancy/contacts/{id}/"),
+        ObjectKind::Provider => format!("circuits/providers/{id}/"),
+        ObjectKind::Vm => format!("virtualization/virtual-machines/{id}/"),
+        ObjectKind::Cluster => format!("virtualization/clusters/{id}/"),
+    };
+
+    let mut base = base_url.to_string();
+    if !base.ends_with('/') {
+        base.push('/');
+    }
+    reqwest::Url::parse(&base)
+        .and_then(|url| url.join(&path))
+        .map_or_else(
+            |_| format!("{}/{path}", base_url.trim_end_matches('/')),
+            |url| url.to_string(),
+        )
 }
 
 /// Classify a free-form status message (typically pushed from an async task,
@@ -2997,6 +3081,8 @@ mod tests {
         let cmds = a.handle_event(press(KeyCode::Enter));
         assert!(cmds.is_empty());
         assert_eq!(a.theme.name(), "nord");
+        assert_eq!(a.status, "theme: nord");
+        assert_eq!(a.status_ttl, Some(TRANSIENT_STATUS_TICKS));
     }
 
     #[test]
@@ -3051,6 +3137,42 @@ mod tests {
     }
 
     #[test]
+    fn detail_o_and_y_target_the_loaded_detail_not_the_home_selection() {
+        let mut a = app();
+        set_results(&mut a, vec![result(1, "edge01")]);
+        detail_loaded(
+            &mut a,
+            Ok(DetailView {
+                kind: ObjectKind::Device,
+                id: 99,
+                title: "device edge99".into(),
+                body: String::new(),
+                tabs: Vec::new(),
+            }),
+        );
+        assert_eq!(a.screen, Screen::Detail);
+
+        let open = a.handle_event(press(KeyCode::Char('o')));
+        assert!(
+            matches!(open.as_slice(), [AppCommand::OpenBrowser { url, .. }] if url == "http://localhost/dcim/devices/99/")
+        );
+        let copy = a.handle_event(press(KeyCode::Char('y')));
+        assert!(matches!(copy.as_slice(), [AppCommand::Copy(v)] if v == "device edge99"));
+    }
+
+    #[test]
+    fn detail_web_url_preserves_netbox_base_subpaths() {
+        assert_eq!(
+            object_web_url("https://nb.example/netbox", ObjectKind::Vm, 7),
+            "https://nb.example/netbox/virtualization/virtual-machines/7/"
+        );
+        assert_eq!(
+            object_web_url("not a url", ObjectKind::IpRange, 3),
+            "not a url/ipam/ip-ranges/3/"
+        );
+    }
+
+    #[test]
     fn ctrl_w_deletes_last_word() {
         // Word-delete is delegated to the cheese-backed input, but it must still
         // work through the pure search handler: type a two-word query, Ctrl+W
@@ -3075,6 +3197,45 @@ mod tests {
         let before = a.theme_index;
         a.handle_event(press(KeyCode::Char('t')));
         assert_ne!(a.theme_index, before);
+        assert_eq!(a.status, format!("theme: {}", a.theme.name()));
+        assert_eq!(a.status_ttl, Some(TRANSIENT_STATUS_TICKS));
+    }
+
+    #[test]
+    fn transient_theme_status_clears_on_preview_ticks() {
+        let mut a = app();
+        a.handle_event(press(KeyCode::Char('t')));
+        assert_eq!(a.status, format!("theme: {}", a.theme.name()));
+
+        for _ in 0..TRANSIENT_STATUS_TICKS - 1 {
+            a.handle_event(AppEvent::PreviewTick);
+            assert!(
+                !a.status.is_empty(),
+                "theme status should survive until its TTL expires"
+            );
+        }
+
+        a.handle_event(AppEvent::PreviewTick);
+        assert!(a.status.is_empty());
+        assert_eq!(a.status_severity, Severity::Info);
+        assert_eq!(a.status_ttl, None);
+    }
+
+    #[test]
+    fn sticky_status_replaces_and_cancels_transient_status() {
+        let mut a = app();
+        a.handle_event(press(KeyCode::Char('t')));
+        assert!(a.status_ttl.is_some());
+
+        detail_loaded(&mut a, Err(anyhow::anyhow!("boom")));
+
+        assert_eq!(a.status, "error: boom");
+        assert_eq!(a.status_severity, Severity::Error);
+        assert_eq!(a.status_ttl, None);
+        for _ in 0..TRANSIENT_STATUS_TICKS {
+            a.handle_event(AppEvent::PreviewTick);
+        }
+        assert_eq!(a.status, "error: boom");
     }
 
     #[test]
@@ -5198,7 +5359,8 @@ mod tests {
         // Right on the theme row cycles + hot-applies live to App.theme.
         a.handle_event(press(KeyCode::Right));
         assert_eq!(a.theme.name(), Theme::list()[1]);
-        assert!(a.status.starts_with("theme:"), "status reflects the change");
+        assert_eq!(a.status, format!("theme: {}", a.theme.name()));
+        assert_eq!(a.status_ttl, Some(TRANSIENT_STATUS_TICKS));
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -861,16 +861,25 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &mut App) {
     // draws the `sigil value` line itself (with a visible cursor) and reports
     // where the terminal cursor should sit, which we then place. The borrow of
     // `app.theme` is cloned out first so the input can borrow `app` mutably.
+    //
+    // The editor is inset one column on each side (`footer_input_area`) so the
+    // `/`/`:` sigil lands at the same column as the header and the normal-mode
+    // `/ search` hint — the footer reads as morphing in place rather than the
+    // sigil snapping to the terminal edge.
     match app.mode {
         Mode::Search => {
             let theme = app.theme.clone();
-            let pos = app.search_input.render(frame, area, '/', &theme);
+            let pos = app
+                .search_input
+                .render(frame, footer_input_area(area), '/', &theme);
             frame.set_cursor_position(pos);
             return;
         }
         Mode::Command => {
             let theme = app.theme.clone();
-            let pos = app.command_input.render(frame, area, ':', &theme);
+            let pos = app
+                .command_input
+                .render(frame, footer_input_area(area), ':', &theme);
             frame.set_cursor_position(pos);
             return;
         }
@@ -882,6 +891,18 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &mut App) {
         Paragraph::new(line).style(Style::default().fg(app.theme.text)),
         area,
     );
+}
+
+/// Inset a footer rect by one column on each side so the Search/Command line
+/// editor's sigil aligns with the header and the normal-mode nav hint (column 1)
+/// rather than hugging the terminal edge. Width floors at 0 on a tiny terminal.
+fn footer_input_area(area: Rect) -> Rect {
+    Rect {
+        x: area.x.saturating_add(1),
+        y: area.y,
+        width: area.width.saturating_sub(2),
+        height: area.height,
+    }
 }
 
 /// Context-sensitive normal-mode footer. Live state (spinner, result count,
@@ -1068,6 +1089,24 @@ mod tests {
         assert_eq!(label_width(&body), LABEL_CAP);
         // A body with no key/value rows needs no column.
         assert_eq!(label_width("just a header line"), 0);
+    }
+
+    #[test]
+    fn footer_input_area_insets_one_column_each_side() {
+        // The search/command editor sits one column in from each edge, so the
+        // sigil aligns with the header instead of hugging the terminal edge.
+        let full = Rect::new(0, 23, 80, 1);
+        let inset = footer_input_area(full);
+        assert_eq!(inset.x, 1, "left-padded by one column");
+        assert_eq!(inset.width, 78, "one column trimmed off each side");
+        assert_eq!((inset.y, inset.height), (23, 1), "row is unchanged");
+    }
+
+    #[test]
+    fn footer_input_area_floors_width_on_a_tiny_terminal() {
+        // A 1-column footer can't be inset twice; width saturates at 0, no panic.
+        let inset = footer_input_area(Rect::new(0, 0, 1, 1));
+        assert_eq!(inset.width, 0);
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -877,38 +877,67 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &mut App) {
         Mode::Normal => {}
     }
 
+    let line = footer_line(app);
+    frame.render_widget(
+        Paragraph::new(line).style(Style::default().fg(app.theme.text)),
+        area,
+    );
+}
+
+/// Context-sensitive normal-mode footer. Live state (spinner, result count,
+/// errors, transient theme notices) gets the left edge; persistent navigation
+/// follows so controls stay visible without burying the thing that just changed.
+fn footer_line(app: &App) -> Line<'static> {
     let theme = &app.theme;
     let mut spans: Vec<Span> = Vec::new();
-    // While a request is in flight, lead the status line with the loading
-    // spinner glyph (styled via the cheese palette). When idle the footer is
-    // exactly as before — no spinner cell.
+    let mut has_state = false;
+
     if app.loading() {
-        spans.push(Span::raw(" "));
         spans.push(app.spinner.span(theme));
+        spans.push(Span::raw(" "));
+        has_state = true;
     }
     if !app.status.is_empty() {
-        // A live status message is colored by its severity: errors red, partial
-        // results yellow, confirmations green, ordinary chatter dim.
         spans.push(Span::styled(
-            format!(" {} ", app.status),
+            app.status.clone(),
             theme.message_style(app.status_severity),
         ));
     } else if app.loading() {
-        // Loading with no specific status: a neutral hint beside the spinner.
         spans.push(Span::styled(
-            " loading… ",
+            "loading…",
+            Style::default().fg(theme.text_dim),
+        ));
+    } else {
+        has_state = false;
+    }
+
+    if has_state || !app.status.is_empty() {
+        spans.push(Span::raw("    "));
+        spans.push(Span::styled(
+            footer_nav(app).trim_start().to_string(),
             Style::default().fg(theme.text_dim),
         ));
     } else {
         spans.push(Span::styled(
-            " / search   Tab pane   Enter open   o browser   y copy   b back   t theme   ? help   q quit ",
+            footer_nav(app),
             Style::default().fg(theme.text_dim),
         ));
     }
-    frame.render_widget(
-        Paragraph::new(Line::from(spans)).style(Style::default().fg(theme.text)),
-        area,
-    );
+    Line::from(spans)
+}
+
+fn footer_nav(app: &App) -> &'static str {
+    match app.screen {
+        Screen::Home if app.focus == Focus::Preview => {
+            " / search · j/k scroll · g/G top/bottom · Tab results · Enter open · o/y open/copy · r refresh · ? help · q quit "
+        }
+        Screen::Home => {
+            " / search · j/k move · Enter open · Tab preview · o/y open/copy · r refresh · t theme · ? help · q quit "
+        }
+        Screen::Detail => {
+            " j/k scroll · g/G top/bottom · i/p/c/v/s tabs · o/y open/copy · b back · r refresh · t theme · ? help · q quit "
+        }
+    }
 }
 
 fn mode_label(mode: Mode) -> &'static str {
@@ -922,6 +951,31 @@ fn mode_label(mode: Mode) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ProfileConfig;
+    use crate::netbox::client::NetBoxClient;
+
+    fn app() -> App {
+        let profile = ProfileConfig {
+            url: "http://localhost".into(),
+            ..Default::default()
+        };
+        let client = NetBoxClient::new(&profile, None).unwrap();
+        App::new(
+            client,
+            "default",
+            "test".into(),
+            "http://localhost".into(),
+            "4.5.5".into(),
+            None,
+        )
+    }
+
+    fn line_text(line: &Line) -> String {
+        line.spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>()
+    }
 
     /// Pull the foreground color the line's last span renders in.
     fn last_fg(line: &Line) -> Option<ratatui::style::Color> {
@@ -1165,6 +1219,60 @@ mod tests {
                 "help must not advertise unbound key {bogus}"
             );
         }
+    }
+
+    #[test]
+    fn footer_nav_is_contextual() {
+        let mut a = app();
+        let home = footer_nav(&a);
+        assert!(home.contains("j/k move"));
+        assert!(home.contains("Enter open"));
+
+        a.focus = Focus::Preview;
+        let preview = footer_nav(&a);
+        assert!(preview.contains("j/k scroll"));
+        assert!(preview.contains("Tab results"));
+
+        a.screen = Screen::Detail;
+        let detail = footer_nav(&a);
+        assert!(detail.contains("b back"));
+        assert!(detail.contains("i/p/c/v/s tabs"));
+        assert!(!detail.contains("Enter open"));
+    }
+
+    #[test]
+    fn footer_status_does_not_replace_navigation() {
+        let mut a = app();
+        a.status = "theme: nord".into();
+
+        let text = line_text(&footer_line(&a));
+
+        assert!(
+            text.starts_with("theme: nord"),
+            "status owns the left edge: {text}"
+        );
+        assert!(text.contains("/ search"), "nav remains present: {text}");
+        let status_idx = text.find("theme: nord").expect("status present");
+        let nav_idx = text.find("/ search").expect("nav present");
+        assert!(status_idx < nav_idx, "status precedes navigation: {text}");
+    }
+
+    #[test]
+    fn footer_loading_state_precedes_navigation() {
+        let mut a = app();
+        a.pending = 1;
+        a.status = "searching edge…".into();
+
+        let text = line_text(&footer_line(&a));
+
+        assert!(text.contains("searching edge"), "status present: {text}");
+        assert!(text.contains("/ search"), "nav remains present: {text}");
+        let status_idx = text.find("searching edge").expect("status present");
+        let nav_idx = text.find("/ search").expect("nav present");
+        assert!(
+            status_idx < nav_idx,
+            "loading state precedes navigation: {text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep the normal footer navigation visible while transient state, errors, spinner, and result counts occupy the far-left status slot
- make theme changes transient so the footer clears back to the resting nav state instead of sticking on `theme: ...`
- make Detail-screen `o` and `y` target the loaded detail object instead of the hidden Home selection

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test --all-features tui::

## Draft notes
This is intentionally a draft starting point. It improves the sticky-footer issue, but the final footer treatment may still need visual iteration after hands-on review.