### PR TITLE
test(netbox): add GraphQL backend confidence coverage

### DIFF
--- a/.github/workflows/netbox-integration.yml
+++ b/.github/workflows/netbox-integration.yml
@@ -1,8 +1,8 @@
 name: NetBox Integration
 
-# Heavy end-to-end checks against a REAL, pinned NetBox 4.2.x. Kept separate from
-# the fast `ci.yml` (fmt/clippy/build/unit tests) because it boots a full NetBox
-# stack and seeds a fixture. The gated tests in `tests/it_netbox.rs` are
+# Heavy end-to-end checks against REAL, pinned NetBox fixtures. Kept separate
+# from the fast `ci.yml` (fmt/clippy/build/unit tests) because it boots a full
+# NetBox stack and seeds a fixture. The gated tests in `tests/it_netbox.rs` are
 # `#[ignore]`d, so they never run in the normal suite — only here, via
 # `--ignored`.
 #
@@ -49,9 +49,52 @@ jobs:
         run: ./tests/integration/seed.py
 
       - name: Run gated integration tests
-        run: cargo test --test it_netbox -- --ignored
+        run: cargo test --test it_netbox -- --ignored --skip graphql_backend
 
       # Always surface NetBox logs on failure to debug a flaky boot/seed.
+      - name: Dump NetBox logs on failure
+        if: failure()
+        run: docker compose -f tests/integration/docker-compose.yml logs --no-color netbox
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f tests/integration/docker-compose.yml down -v
+
+  netbox-45-graphql:
+    name: live NetBox 4.5 GraphQL search
+    runs-on: ubuntu-latest
+    env:
+      NETBOX_IMAGE: netboxcommunity/netbox:v4.5.10-4.0.2
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build nbox
+        run: cargo build --all-features --verbose
+
+      - name: Boot NetBox 4.5 fixture
+        run: docker compose -f tests/integration/docker-compose.yml up -d
+
+      - name: Wait for NetBox 4.5 to finish first boot
+        run: NETBOX_READY_HTTP_CODES=200,403 ./tests/integration/wait-for-ready.sh 420
+
+      - name: Resolve NetBox 4.5 API token
+        run: echo "NETBOX_TOKEN=$(./tests/integration/resolve-token.sh)" >> "$GITHUB_ENV"
+
+      - name: Wait for NetBox to be ready
+        run: ./tests/integration/wait-for-ready.sh 60
+
+      - name: Seed the fixture
+        run: ./tests/integration/seed.py
+
+      - name: Run gated GraphQL integration tests
+        run: cargo test --test it_netbox graphql_backend -- --ignored --test-threads=1
+
       - name: Dump NetBox logs on failure
         if: failure()
         run: docker compose -f tests/integration/docker-compose.yml logs --no-color netbox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ stderr. Every tool is annotated read-only.
 
 | Tool | Purpose |
 | ---- | ------- |
-| `nbox_status` | Connection + NetBox/Django/Python versions (call first to confirm reachability). |
+| `nbox_status` | Connection + active backend + NetBox/Django/Python versions (call first to confirm reachability). |
 | `nbox_search` | Search devices/sites/IPs/prefixes/VLANs/circuits/aggregates/ASNs/IP ranges/tenants/contacts/providers/VMs/clusters; `query` (required), `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag` (one scope filter at a time), `vrf` (id\|rd\|name; filters IP/prefix results only). Find a reference before `nbox_get`. |
 | `nbox_get` | One object: `kind` (device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, cluster) + `ref`; `vrf`/`site`/`group` disambiguate (an ambiguous ref returns the candidates). |
 | `nbox_get_interface` | One interface on a device: config, addresses, cable-path trace. |

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ a directory — `nbox man man/` — to write the full set instead (`nbox.1` plus
 
 ```bash
 nbox                              # launch the TUI
-nbox status                       # connection + NetBox/Django/Python versions
+nbox status                       # connection + backend + NetBox/Django/Python versions
 nbox search <query> [--limit N] [--status/--site/--region/--site-group/--location/--tenant/--role/--tag <v>] [--vrf <id|rd|name>] [--cols a,b,c] [--partial]
                                   # --site/--region/--site-group/--location resolve the ref once and filter
                                   # scope-capable endpoints by resolved id (prefixes/clusters via
@@ -414,7 +414,7 @@ The tools are all annotated read-only:
 
 | Tool | What |
 |------|------|
-| `nbox_status` | Connection + NetBox/Django/Python versions. |
+| `nbox_status` | Connection + backend + NetBox/Django/Python versions. |
 | `nbox_search` | Search devices/IPs/prefixes/VLANs/sites/circuits/providers/aggregates/ASNs/IP-ranges/tenants/contacts/VMs/clusters; `query` (required), `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag`, `vrf` (id\|rd\|name; filters IP/prefix results only). |
 | `nbox_get` | Fetch one object by `kind` (device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, cluster) + `ref`; `vrf`/`site`/`group` disambiguate. |
 | `nbox_get_interface` | One interface on a device, with its cable-path trace. |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -22,7 +22,7 @@ nbox is a read-only NetBox client — a CLI and a TUI over the same core.
 | `nbox cluster <name\|id>` | Cluster: type, group, status, tenant, scope (site/region/…), device + VM counts, description, tags, custom fields. |
 | `nbox tags` | List tags. |
 | `nbox journal <kind> <ref>` | Recent journal entries for an object. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster. `--journal` on a detail lookup folds the most recent entries inline (default 5); `--journal-limit <N>` overrides the cap and implies `--journal`. (`tenant`/`contact`/`provider`/`vm`/`cluster` have no inline `--journal` flag — use `nbox journal`.) |
-| `nbox status` | Connection + NetBox/Django/Python versions. |
+| `nbox status` | Connection + active backend + NetBox/Django/Python versions. |
 | `nbox open <kind>/<ref>` | Open an object in the browser. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, and `interface/<device>/<name>` (the interface name may contain slashes, e.g. `xe-0/0/1`). |
 | `nbox raw GET <path>` | Raw read-only API request (escape hatch). |
 
@@ -93,7 +93,7 @@ are annotated read-only.
 
 | Tool | What |
 | ---- | ---- |
-| `nbox_status` | Connection + NetBox/Django/Python versions. |
+| `nbox_status` | Connection + active backend + NetBox/Django/Python versions. |
 | `nbox_search` | Search devices/IPs/prefixes/VLANs/sites/circuits/aggregates/ASNs/IP-ranges/tenants/contacts/providers/VMs/clusters; `query`, `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag`, `vrf` (id\|rd\|name; IP/prefix only). |
 | `nbox_get` | One object by `kind` (device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, cluster) + `ref`; `vrf`/`site`/`group` disambiguate. |
 | `nbox_get_interface` | One interface on a device, with its cable-path trace. |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -324,7 +324,7 @@ All tools are annotated read-only.
 
 | Tool | Purpose |
 | ---- | ------- |
-| `nbox_status` | Connection target plus NetBox/Django/Python versions. Call first to confirm reachability. |
+| `nbox_status` | Connection target plus active backend and NetBox/Django/Python versions. Call first to confirm reachability. |
 | `nbox_search` | Free-text search across devices, sites, IPs, prefixes, VLANs, circuits, aggregates, ASNs, IP ranges, tenants, contacts, providers, virtual machines, and clusters. Optional `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag`, and `vrf` filters (`vrf` filters IP/prefix results only; only one scope filter at a time). Use it to find an object's exact reference. |
 | `nbox_get` | Fetch one object by `kind` + `ref`. An ambiguous `ref` returns a candidate list; pass `vrf` (ip/prefix) or `site`/`group` (vlan) to disambiguate. |
 | `nbox_get_interface` | One interface on a device: its config, assigned addresses, and cable-path trace. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,12 +204,24 @@ pub struct ProfileConfig {
 ///
 /// REST remains the default and full-coverage backend. GraphQL is opt-in and may
 /// fall back to REST for operations NetBox does not expose through GraphQL.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum BackendKind {
     #[default]
     Rest,
     Graphql,
+}
+
+impl BackendKind {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rest => "rest",
+            Self::Graphql => "graphql",
+        }
+    }
 }
 
 impl ProfileConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -819,6 +819,7 @@ async fn run_status(ctx: &Ctx) -> Result<()> {
 
     let report = serde_json::json!({
         "netbox_url": url,
+        "backend": client.backend(),
         "netbox_version": status.netbox_version,
         "django_version": status.django_version,
         "python_version": status.python_version,
@@ -827,6 +828,7 @@ async fn run_status(ctx: &Ctx) -> Result<()> {
     emit(ctx, &report, || {
         let mut kv = KeyValues::new();
         kv.push("netbox_url", url.clone())
+            .push("backend", client.backend().as_str())
             .push("netbox_version", status.netbox_version.clone())
             .push_opt("django", status.django_version.clone())
             .push_opt("python", status.python_version.clone());

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -25,6 +25,7 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::config::BackendKind;
 use crate::domain::detail;
 use crate::domain::interface_view::InterfaceView;
 use crate::domain::journal_view::JournalView;
@@ -213,7 +214,7 @@ pub struct ListTagsArgs {
     pub limit: Option<usize>,
 }
 
-/// `nbox_status` result: connection target plus NetBox/Django/Python versions.
+/// `nbox_status` result: connection target, active backend, and versions.
 ///
 /// The version keys mirror the previous `serde_json::json!` shape exactly: they
 /// are always present, with `null` when NetBox omits the value (no
@@ -222,6 +223,8 @@ pub struct ListTagsArgs {
 pub struct StatusReport {
     /// The NetBox base URL the server is connected to.
     pub netbox_url: String,
+    /// The active read backend for this profile.
+    pub backend: BackendKind,
     /// The NetBox application version.
     pub netbox_version: String,
     /// The Django framework version NetBox runs on (`null` if unreported).
@@ -384,13 +387,14 @@ impl NboxMcp {
     /// reachability and the NetBox/Django/Python versions. No parameters.
     #[tool(
         name = "nbox_status",
-        description = "Show NetBox connection and version info (NetBox/Django/Python versions). Use to confirm reachability before other lookups.",
+        description = "Show NetBox connection, active backend, and version info (NetBox/Django/Python versions). Use to confirm reachability before other lookups.",
         annotations(read_only_hint = true)
     )]
     async fn nbox_status(&self) -> Result<Json<StatusReport>, ErrorData> {
         let status = self.client.status().await.map_err(to_mcp_error)?;
         Ok(Json(StatusReport {
             netbox_url: self.client.base_url().as_str().to_string(),
+            backend: self.client.backend(),
             netbox_version: status.netbox_version,
             django_version: status.django_version,
             python_version: status.python_version,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -217,6 +217,7 @@ async fn status_returns_versions() {
     let value = serde_json::to_value(&report).expect("serialize report");
 
     assert_eq!(value["netbox_version"], "4.5.5");
+    assert_eq!(value["backend"], "rest");
     assert_eq!(value["django_version"], "5.0.9");
     assert_eq!(value["python_version"], "3.12.3");
     // The configured base URL is echoed back (the mock's URI, trailing slash).

--- a/src/netbox/graphql.rs
+++ b/src/netbox/graphql.rs
@@ -106,6 +106,22 @@ impl GraphqlCapabilities {
     #[must_use]
     pub fn filter_value(&self, filter_type: &str, name: &str, value: Value) -> Option<Value> {
         let field = self.filters.get(filter_type)?.get(name)?;
+        if name == "scope_type" && field.named_type.as_deref() == Some("ContentTypeFilter") {
+            let Value::String(content_type) = value else {
+                return None;
+            };
+            let (app_label, model) = content_type.split_once('.')?;
+            return Some(json!({
+                "app_label": { "exact": app_label },
+                "model": { "exact": model },
+            }));
+        }
+        if field.named_type.as_deref() == Some("TreeNodeFilter") {
+            return Some(json!({
+                "id": coerce_list_item(value),
+                "match_type": "EXACT",
+            }));
+        }
         let value = normalize_filter_value(name, value, field);
         match field.shape {
             FilterShape::Scalar => Some(value),
@@ -299,13 +315,6 @@ impl GraphqlCapabilities {
         let mut filters = HashMap::new();
         for batch in batches {
             for (name, input) in batch.inputs() {
-                let Some(input) = input else {
-                    tracing::warn!(
-                        filter_type = name,
-                        "NetBox GraphQL filter type missing from introspection; filtered searches for this branch may be skipped"
-                    );
-                    continue;
-                };
                 let Some(fields) = input.input_fields else {
                     tracing::warn!(
                         filter_type = name,
@@ -339,23 +348,51 @@ impl GraphqlCapabilities {
 }
 
 impl FilterResponse {
-    fn inputs(self) -> [(&'static str, Option<InputType>); 14] {
-        [
-            ("DeviceFilter", self.device),
-            ("SiteFilter", self.site),
-            ("IPAddressFilter", self.ip),
-            ("PrefixFilter", self.prefix),
-            ("VLANFilter", self.vlan),
-            ("CircuitFilter", self.circuit),
-            ("AggregateFilter", self.aggregate),
-            ("ASNFilter", self.asn),
-            ("IPRangeFilter", self.ip_range),
-            ("TenantFilter", self.tenant),
-            ("ContactFilter", self.contact),
-            ("ProviderFilter", self.provider),
-            ("VirtualMachineFilter", self.virtual_machine),
-            ("ClusterFilter", self.cluster),
-        ]
+    fn inputs(self) -> Vec<(&'static str, InputType)> {
+        let mut inputs = Vec::new();
+        if let Some(input) = self.device {
+            inputs.push(("DeviceFilter", input));
+        }
+        if let Some(input) = self.site {
+            inputs.push(("SiteFilter", input));
+        }
+        if let Some(input) = self.ip {
+            inputs.push(("IPAddressFilter", input));
+        }
+        if let Some(input) = self.prefix {
+            inputs.push(("PrefixFilter", input));
+        }
+        if let Some(input) = self.vlan {
+            inputs.push(("VLANFilter", input));
+        }
+        if let Some(input) = self.circuit {
+            inputs.push(("CircuitFilter", input));
+        }
+        if let Some(input) = self.aggregate {
+            inputs.push(("AggregateFilter", input));
+        }
+        if let Some(input) = self.asn {
+            inputs.push(("ASNFilter", input));
+        }
+        if let Some(input) = self.ip_range {
+            inputs.push(("IPRangeFilter", input));
+        }
+        if let Some(input) = self.tenant {
+            inputs.push(("TenantFilter", input));
+        }
+        if let Some(input) = self.contact {
+            inputs.push(("ContactFilter", input));
+        }
+        if let Some(input) = self.provider {
+            inputs.push(("ProviderFilter", input));
+        }
+        if let Some(input) = self.virtual_machine {
+            inputs.push(("VirtualMachineFilter", input));
+        }
+        if let Some(input) = self.cluster {
+            inputs.push(("ClusterFilter", input));
+        }
+        inputs
     }
 }
 
@@ -404,6 +441,49 @@ mod tests {
         assert_eq!(
             caps.filter_value("DeviceFilter", "id", json!(1)),
             Some(json!({ "exact": 1 }))
+        );
+    }
+
+    #[test]
+    fn content_type_filter_splits_scope_type_into_app_and_model() {
+        let mut caps = GraphqlCapabilities::default();
+        caps.filters.insert(
+            "PrefixFilter".into(),
+            HashMap::from([(
+                "scope_type".into(),
+                FilterField {
+                    shape: FilterShape::Lookup,
+                    named_type: Some("ContentTypeFilter".into()),
+                },
+            )]),
+        );
+
+        assert_eq!(
+            caps.filter_value("PrefixFilter", "scope_type", json!("dcim.sitegroup")),
+            Some(json!({
+                "app_label": { "exact": "dcim" },
+                "model": { "exact": "sitegroup" }
+            }))
+        );
+    }
+
+    #[test]
+    fn tree_node_filter_shapes_id_with_exact_match_type() {
+        let mut caps = GraphqlCapabilities::default();
+        caps.filters.insert(
+            "DeviceFilter".into(),
+            HashMap::from([(
+                "location_id".into(),
+                FilterField {
+                    shape: FilterShape::Lookup,
+                    named_type: Some("TreeNodeFilter".into()),
+                },
+            )]),
+        );
+
+        assert_eq!(
+            caps.filter_value("DeviceFilter", "location_id", json!(7)),
+            Some(json!({ "id": "7", "match_type": "EXACT" }))
         );
     }
 

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -1182,7 +1182,7 @@ impl NetBoxClient {
                 caps,
                 "contact_list",
                 Value::Object(filters),
-                "id name display email group { id name display slug }",
+                "id name display email",
                 limit,
             )
             .await?;
@@ -1195,10 +1195,7 @@ impl NetBoxClient {
                     kind: ObjectKind::Contact,
                     id,
                     score: score_match(q, &display),
-                    subtitle: c
-                        .group
-                        .and_then(GqlBrief::label)
-                        .or_else(|| non_empty(c.email)),
+                    subtitle: non_empty(c.email),
                     url: self.gql_web_url(ObjectKind::Contact, id),
                     display,
                 })
@@ -2119,7 +2116,6 @@ struct GqlContact {
     name: Option<String>,
     display: Option<String>,
     email: Option<String>,
-    group: Option<GqlBrief>,
 }
 
 impl GqlId for GqlContact {

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,9 +1,9 @@
 # NetBox integration fixture
 
-End-to-end checks that run the compiled `nbox` binary against a real, pinned
-NetBox 4.2.x. This catches what the offline wiremock suite can't: polymorphic
-scope filters, pagination offset windows, available-prefix/IP shapes, and the
-serializer/detail-model shapes of the live API.
+End-to-end checks that run the compiled `nbox` binary against real, pinned NetBox
+fixtures. This catches what the offline wiremock suite can't: polymorphic scope
+filters, pagination offset windows, available-prefix/IP shapes, GraphQL schema
+drift, and the serializer/detail-model shapes of the live API.
 
 These are heavy, so they live behind a separate workflow
 (`.github/workflows/netbox-integration.yml`) and the Rust tests are all
@@ -11,13 +11,15 @@ These are heavy, so they live behind a separate workflow
 
 ## Pieces
 
-- `docker-compose.yml` — boots ONE pinned NetBox (`netboxcommunity/netbox:v4.2.9`)
-  plus Postgres and Redis. The API is exposed on host port **8000**
-  (`http://localhost:8000`). Postgres runs on a `tmpfs`, so every `up` starts
-  from a clean DB.
+- `docker-compose.yml` — boots one pinned NetBox image (default
+  `netboxcommunity/netbox:v4.2.9`, override with `NETBOX_IMAGE`) plus Postgres
+  and Redis. The API is exposed on host port **8000** (`http://localhost:8000`).
+  Postgres runs on a `tmpfs`, so every `up` starts from a clean DB.
 - `wait-for-ready.sh` — polls `/api/status/` until NetBox answers 200 (or times
   out). First boot runs migrations + superuser creation, so this can take a
   couple of minutes on a cold image.
+- `resolve-token.sh` — prints the NetBox 4.5+ v2 API token assembled from the
+  generated public key and the deterministic fixture secret.
 - `seed.py` — creates the fixture (stdlib only, no pip installs). Idempotent.
 - `../it_netbox.rs` — the gated Rust tests.
 
@@ -34,6 +36,13 @@ The NetBox image's entrypoint creates the superuser and a `Token` with this exac
 key on first boot (via `SUPERUSER_API_TOKEN` in `docker-compose.yml`). Because
 the DB is ephemeral (`tmpfs`), this is always the token in play. The tests and
 seed read it from `NETBOX_TOKEN`, falling back to this default.
+
+NetBox 4.5+ stores the deterministic secret behind a generated v2 token key.
+For those images, wait until first boot finishes, then export the resolved token:
+
+```sh
+export NETBOX_TOKEN="$(./tests/integration/resolve-token.sh)"
+```
 
 ## Fixture created by `seed.py`
 
@@ -60,7 +69,7 @@ docker compose -f tests/integration/docker-compose.yml up -d
 
 NBOX_URL=http://localhost:8000 \
   NETBOX_TOKEN=0123456789abcdef0123456789abcdef0fedcba9 \
-  cargo test --test it_netbox -- --ignored
+  cargo test --test it_netbox -- --ignored --skip graphql_backend
 
 docker compose -f tests/integration/docker-compose.yml down -v
 ```
@@ -68,8 +77,21 @@ docker compose -f tests/integration/docker-compose.yml down -v
 `NBOX_URL` and `NETBOX_TOKEN` default to the values above, so exporting them is
 optional when using this compose file unchanged.
 
+For the GraphQL compatibility lane against NetBox 4.5:
+
+```sh
+NETBOX_IMAGE=netboxcommunity/netbox:v4.5.10-4.0.2 \
+  docker compose -f tests/integration/docker-compose.yml up -d
+NETBOX_READY_HTTP_CODES=200,403 ./tests/integration/wait-for-ready.sh
+export NETBOX_TOKEN="$(./tests/integration/resolve-token.sh)"
+./tests/integration/wait-for-ready.sh
+./tests/integration/seed.py
+cargo test --test it_netbox graphql_backend -- --ignored --test-threads=1
+docker compose -f tests/integration/docker-compose.yml down -v
+```
+
 ## Bumping the NetBox version
 
-Change the `netbox` image tag in `docker-compose.yml` to a specific 4.2.x patch
-(never a floating tag), re-run the local flow above to confirm it's still green,
-then commit.
+Set `NETBOX_IMAGE` to a specific pinned tag, re-run the local flow above to
+confirm it's still green, then commit the new workflow/default only if it is
+intentional.

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,9 +1,9 @@
-# NetBox 4.2 integration fixture for nbox.
+# NetBox integration fixture for nbox.
 #
-# Boots ONE pinned NetBox 4.2.x plus its Postgres and Redis, exposes the API on
-# a fixed host port, and provisions a DETERMINISTIC superuser API token that the
-# seed script, the gated Rust tests, and CI all share. Read-only smoke target:
-# no worker/housekeeping containers (nbox never enqueues background jobs).
+# Boots one pinned NetBox image plus its Postgres and Redis, exposes the API on a
+# fixed host port, and provisions a DETERMINISTIC superuser API token that the
+# seed script, the gated Rust tests, and CI all share. Read-only smoke target: no
+# worker/housekeeping containers (nbox never enqueues background jobs).
 #
 # Usage (see README.md in this directory):
 #   docker compose -f tests/integration/docker-compose.yml up -d
@@ -43,9 +43,9 @@ services:
       retries: 30
 
   netbox:
-    # EXACT, non-floating tag. v4.2.9 is the latest 4.2.x patch at authoring time.
-    # Bump deliberately (and re-run the smoke test) when adopting a newer 4.2.x.
-    image: netboxcommunity/netbox:v4.2.9
+    # EXACT, non-floating default. CI can override NETBOX_IMAGE for other pinned
+    # lines (for example, GraphQL compatibility against 4.5).
+    image: ${NETBOX_IMAGE:-netboxcommunity/netbox:v4.2.9}
     depends_on:
       postgres:
         condition: service_healthy
@@ -78,6 +78,10 @@ services:
       SUPERUSER_EMAIL: admin@example.com
       SUPERUSER_PASSWORD: admin
       SUPERUSER_API_TOKEN: "0123456789abcdef0123456789abcdef0fedcba9"
+      # NetBox 4.5+ requires at least one pepper to create/use v2 API tokens.
+      # netbox-docker maps API_TOKEN_PEPPER_1 into NetBox's API_TOKEN_PEPPERS
+      # config dict. Static is fine here: this is an ephemeral CI fixture.
+      API_TOKEN_PEPPER_1: "0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghij"
     ports:
       # NetBox's nginx-unit serves the app on 8080 inside the container; expose
       # it on host 8000 (NBOX_URL=http://localhost:8000).

--- a/tests/integration/resolve-token.sh
+++ b/tests/integration/resolve-token.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Print the API token that the disposable NetBox fixture expects.
+#
+# NetBox 4.5 stores the seeded token secret separately from a generated public
+# key and expects callers to send `nbt_<key>.<secret>`. Older fixtures accept the
+# bare deterministic secret, so this helper is only needed by the 4.5 GraphQL CI
+# lane after the app has finished first-boot initialization.
+set -euo pipefail
+
+COMPOSE_FILE="${COMPOSE_FILE:-tests/integration/docker-compose.yml}"
+NETBOX_TOKEN="${NETBOX_TOKEN:-0123456789abcdef0123456789abcdef0fedcba9}"
+NETBOX_USERNAME="${NETBOX_USERNAME:-admin}"
+
+key="$(
+  docker compose -f "${COMPOSE_FILE}" exec -T netbox \
+    /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py shell -c \
+    "from users.models import Token; print(Token.objects.get(user__username='${NETBOX_USERNAME}').key)" \
+    | tail -n 1
+)"
+
+case "${key}" in
+  nbt_*)
+    printf '%s.%s\n' "${key}" "${NETBOX_TOKEN}"
+    ;;
+  "${NETBOX_TOKEN}")
+    printf '%s\n' "${NETBOX_TOKEN}"
+    ;;
+  *)
+    printf 'nbt_%s.%s\n' "${key}" "${NETBOX_TOKEN}"
+    ;;
+esac

--- a/tests/integration/wait-for-ready.sh
+++ b/tests/integration/wait-for-ready.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Poll NetBox's /api/status/ until it answers (HTTP 200), or time out.
+# Poll NetBox's /api/status/ until it answers with an accepted HTTP code, or
+# time out.
 #
 # NetBox's first boot runs DB migrations + superuser creation before the API
 # serves, so this can take a couple of minutes on a cold image. We poll rather
@@ -9,24 +10,33 @@
 # without a token), so the probe sends the deterministic CI token.
 #
 #   NBOX_URL=http://localhost:8000 NETBOX_TOKEN=<token> ./wait-for-ready.sh [timeout_seconds]
+#   NETBOX_READY_HTTP_CODES=200,403 ./wait-for-ready.sh [timeout_seconds]
 #
 # Defaults: NBOX_URL=http://localhost:8000, the seeded token, timeout 300s.
 set -euo pipefail
 
 NBOX_URL="${NBOX_URL:-http://localhost:8000}"
 NETBOX_TOKEN="${NETBOX_TOKEN:-0123456789abcdef0123456789abcdef0fedcba9}"
+NETBOX_READY_HTTP_CODES="${NETBOX_READY_HTTP_CODES:-200}"
 TIMEOUT="${1:-300}"
 INTERVAL=3
 
 status_url="${NBOX_URL%/}/api/status/"
 deadline=$(( $(date +%s) + TIMEOUT ))
 
-echo "Waiting for NetBox at ${status_url} (timeout ${TIMEOUT}s)..."
+is_ready_code() {
+  case ",${NETBOX_READY_HTTP_CODES}," in
+    *,"$1",*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+echo "Waiting for NetBox at ${status_url} (HTTP ${NETBOX_READY_HTTP_CODES}; timeout ${TIMEOUT}s)..."
 while :; do
   code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
     -H "Authorization: Token ${NETBOX_TOKEN}" "${status_url}" || echo 000)"
-  if [ "${code}" = "200" ]; then
-    echo "NetBox is ready (HTTP 200 from /api/status/)."
+  if is_ready_code "${code}"; then
+    echo "NetBox is ready (HTTP ${code} from /api/status/)."
     exit 0
   fi
   if [ "$(date +%s)" -ge "${deadline}" ]; then

--- a/tests/it_netbox.rs
+++ b/tests/it_netbox.rs
@@ -1,4 +1,4 @@
-//! Gated end-to-end integration tests against a LIVE NetBox 4.2.x.
+//! Gated end-to-end integration tests against LIVE NetBox fixtures.
 //!
 //! These run the *real* compiled binary (`env!("CARGO_BIN_EXE_nbox")`) against a
 //! running NetBox seeded by `tests/integration/seed.py`. They catch what wiremock
@@ -7,7 +7,8 @@
 //!
 //! Every test is `#[ignore]`, so plain `cargo test` SKIPS them — the offline
 //! suite stays green and unchanged. The `netbox-integration` workflow boots the
-//! fixture, seeds it, and runs `cargo test --test it_netbox -- --ignored`.
+//! fixture, seeds it, and runs either the full ignored suite against 4.2 or the
+//! GraphQL-filtered subset against 4.5.
 //!
 //! Run locally:
 //!   docker compose -f tests/integration/docker-compose.yml up -d
@@ -43,9 +44,10 @@ fn netbox_token() -> String {
 }
 
 /// A throwaway config file holding one profile that points at the live NetBox.
-/// `page_size` is configurable so the pagination test can force multiple pages.
+/// `page_size` is configurable so the pagination test can force multiple pages,
+/// and `backend` lets GraphQL-smoke tests exercise the opt-in search path.
 /// The `NamedTempFile` is returned so it lives as long as the test needs it.
-fn temp_config(page_size: usize) -> NamedTempFile {
+fn temp_config_with_backend(page_size: usize, backend: &str) -> NamedTempFile {
     let mut config = NamedTempFile::new().expect("create temp config");
     write!(
         config,
@@ -54,9 +56,11 @@ fn temp_config(page_size: usize) -> NamedTempFile {
          [profiles.ci]\n\
          url = \"{url}\"\n\
          token_env = \"NETBOX_TOKEN_UNUSED\"\n\
+         backend = \"{backend}\"\n\
          page_size = {page_size}\n\
          verify_tls = false\n",
         url = netbox_url(),
+        backend = backend,
     )
     .expect("write temp config");
     config.flush().expect("flush temp config");
@@ -65,8 +69,8 @@ fn temp_config(page_size: usize) -> NamedTempFile {
 
 /// Run `nbox <args>` against the live instance with the given page size, using a
 /// throwaway profile and `NBOX_TOKEN` for auth. Returns the captured output.
-fn run_nbox_with_page_size(page_size: usize, args: &[&str]) -> Output {
-    let config = temp_config(page_size);
+fn run_nbox_with_backend(page_size: usize, backend: &str, args: &[&str]) -> Output {
+    let config = temp_config_with_backend(page_size, backend);
     let output = Command::new(env!("CARGO_BIN_EXE_nbox"))
         .arg("--config")
         .arg(config.path())
@@ -83,9 +87,18 @@ fn run_nbox_with_page_size(page_size: usize, args: &[&str]) -> Output {
     output
 }
 
+fn run_nbox_with_page_size(page_size: usize, args: &[&str]) -> Output {
+    run_nbox_with_backend(page_size, "rest", args)
+}
+
 /// Run `nbox <args>` with the default page size (100).
 fn run_nbox(args: &[&str]) -> Output {
     run_nbox_with_page_size(100, args)
+}
+
+/// Run `nbox <args>` through a profile using the opt-in GraphQL search backend.
+fn run_nbox_graphql(args: &[&str]) -> Output {
+    run_nbox_with_backend(100, "graphql", args)
 }
 
 /// Assert the command succeeded (exit 0); on failure, dump both streams.
@@ -177,6 +190,98 @@ fn search_site_returns_scope_filtered_prefix() {
         arr.iter()
             .any(|r| r["kind"] == "prefix" && r["display"] == "10.10.0.0/16"),
         "site-scoped prefix 10.10.0.0/16 not returned for --site ci-site: {results}"
+    );
+}
+
+// --- GraphQL search backend smoke -----------------------------------------
+
+/// The opt-in GraphQL backend finds the same seeded device as REST search.
+#[test]
+#[ignore = "requires a live NetBox (GraphQL integration workflow)"]
+fn graphql_backend_search_finds_seeded_device() {
+    let out = run_nbox_graphql(&["-o", "json", "search", "ci-dev1"]);
+    assert_ok(&out, "search ci-dev1 (graphql)");
+    let results = json_of(&out);
+    let arr = results.as_array().expect("search JSON is an array");
+    assert!(
+        arr.iter()
+            .any(|r| r["kind"] == "device" && r["display"] == "ci-dev1"),
+        "GraphQL search did not surface device ci-dev1: {results}"
+    );
+}
+
+/// `--site` scopes both polymorphic prefixes and site-backed VLANs under GraphQL.
+#[test]
+#[ignore = "requires a live NetBox (GraphQL integration workflow)"]
+fn graphql_backend_site_scope_returns_prefix_and_vlan() {
+    let prefix = run_nbox_graphql(&["-o", "json", "search", "10.10", "--site", "ci-site"]);
+    assert_ok(&prefix, "search 10.10 --site ci-site (graphql)");
+    let prefix_results = json_of(&prefix);
+    let prefix_arr = prefix_results.as_array().expect("search JSON is an array");
+    assert!(
+        prefix_arr
+            .iter()
+            .any(|r| r["kind"] == "prefix" && r["display"] == "10.10.0.0/16"),
+        "GraphQL site scope did not surface site-scoped prefix: {prefix_results}"
+    );
+
+    let vlan = run_nbox_graphql(&["-o", "json", "search", "ci-vlan", "--site", "ci-site"]);
+    assert_ok(&vlan, "search ci-vlan --site ci-site (graphql)");
+    let vlan_results = json_of(&vlan);
+    let vlan_arr = vlan_results.as_array().expect("search JSON is an array");
+    assert!(
+        vlan_arr
+            .iter()
+            .any(|r| r["kind"] == "vlan" && r["display"] == "1234 ci-vlan"),
+        "GraphQL site scope did not surface ci-site VLAN: {vlan_results}"
+    );
+}
+
+/// GraphQL search applies exact polymorphic scope filters for all id-based scopes.
+#[test]
+#[ignore = "requires a live NetBox (GraphQL integration workflow)"]
+fn graphql_backend_scope_filters_return_exact_prefixes() {
+    for (flag, ref_, expected) in [
+        ("--region", "ci-region", "10.20.0.0/16"),
+        ("--site-group", "ci-sitegroup", "10.30.0.0/16"),
+        ("--location", "ci-loc", "10.40.0.0/16"),
+    ] {
+        let what = format!("search 10. {flag} {ref_} (graphql)");
+        let out = run_nbox_graphql(&["-o", "json", "search", "10.", flag, ref_]);
+        assert_ok(&out, &what);
+        let results = json_of(&out);
+        let arr = results.as_array().expect("search JSON is an array");
+        assert!(
+            arr.iter()
+                .any(|r| r["kind"] == "prefix" && r["display"] == expected),
+            "{flag} {ref_} should surface {expected}: {results}"
+        );
+        for other in ["10.20.0.0/16", "10.30.0.0/16", "10.40.0.0/16"] {
+            if other != expected {
+                assert!(
+                    !arr.iter().any(|r| r["display"] == other),
+                    "{flag} {ref_} leaked another scope's prefix {other}: {results}"
+                );
+            }
+        }
+    }
+}
+
+/// GraphQL search applies the resolved VRF id to prefixes.
+#[test]
+#[ignore = "requires a live NetBox (GraphQL integration workflow)"]
+fn graphql_backend_vrf_filters_duplicate_prefix() {
+    let out = run_nbox_graphql(&["-o", "json", "search", "10.0", "--vrf", "ci-vrf"]);
+    assert_ok(&out, "search 10.0 --vrf ci-vrf (graphql)");
+    let results = json_of(&out);
+    let arr = results.as_array().expect("search JSON is an array");
+    let matches = arr
+        .iter()
+        .filter(|r| r["kind"] == "prefix" && r["display"] == "10.0.0.0/24")
+        .count();
+    assert_eq!(
+        matches, 1,
+        "GraphQL VRF search should return only the VRF-scoped duplicate prefix: {results}"
     );
 }
 

--- a/tests/output_flags_tests.rs
+++ b/tests/output_flags_tests.rs
@@ -293,6 +293,7 @@ fn status_report_json_honors_all_flags() {
     // The exact value `run_status` hands to `emit` for `--json`.
     let report = json!({
         "netbox_url": "https://netbox.example.com",
+        "backend": "rest",
         "netbox_version": "4.2.0",
         "django_version": "5.0.9",
         "python_version": "3.11.2",

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -121,6 +121,105 @@ async fn mount_graphql_device_result(server: &MockServer) {
         .await;
 }
 
+fn graphql_list_field(name: &str, filter: &str) -> serde_json::Value {
+    json!({
+        "name": name,
+        "args": [
+            {
+                "name": "filters",
+                "type": {"kind": "INPUT_OBJECT", "name": filter}
+            },
+            {
+                "name": "pagination",
+                "type": {"kind": "INPUT_OBJECT", "name": "PaginationInput"}
+            }
+        ]
+    })
+}
+
+fn graphql_input_field(name: &str) -> serde_json::Value {
+    json!({
+        "name": name,
+        "type": {"kind": "INPUT_OBJECT", "name": "StringLookup"}
+    })
+}
+
+async fn mount_graphql_capabilities(
+    server: &MockServer,
+    fields: Vec<serde_json::Value>,
+    first_batch: serde_json::Value,
+    second_batch: serde_json::Value,
+) {
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("__schema"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "__schema": {
+                    "queryType": {
+                        "fields": fields
+                    }
+                }
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("__type"))
+        .and(body_string_contains("DeviceFilter"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": first_batch
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("__type"))
+        .and(body_string_contains("ASNFilter"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": second_batch
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_graphql_scope_refs(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/regions/"))
+        .and(query_param("slug", "scope-ref"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": 7, "url": "http://nb/api/dcim/regions/7/", "name": "scope-ref", "slug": "scope-ref"}]
+        })))
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": 9, "url": "http://nb/api/dcim/sites/9/", "name": "iad1", "slug": "iad1"}]
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_graphql_vrf_ref(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/vrfs/3/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 3,
+            "url": "http://nb/api/ipam/vrfs/3/",
+            "name": "blue",
+            "rd": "65000:3"
+        })))
+        .mount(server)
+        .await;
+}
+
 fn graphql_request_query(request: &wiremock::Request) -> Option<String> {
     request
         .body_json::<serde_json::Value>()
@@ -128,6 +227,18 @@ fn graphql_request_query(request: &wiremock::Request) -> Option<String> {
         .get("query")?
         .as_str()
         .map(str::to_string)
+}
+
+fn graphql_request_for(requests: &[wiremock::Request], list_name: &str) -> serde_json::Value {
+    requests
+        .iter()
+        .filter_map(|request| request.body_json::<serde_json::Value>().ok())
+        .find(|body| {
+            body.get("query")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|query| query.contains(list_name))
+        })
+        .unwrap_or_else(|| panic!("{list_name} query was sent"))
 }
 
 #[tokio::test]
@@ -332,6 +443,358 @@ async fn graphql_backend_propagates_graphql_errors() {
     assert!(
         format!("{err:#}").contains("field exploded"),
         "got: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn graphql_backend_null_data_without_errors_fails_closed() {
+    let server = MockServer::start().await;
+    mount_graphql_device_schema(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("device_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": null
+        })))
+        .mount(&server)
+        .await;
+
+    let err = graphql_client(&server)
+        .search(SearchRequest {
+            query: "edge".into(),
+            limit: 10,
+            filters: SearchFilters::default(),
+        })
+        .await
+        .expect_err("null GraphQL data should fail the search branch");
+
+    assert!(
+        format!("{err:#}").contains("GraphQL response did not include data"),
+        "got: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn graphql_backend_prefix_and_cluster_use_polymorphic_scope_filters() {
+    let server = MockServer::start().await;
+    mount_graphql_scope_refs(&server).await;
+    mount_graphql_capabilities(
+        &server,
+        vec![
+            graphql_list_field("prefix_list", "PrefixFilter"),
+            graphql_list_field("cluster_list", "ClusterFilter"),
+        ],
+        json!({
+            "prefix": {
+                "inputFields": [
+                    graphql_input_field("q"),
+                    graphql_input_field("scope_type"),
+                    graphql_input_field("scope_id")
+                ]
+            }
+        }),
+        json!({
+            "cluster": {
+                "inputFields": [
+                    graphql_input_field("q"),
+                    graphql_input_field("scope_type"),
+                    graphql_input_field("scope_id")
+                ]
+            }
+        }),
+    )
+    .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("prefix_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "prefix_list": [{
+                    "id": "11",
+                    "prefix": "10.20.0.0/16",
+                    "display": "10.20.0.0/16",
+                    "scope": {"id": "7", "name": "scope-ref", "display": "scope-ref", "slug": "scope-ref"}
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("cluster_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "cluster_list": [{
+                    "id": "12",
+                    "name": "cluster-a",
+                    "display": "cluster-a",
+                    "type": null,
+                    "scope": {"id": "7", "name": "scope-ref", "display": "scope-ref", "slug": "scope-ref"}
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let results = graphql_client(&server)
+        .search(SearchRequest {
+            query: "scope".into(),
+            limit: 10,
+            filters: SearchFilters {
+                region: Some("scope-ref".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap()
+        .results;
+
+    assert!(
+        results.iter().any(|r| r.kind == ObjectKind::Prefix),
+        "got: {results:?}"
+    );
+    assert!(
+        results.iter().any(|r| r.kind == ObjectKind::Cluster),
+        "got: {results:?}"
+    );
+    let requests = server.received_requests().await.unwrap();
+    for list_name in ["prefix_list", "cluster_list"] {
+        let body = graphql_request_for(&requests, list_name);
+        assert_eq!(
+            body["variables"]["filters"]["scope_type"],
+            json!({"exact": "dcim.region"}),
+            "{list_name} should carry scope_type: {body:#}"
+        );
+        assert_eq!(
+            body["variables"]["filters"]["scope_id"],
+            json!({"exact": 7}),
+            "{list_name} should carry scope_id: {body:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn graphql_backend_ip_and_prefix_use_vrf_id_filter() {
+    let server = MockServer::start().await;
+    mount_graphql_vrf_ref(&server).await;
+    mount_graphql_capabilities(
+        &server,
+        vec![
+            graphql_list_field("ip_address_list", "IPAddressFilter"),
+            graphql_list_field("prefix_list", "PrefixFilter"),
+        ],
+        json!({
+            "ip": {
+                "inputFields": [
+                    graphql_input_field("q"),
+                    graphql_input_field("vrf_id")
+                ]
+            },
+            "prefix": {
+                "inputFields": [
+                    graphql_input_field("q"),
+                    graphql_input_field("vrf_id")
+                ]
+            }
+        }),
+        json!({}),
+    )
+    .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("ip_address_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "ip_address_list": [{
+                    "id": "21",
+                    "address": "10.0.0.10/24",
+                    "display": "10.0.0.10/24",
+                    "dns_name": ""
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("prefix_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "prefix_list": [{
+                    "id": "22",
+                    "prefix": "10.0.0.0/24",
+                    "display": "10.0.0.0/24",
+                    "scope": null
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let results = graphql_client(&server)
+        .search(SearchRequest {
+            query: "10.0".into(),
+            limit: 10,
+            filters: SearchFilters {
+                vrf: Some("3".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap()
+        .results;
+
+    assert!(
+        results.iter().any(|r| r.kind == ObjectKind::IpAddress),
+        "got: {results:?}"
+    );
+    assert!(
+        results.iter().any(|r| r.kind == ObjectKind::Prefix),
+        "got: {results:?}"
+    );
+    let requests = server.received_requests().await.unwrap();
+    for list_name in ["ip_address_list", "prefix_list"] {
+        let body = graphql_request_for(&requests, list_name);
+        assert_eq!(
+            body["variables"]["filters"]["vrf_id"],
+            json!({"exact": 3}),
+            "{list_name} should carry vrf_id: {body:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn graphql_backend_vlan_and_vm_use_site_id_filter() {
+    let server = MockServer::start().await;
+    mount_graphql_scope_refs(&server).await;
+    mount_graphql_capabilities(
+        &server,
+        vec![
+            graphql_list_field("vlan_list", "VLANFilter"),
+            graphql_list_field("virtual_machine_list", "VirtualMachineFilter"),
+        ],
+        json!({
+            "vlan": {
+                "inputFields": [
+                    graphql_input_field("q"),
+                    graphql_input_field("site_id")
+                ]
+            }
+        }),
+        json!({
+            "virtualMachine": {
+                "inputFields": [
+                    graphql_input_field("q"),
+                    graphql_input_field("site_id")
+                ]
+            }
+        }),
+    )
+    .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("vlan_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "vlan_list": [{
+                    "id": "31",
+                    "vid": 1234,
+                    "name": "ci-vlan",
+                    "display": "ci-vlan",
+                    "site": {"id": "9", "name": "iad1", "display": "iad1", "slug": "iad1"},
+                    "group": null
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .and(body_string_contains("virtual_machine_list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "virtual_machine_list": [{
+                    "id": "32",
+                    "name": "vm01",
+                    "display": "vm01",
+                    "cluster": null,
+                    "site": {"id": "9", "name": "iad1", "display": "iad1", "slug": "iad1"}
+                }]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let results = graphql_client(&server)
+        .search(SearchRequest {
+            query: "ci".into(),
+            limit: 10,
+            filters: SearchFilters {
+                site: Some("iad1".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap()
+        .results;
+
+    assert!(
+        results.iter().any(|r| r.kind == ObjectKind::Vlan),
+        "got: {results:?}"
+    );
+    assert!(
+        results.iter().any(|r| r.kind == ObjectKind::Vm),
+        "got: {results:?}"
+    );
+    let requests = server.received_requests().await.unwrap();
+    for list_name in ["vlan_list", "virtual_machine_list"] {
+        let body = graphql_request_for(&requests, list_name);
+        assert_eq!(
+            body["variables"]["filters"]["site_id"],
+            json!({"exact": 9}),
+            "{list_name} should carry site_id: {body:#}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn graphql_backend_unsupported_filter_skips_without_unfiltered_query() {
+    let server = MockServer::start().await;
+    mount_graphql_capabilities(
+        &server,
+        vec![graphql_list_field("aggregate_list", "AggregateFilter")],
+        json!({
+            "aggregate": {
+                "inputFields": [
+                    graphql_input_field("q")
+                ]
+            }
+        }),
+        json!({}),
+    )
+    .await;
+
+    let outcome = graphql_client(&server)
+        .search(SearchRequest {
+            query: "10".into(),
+            limit: 10,
+            filters: SearchFilters {
+                role: Some("leaf".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap();
+
+    assert!(outcome.results.is_empty(), "got: {:?}", outcome.results);
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    let requests = server.received_requests().await.unwrap();
+    assert!(
+        requests
+            .iter()
+            .filter_map(graphql_request_query)
+            .all(|query| !query.contains("aggregate_list")),
+        "aggregate_list should be skipped instead of queried without the unsupported role filter: {requests:#?}"
     );
 }
 


### PR DESCRIPTION
## What changed

- Adds a live NetBox 4.5 GraphQL integration workflow lane, including v2 token resolution for the docker fixture.
- Adds targeted GraphQL parity/error tests for polymorphic scope, VRF filtering, site filtering, unsupported filters, null data, and error propagation.
- Adds backend visibility to `nbox status` and MCP `nbox_status`.
- Hardens GraphQL filter shaping for NetBox 4.5 `ContentTypeFilter` and `TreeNodeFilter`, and avoids the 4.5 contact `group`/`groups` selection drift in search.

## Why

The opt-in GraphQL backend needs a confidence lane against the NetBox 4.5 schema family it was built for, while REST remains the default path. The live 4.5 run also exposed schema-shape differences that the offline tests now cover.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --no-default-features`
- `NETBOX_IMAGE=netboxcommunity/netbox:v4.5.10-4.0.2 ... cargo test --test it_netbox graphql_backend -- --ignored --test-threads=1`
- default NetBox 4.2 fixture: `cargo test --test it_netbox -- --ignored --skip graphql_backend --test-threads=1`
