### PR TITLE
fix: clamp connect_timeout, single exit config write, reset live-browse on profile switch

### DIFF
--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -48,9 +48,15 @@ impl NetBoxClient {
         let timeout = Duration::from_secs(profile.timeout_secs.unwrap_or(15));
         let verify_tls = profile.verify_tls.unwrap_or(true);
 
+        // Keep the connect timeout under the overall timeout (a 10s connect
+        // budget with a 5s total is confusing); clamp to [1s, 10s].
+        let connect_timeout = Duration::from_secs(10)
+            .min(timeout.saturating_sub(Duration::from_secs(1)))
+            .max(Duration::from_secs(1));
+
         let http = reqwest::Client::builder()
             .timeout(timeout)
-            .connect_timeout(Duration::from_secs(10))
+            .connect_timeout(connect_timeout)
             // NetBox is commonly served by gunicorn *sync* workers, which close
             // the connection after each response rather than honoring HTTP/1.1
             // keep-alive. nbox's search fan-out fires ~17 requests at once; a

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -32,23 +32,24 @@ pub async fn run_on(
 ) -> Result<()> {
     let result = event_loop(terminal, app, refresh_secs).await;
 
-    // Persist the theme if it changed during the session.
-    if app.theme.name() != app.initial_theme
-        && let Some(path) = &app.config_path
-        && let Err(e) = crate::config::save_ui_theme(path, app.theme.name())
-    {
-        tracing::warn!("failed to persist theme: {e:#}");
+    // Persist only the `[ui]` fields that changed this session, in ONE
+    // format-preserving write so a failure can't leave the file half-updated.
+    let mut fields = Vec::new();
+    // Theme, if it changed.
+    if app.theme.name() != app.initial_theme {
+        fields.push(crate::config::UiField::Theme(app.theme.name().to_string()));
     }
-
-    // Persist the last-browsed Nav kind if it moved this session, so the next
-    // launch lands where the user left off (mirrors the theme guard).
+    // Last-browsed Nav kind, if it moved (so the next launch lands where the
+    // user left off).
     let last_browsed = app.last_browsed.map(|k| k.as_str().to_string());
-    if last_browsed != app.initial_last_browsed
+    if last_browsed != app.initial_last_browsed {
+        fields.push(crate::config::UiField::LastBrowsed(last_browsed));
+    }
+    if !fields.is_empty()
         && let Some(path) = &app.config_path
-        && let Err(e) =
-            crate::config::save_ui_field(path, &crate::config::UiField::LastBrowsed(last_browsed))
+        && let Err(e) = crate::config::save_ui_fields(path, &fields)
     {
-        tracing::warn!("failed to persist last-browsed kind: {e:#}");
+        tracing::warn!("failed to persist ui fields: {e:#}");
     }
 
     result

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -3172,6 +3172,10 @@ impl App {
         self.recent.clear();
         self.selected = 0;
         self.browse_kind = None;
+        // Land on a clean results pane: cancel any pending auto-browse and re-anchor
+        // the nav tick so the switch can't trip a spurious browse on the new instance.
+        self.browse_dirty = false;
+        self.nav_tick_anchor = self.nav_selected;
         // Old instance's counts are moot; a LoadNavCounts refetch repopulates them.
         self.nav_counts.clear();
         self.detail = None;
@@ -6172,6 +6176,17 @@ mod tests {
         assert_eq!(a.browse_kind, None);
         assert!(a.view.is_empty(), "Recent clears the browse results");
         assert_eq!(a.focus, Focus::Nav);
+
+        // With the browse results gone, the home target falls back to Recent.
+        // Seed a recent and confirm `home_target` resolves to it (selection 0).
+        assert!(a.results.is_empty() && a.selected == 0);
+        let r = result_of(ObjectKind::Vlan, 42, "vlan-42");
+        a.recent.push(RecentItem {
+            kind: r.kind,
+            id: r.id,
+            title: r.display.clone(),
+        });
+        assert_eq!(a.home_target(), Some((ObjectKind::Vlan, 42)));
     }
 
     #[test]


### PR DESCRIPTION
Three small ROADMAP code-nits. They touch disjoint files and are additive / behavior-preserving.

- **client.rs**: clamp `connect_timeout` under the overall `timeout` (to `[1s, 10s]`) so a small `timeout_secs` can't be exceeded by the hardcoded 10s connect budget.
- **app.rs**: persist theme + last_browsed on exit in ONE `save_ui_fields` write (only the fields that changed this session), instead of two separate read-modify-write calls.
- **state.rs**: on profile switch, also reset `browse_dirty` and re-anchor `nav_tick_anchor` so the switch lands on a clean results pane with no spurious auto-browse; extend the recents-fallback test to actually prove the fallback.