### PR TITLE
feat(tui): cycle profiles in config-file order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-run introspection. GraphQL pagination is capped at NetBox's maximum page
   size, and list decode errors include the GraphQL list name for easier debugging.
 
+### Changed
+- The TUI profile switcher (`P` / `Ctrl+P`) now cycles profiles in **config-file
+  order** instead of alphabetical. Profiles are loaded into an order-preserving
+  map (`indexmap` + `toml`'s `preserve_order`), so `[profiles.*]` keep their TOML
+  document order everywhere they're listed (`profile list`, `config show`, and the
+  switcher). No config change needed.
+
 ## [0.2.0] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures",
+ "indexmap",
  "insta",
  "ipnet",
  "is-terminal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,17 @@ clap_mangen = "0.3"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
+# Order-preserving map so `[profiles.*]` keep TOML document order (profile
+# cycling follows the config file, not alphabetical). Already in the tree.
+indexmap = { version = "2", features = ["serde"] }
 serde_json = "1"
 # JSON Schema derivation for MCP tool output schemas. Pinned to the exact
 # version rmcp 1.7 depends on so `Json<T>` accepts our `JsonSchema` types
 # (the trait bound is satisfied only by that one schemars instance).
 schemars = "=1.2.1"
-toml = "1"
+# `preserve_order` keeps map keys in TOML document order through deserialization
+# (so `[profiles.*]` load in file order for the TUI switcher, not alphabetical).
+toml = { version = "1", features = ["preserve_order"] }
 toml_edit = "0.25"
 
 # Config and paths

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,11 @@
 //! `%APPDATA%\nbox\config.toml` (Windows). We read with `toml` and mutate with
 //! `toml_edit` so user comments and formatting survive `profile add`/`use`.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, Item, Table, value};
 
@@ -73,8 +73,10 @@ pub struct Config {
     #[serde(default)]
     pub serve: ServeConfig,
 
+    /// An order-preserving map so the profiles keep their TOML document order
+    /// (the TUI profile switcher cycles in config-file order, not alphabetical).
     #[serde(default)]
-    pub profiles: BTreeMap<String, ProfileConfig>,
+    pub profiles: IndexMap<String, ProfileConfig>,
 }
 
 /// `nbox serve` (MCP server) settings. The CLI flags (`--http`, `--http-token`)
@@ -1000,6 +1002,21 @@ page_size = 250
         assert_eq!(work.backend(), BackendKind::Graphql);
         assert_eq!(work.page_size, Some(250));
         assert_eq!(work.verify_tls, None);
+    }
+
+    #[test]
+    fn profiles_preserve_config_file_order_not_alphabetical() {
+        // Declared out of alphabetical order on purpose: the `IndexMap` must keep
+        // TOML document order so the TUI switcher (`P`/`Ctrl+P`) cycles in file
+        // order. A `BTreeMap` would re-sort these to alpha and break that.
+        let cfg: Config = toml::from_str(
+            "[profiles.zebra]\nurl = \"https://z\"\n\
+             [profiles.alpha]\nurl = \"https://a\"\n\
+             [profiles.mike]\nurl = \"https://m\"\n",
+        )
+        .unwrap();
+        let order: Vec<&str> = cfg.profiles.keys().map(String::as_str).collect();
+        assert_eq!(order, ["zebra", "alpha", "mike"]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,10 +776,9 @@ async fn build_tui_app(
     let status = client.verify_compatible().await?;
 
     // All configured profiles the running session can cycle between without
-    // restarting. Order is alphabetical-by-name (the `BTreeMap` iterates sorted),
-    // not TOML document order — making cycling follow the config file would mean
-    // an order-preserving map across config (de)serialization, deferred for now.
-    // The switcher (`P` / `Ctrl+P`, or the palette `profile <name>` verb)
+    // restarting, in config-file (TOML document) order — `profiles` is an
+    // order-preserving `IndexMap`, so `P` / `Ctrl+P` walk the file order rather
+    // than alphabetical. The switcher (or the palette `profile <name>` verb)
     // reconnects + re-probes each one live; see `tui::state::App::cycle_profile`.
     let profiles: Vec<tui::state::ProfileEntry> = cfg
         .profiles


### PR DESCRIPTION
## Summary
The TUI profile switcher (`P` / `Ctrl+P`) cycled profiles **alphabetically** because `Config.profiles` was a `BTreeMap`. This switches it to an order-preserving `IndexMap` and enables `toml`'s `preserve_order` feature so `[profiles.*]` keep their TOML document order through deserialization.

Now the switcher, `profile list`, and `config show` all follow **config-file order**. No config change needed; `indexmap` was already in the lockfile transitively.

This is goal #5 from the read-only UX track (the research flagged it as the quick first win) — isolated to `config.rs`/`lib.rs`, no overlap with the footer/filters work.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` + `--no-default-features`
- `cargo test --all-features` — 760 passed / 0 failed, incl. a new `profiles_preserve_config_file_order_not_alphabetical` lock test