### PR TITLE
test+docs: NetBox 4.2/4.3/4.5 compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,8 @@ raw escape-hatch tool come later.
 ## NetBox Compatibility
 
 - **Requires NetBox 4.2+** (the polymorphic `scope` model for prefixes/VLANs).
-  nbox checks the instance version via `/api/status/` on connect.
+  nbox checks the instance version via `/api/status/` on connect. Full 4.2 / 4.3 /
+  4.5+ matrix: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md).
 - Targets the NetBox **REST API** (`/api/`) as the canonical integration path.
 - `nbox status --json` and MCP `nbox_status` include a per-surface `api` block
   (configured vs effective backend) and a typed `capabilities` object with
@@ -539,6 +540,7 @@ Full list with copy-paste fixes: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.
 
 - [Features](docs/FEATURES.md) — full command reference
 - [Configuration](docs/CONFIG.md) — config, profiles, token resolution, cache
+- [Compatibility](docs/COMPATIBILITY.md) — NetBox 4.2 / 4.3 / 4.5+ matrix and how nbox adapts
 - [Comparison](docs/COMPARISON.md) — nbox vs the NetBox web UI / raw API, and when to use each
 - [Scripting & automation](docs/SCRIPTING.md) — JSON/CSV/envelope schemas, exit codes, jq recipes, CI
 - [MCP server](docs/MCP.md) — agent setup, tools, HTTP/OIDC

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -14,12 +14,16 @@ flag, and the per-surface backend routing.
 
 | Concern | 4.2 | 4.3 | 4.5+ |
 |---|---|---|---|
-| Scope model | polymorphic `scope` (`scope_type` + `scope_id`); prefix `site` FK dropped | same | same |
-| Search backend | REST (full-text `q`) | **REST only** — GraphQL `q` dropped | REST only |
-| GraphQL filter shape | per-field input objects | per-field Strawberry lookups | per-field Strawberry lookups |
-| Prefix `utilization` source | REST API field | REST API field | **client-side** — API field dropped |
-| `/api/status/` auth | unauthenticated | unauthenticated | **requires auth** |
-| Token scheme | v1 `Authorization: Token` | v1 `Token` | v1 `Token` **+ v2 `Authorization: Bearer nbt_…`** |
+| Scope model | polymorphic `scope` (`scope_type` + `scope_id`); prefix `site` FK dropped ¹ | same | same |
+| Search backend | REST `q=` fan-out | REST (GraphQL has no `q`) | REST (GraphQL has no `q`) |
+| GraphQL filtering | per-field input objects | advanced per-field lookups (AND/OR, custom fields) ² | same |
+| Prefix `utilization` | returned by the REST API | returned by the REST API | not returned → computed client-side ³ |
+| `/api/status/` auth | open by default | open by default | requires auth ³ |
+| Token scheme | v1 `Authorization: Token` | v1 `Token` | v1 `Token` **+ v2 `Authorization: Bearer nbt_…`** ¹ |
+
+¹ In the official NetBox release notes — the `4.2.0` scope change (Jan 2025) and the `4.5` v2 tokens (HMAC, `nbt_` prefix, `Bearer`; v1 retained until 4.7).
+² NetBox [#7598](https://github.com/netbox-community/netbox/issues/7598), "adopt advanced query filtering in GraphQL." GraphQL never had a REST-style full-text `q`; this rework is why a per-kind GraphQL search can't stand in for REST search.
+³ **Observed** against live instances (4.2 vs 4.5.10), **not called out in the release notes** — so treat as empirical, not a documented contract. `/api/status/` auth may reflect instance `LOGIN_REQUIRED`-style config rather than a strict version change; either way nbox authenticates **every** request (including the version probe), so it is unaffected.
 
 ## How nbox adapts
 
@@ -30,15 +34,19 @@ flag, and the per-surface backend routing.
   `scope_id=<id>`; the rest get `site_id`/`region_id`/… An endpoint with no clean
   filter for the active scope skips itself rather than return an unfiltered set.
 
-- **Search is always REST (4.3).** NetBox 4.3 moved GraphQL filtering to per-field
-  lookups and dropped the full-text `q`, which has no GraphQL equivalent. `nbox
-  search` is a parallel REST `q=` fan-out across the object endpoints. Even with a
+- **Search is always REST.** NetBox 4.3 reworked GraphQL filtering into advanced
+  per-field lookups (AND/OR, custom fields — NetBox #7598). GraphQL has no
+  REST-style full-text `q`, so a per-kind GraphQL search can't reproduce canonical
+  search; `nbox search` is a parallel REST `q=` fan-out across the object
+  endpoints. Even with a
   `graphql` preference for the search surface, the backend resolves to a REST
   fallback (without probing the schema) and `status` carries the reason. GraphQL
   stays an opt-in accelerator for the VRF view only.
 
-- **Client-side container utilization (4.5).** NetBox 4.5 dropped the prefix
-  `utilization` field from the REST API. nbox computes a container prefix's
+- **Client-side container utilization.** As of NetBox 4.5 the prefix REST API no
+  longer returns `utilization` (observed live — present on 4.2, absent on 4.5's
+  list, detail, and OpenAPI schema; not called out in the release notes). nbox
+  computes a container prefix's
   utilization from the already-fetched tree — the fraction of its space its direct
   children cover, `Σ 2^(parent_len − child_len)` — so no extra calls, on every
   version. An older NetBox that still serves `utilization` keeps its richer value;

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,56 @@
+# NetBox Compatibility
+
+nbox targets **NetBox 4.2+** over the REST API. Each release in the 4.2–4.5 range
+moved an API contract nbox depends on; nbox handles the differences at runtime
+(version probe + schema probe) rather than pinning a single version. The table
+below is the matrix; the behavior is pinned by `tests/compat_tests.rs`.
+
+The floor is enforced on connect via `/api/status/`
+(`netbox_version` < 4.2 → fail fast). `nbox status --json` and MCP `nbox_status`
+report the connected version, the build's `minimum_supported`, a `compatible`
+flag, and the per-surface backend routing.
+
+## Matrix
+
+| Concern | 4.2 | 4.3 | 4.5+ |
+|---|---|---|---|
+| Scope model | polymorphic `scope` (`scope_type` + `scope_id`); prefix `site` FK dropped | same | same |
+| Search backend | REST (full-text `q`) | **REST only** — GraphQL `q` dropped | REST only |
+| GraphQL filter shape | per-field input objects | per-field Strawberry lookups | per-field Strawberry lookups |
+| Prefix `utilization` source | REST API field | REST API field | **client-side** — API field dropped |
+| `/api/status/` auth | unauthenticated | unauthenticated | **requires auth** |
+| Token scheme | v1 `Authorization: Token` | v1 `Token` | v1 `Token` **+ v2 `Authorization: Bearer nbt_…`** |
+
+## How nbox adapts
+
+- **Scope (4.2).** Prefixes/VLANs/clusters use the polymorphic `scope`, so a plain
+  `?site=` slug filter is dead on those endpoints. `--site`/`--region`/`--group`/
+  `--location` resolve to a numeric id once, then go out-of-band per endpoint: the
+  polymorphic endpoints (prefixes, clusters) get `scope_type=dcim.<kind>` +
+  `scope_id=<id>`; the rest get `site_id`/`region_id`/… An endpoint with no clean
+  filter for the active scope skips itself rather than return an unfiltered set.
+
+- **Search is always REST (4.3).** NetBox 4.3 moved GraphQL filtering to per-field
+  lookups and dropped the full-text `q`, which has no GraphQL equivalent. `nbox
+  search` is a parallel REST `q=` fan-out across the object endpoints. Even with a
+  `graphql` preference for the search surface, the backend resolves to a REST
+  fallback (without probing the schema) and `status` carries the reason. GraphQL
+  stays an opt-in accelerator for the VRF view only.
+
+- **Client-side container utilization (4.5).** NetBox 4.5 dropped the prefix
+  `utilization` field from the REST API. nbox computes a container prefix's
+  utilization from the already-fetched tree — the fraction of its space its direct
+  children cover, `Σ 2^(parent_len − child_len)` — so no extra calls, on every
+  version. An older NetBox that still serves `utilization` keeps its richer value;
+  a leaf (no children) has no client-side value (IP-level utilization would need
+  per-prefix queries).
+
+- **Token scheme (4.5).** v2 tokens are shaped `nbt_<key>.<secret>` and sent as
+  `Authorization: Bearer`; legacy v1 tokens as `Authorization: Token`. The default
+  `auth_scheme = "auto"` detects the shape; force one with `auth_scheme =
+  "bearer"`/`"token"` on the profile.
+
+- **GraphQL schema probe.** When a surface opts into GraphQL, nbox probes the live
+  schema (filter input shapes + pagination) instead of hard-coding a version, so
+  4.2/4.3/4.5+ differences are absorbed, and falls back to REST (with the reason in
+  `status`) when the schema can't back the surface.

--- a/tests/compat_tests.rs
+++ b/tests/compat_tests.rs
@@ -1,0 +1,375 @@
+//! NetBox 4.2 / 4.3 / 4.5 compatibility matrix, pinned as tests.
+//!
+//! Each version moved an API contract nbox depends on; this file locks the
+//! behavior nbox emits across that range so a regression in one version's path
+//! can't pass silently. The matrix it mirrors lives in `docs/COMPATIBILITY.md`.
+//!
+//!   - **4.2** introduced the polymorphic `scope` (`scope_type` + `scope_id`),
+//!     dropping the prefix `site` FK → scope filtering sends `scope_type=dcim.<kind>`.
+//!   - **4.3** moved GraphQL filtering to per-field lookups and dropped the
+//!     full-text `q` filter → `nbox search` is always REST.
+//!   - **4.5** dropped the prefix `utilization` field → nbox computes container
+//!     utilization client-side from the fetched tree; v2 tokens (`nbt_…`) are sent
+//!     as `Bearer`, v1 as `Token`.
+//!
+//! Patterns mirror `tests/client_tests.rs` and `tests/search_tests.rs`.
+
+use nbox::config::{ApiConfig, ApiSurface, BackendPreference, ProfileConfig};
+use nbox::netbox::capabilities::EffectiveBackend;
+use nbox::netbox::client::NetBoxClient;
+use nbox::netbox::prefix_tree::build_nodes;
+use nbox::netbox::status::{MIN_MAJOR, MIN_MINOR, Status};
+use serde_json::{Value, json};
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn client(server: &MockServer) -> NetBoxClient {
+    let profile = ProfileConfig {
+        url: server.uri(),
+        ..Default::default()
+    };
+    NetBoxClient::new(&profile, None).unwrap()
+}
+
+fn status_for(version: &str) -> Status {
+    Status {
+        netbox_version: version.into(),
+        django_version: None,
+        python_version: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Minimum-version gating (floor = 4.2).
+// ---------------------------------------------------------------------------
+
+/// The capability report's `compatible` flag tracks the 4.2 floor exactly, and
+/// `minimum_supported` reports the build's `MIN_MAJOR.MIN_MINOR` regardless of the
+/// connected version. 4.1 is below the floor; 4.2 and 4.5 meet it.
+#[tokio::test]
+async fn capabilities_compatible_flag_tracks_the_4_2_floor() {
+    let server = MockServer::start().await;
+    let nbox = client(&server);
+    let expected_min = format!("{MIN_MAJOR}.{MIN_MINOR}");
+
+    for (version, want_compatible) in [
+        ("4.1.0", false),
+        ("4.2.0", true),
+        ("4.3.0", true),
+        ("4.5.5", true),
+    ] {
+        let caps = nbox.capabilities(&status_for(version)).await;
+        assert_eq!(
+            caps.version.compatible, want_compatible,
+            "version {version} compatibility"
+        );
+        assert_eq!(caps.version.netbox, version);
+        assert_eq!(
+            caps.version.minimum_supported, expected_min,
+            "minimum is the build floor, not the connected version"
+        );
+    }
+}
+
+/// `verify_compatible` (the TUI's launch probe) rejects a sub-4.2 `/api/status/`
+/// and accepts 4.2+, surfacing the reported version on success.
+#[tokio::test]
+async fn verify_compatible_gates_on_the_status_version() {
+    // Below the floor → error naming the version and the floor.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/status/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "netbox-version": "4.1.9"
+        })))
+        .mount(&server)
+        .await;
+    let err = client(&server)
+        .verify_compatible()
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("4.1.9"), "error names the version: {err}");
+    assert!(err.contains("4.2"), "error names the floor: {err}");
+
+    // At the floor → accepted, version echoed back.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/status/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "netbox-version": "4.2.0"
+        })))
+        .mount(&server)
+        .await;
+    let status = client(&server).verify_compatible().await.unwrap();
+    assert_eq!(status.netbox_version, "4.2.0");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Client-side container utilization (NetBox 4.5 dropped the API field).
+// ---------------------------------------------------------------------------
+
+/// A prefix tree node built from a payload that OMITS `utilization` (NetBox 4.5+):
+/// a container fills its utilization from direct-child coverage, while a leaf
+/// without children stays `None`. Exercises the pure `build_nodes` /
+/// `fill_child_coverage` path — no wiremock needed.
+#[test]
+fn container_utilization_is_computed_client_side_when_api_omits_it() {
+    // /16 carved into a /17 + a /18 → 0.5 + 0.25 = 75% covered. None of the rows
+    // carry `utilization` (the 4.5 API shape).
+    let prefix =
+        |id: u64, cidr: &str, depth: u64, children: u64| -> nbox::netbox::models::ipam::Prefix {
+            serde_json::from_value(json!({
+                "id": id,
+                "url": format!("http://nb/api/ipam/prefixes/{id}/"),
+                "prefix": cidr,
+                "status": {"value": "active", "label": "Active"},
+                "children": children,
+                "_depth": depth,
+            }))
+            .unwrap()
+        };
+
+    let nodes = build_nodes(vec![
+        prefix(1, "10.0.0.0/16", 0, 2),
+        prefix(2, "10.0.0.0/17", 1, 0),
+        prefix(3, "10.0.128.0/18", 1, 0),
+    ]);
+
+    // The container's utilization was synthesized from its children.
+    assert_eq!(
+        nodes[0].utilization,
+        Some(75),
+        "container utilization computed from child coverage"
+    );
+    // Leaves (no children) stay None — IP-level utilization would need per-prefix
+    // queries the API no longer answers cheaply.
+    assert_eq!(nodes[1].utilization, None);
+    assert_eq!(nodes[2].utilization, None);
+}
+
+/// An older NetBox (≤ 4.4) that still serves `utilization` keeps its
+/// API-provided value rather than overwriting it with the client-side estimate.
+#[test]
+fn api_provided_utilization_is_preserved_on_older_netbox() {
+    let container: nbox::netbox::models::ipam::Prefix = serde_json::from_value(json!({
+        "id": 1, "url": "http://nb/api/ipam/prefixes/1/", "prefix": "10.0.0.0/16",
+        "status": {"value": "active", "label": "Active"},
+        "children": 1, "_depth": 0,
+        "utilization": 61,
+    }))
+    .unwrap();
+    let child: nbox::netbox::models::ipam::Prefix = serde_json::from_value(json!({
+        "id": 2, "url": "http://nb/api/ipam/prefixes/2/", "prefix": "10.0.0.0/24",
+        "status": {"value": "active", "label": "Active"},
+        "children": 0, "_depth": 1,
+    }))
+    .unwrap();
+
+    let nodes = build_nodes(vec![container, child]);
+    assert_eq!(
+        nodes[0].utilization,
+        Some(61),
+        "an API-provided value wins over the computed one"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Search is REST regardless of version (4.3 dropped the GraphQL `q` filter).
+// ---------------------------------------------------------------------------
+
+/// Even with a `graphql` preference for the search surface, the search backend
+/// resolves to a REST fallback — without probing the schema — carrying the
+/// product-rule reason. This holds on every NetBox version: it's not a schema
+/// gap, it's that GraphQL has no REST-equivalent full-text `q`.
+#[tokio::test]
+async fn search_surface_is_rest_even_when_graphql_is_preferred() {
+    let profile = ProfileConfig {
+        // No /graphql/ endpoint is mounted: the search fallback must not probe.
+        url: "http://netbox.invalid".into(),
+        api: Some(ApiConfig {
+            search: Some(BackendPreference::Graphql),
+            vrf: Some(BackendPreference::Rest),
+        }),
+        ..Default::default()
+    };
+    let nbox = NetBoxClient::new(&profile, None).unwrap();
+
+    let effective = nbox.effective_backend(ApiSurface::Search).await;
+    assert!(!effective.uses_graphql(), "search never uses GraphQL");
+    assert_eq!(effective.label(), "rest");
+    let reason = match &effective {
+        EffectiveBackend::RestFallback { reason } => reason.clone(),
+        other => panic!("search must be a REST fallback, got {other:?}"),
+    };
+    assert!(
+        reason.to_lowercase().contains("full-text") || reason.contains('q'),
+        "fallback reason names the missing full-text q search: {reason}"
+    );
+
+    // The routing the `status` surface exposes agrees: configured graphql,
+    // effective rest, with the reason carried.
+    let routing = nbox.api_routing().await;
+    assert_eq!(routing.search.configured, BackendPreference::Graphql);
+    assert_eq!(routing.search.effective, "rest");
+    assert_eq!(routing.search.reason.as_deref(), Some(reason.as_str()));
+}
+
+/// The capability report marks the GraphQL `search` surface unsupported with the
+/// reason string, independent of the connected version. A pure-REST profile keeps
+/// `status` cheap (no probe), so the per-surface GraphQL shape is summarized via
+/// the routing block, and the search REST capability stays true on 4.2 and 4.5.
+#[tokio::test]
+async fn search_capability_is_rest_only_across_versions() {
+    let server = MockServer::start().await;
+    let nbox = client(&server);
+
+    for version in ["4.2.0", "4.3.0", "4.5.5"] {
+        let caps = nbox.capabilities(&status_for(version)).await;
+        assert!(caps.rest.search, "REST always backs search on {version}");
+        // A REST profile doesn't probe GraphQL, so it reports no surfaces — search
+        // can only ever route to REST here.
+        assert!(!caps.graphql.probed, "REST profile skips the GraphQL probe");
+        assert!(caps.graphql.surfaces.is_none());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Scope filtering shape (4.2 polymorphic scope).
+// ---------------------------------------------------------------------------
+
+/// A `--site` search resolves the site to its id once, then filters the prefix
+/// endpoint by `scope_type=dcim.site` + `scope_id=<id>` (the 4.2 polymorphic
+/// scope), not the dead `?site=` slug filter. The prefix mock matches ONLY when
+/// both scope params are present, so a regression to the old FK would 404/miss.
+#[tokio::test]
+async fn site_scope_filters_prefixes_by_scope_type_and_id() {
+    let server = MockServer::start().await;
+
+    // Site resolution: the slug lookup returns id 9.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 9, "url": "http://nb/api/dcim/sites/9/", "name": "iad1", "slug": "iad1"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    // The prefix endpoint must carry the translated polymorphic scope params.
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/"))
+        .and(query_param("scope_type", "dcim.site"))
+        .and(query_param("scope_id", "9"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 11, "url": "http://nb/api/ipam/prefixes/11/", "prefix": "10.1.0.0/24",
+                "scope_type": "dcim.site", "scope": {"id": 9, "display": "iad1"}
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    // Remaining endpoints the search fan-out touches: empty pages so the run is
+    // unambiguous and the assertion isolates the prefix scope behavior.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("q", "10.1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_page()))
+        .mount(&server)
+        .await;
+    for endpoint in [
+        "/api/dcim/devices/",
+        "/api/ipam/vlans/",
+        "/api/virtualization/virtual-machines/",
+        "/api/virtualization/clusters/",
+        "/api/dcim/racks/",
+        "/api/ipam/vrfs/",
+        "/api/ipam/route-targets/",
+    ] {
+        Mock::given(method("GET"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_json(empty_page()))
+            .mount(&server)
+            .await;
+    }
+
+    let results = client(&server)
+        .search(nbox::netbox::search::SearchRequest {
+            query: "10.1".into(),
+            limit: 25,
+            filters: nbox::netbox::search::SearchFilters {
+                site: Some("iad1".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap()
+        .results;
+
+    let prefix = results
+        .iter()
+        .find(|r| r.kind == nbox::netbox::search::ObjectKind::Prefix)
+        .expect("site-scoped prefix surfaced via scope_type/scope_id");
+    assert_eq!(prefix.display, "10.1.0.0/24");
+    assert_eq!(prefix.subtitle.as_deref(), Some("iad1"));
+}
+
+// ---------------------------------------------------------------------------
+// Token scheme: v2 (`nbt_…`) → Bearer, v1 → Token (auto-detected). NetBox 4.5
+// added v2 tokens; older versions only issue v1.
+// ---------------------------------------------------------------------------
+
+/// Auto scheme sends a v2 token (`nbt_<key>.<secret>`) as `Authorization: Bearer`.
+#[tokio::test]
+async fn v2_token_is_sent_as_bearer() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(header("authorization", "Bearer nbt_key.secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_page()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let profile = ProfileConfig {
+        url: server.uri(),
+        ..Default::default()
+    };
+    let nbox = NetBoxClient::new(&profile, Some("nbt_key.secret".into())).unwrap();
+    let _page: nbox::netbox::pagination::Page<Value> = nbox
+        .list(nbox::netbox::endpoints::Endpoint::Sites, vec![])
+        .await
+        .unwrap();
+}
+
+/// Auto scheme sends a legacy v1 token as `Authorization: Token`.
+#[tokio::test]
+async fn v1_token_is_sent_as_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(header("authorization", "Token 0123456789abcdef"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty_page()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let profile = ProfileConfig {
+        url: server.uri(),
+        ..Default::default()
+    };
+    let nbox = NetBoxClient::new(&profile, Some("0123456789abcdef".into())).unwrap();
+    let _page: nbox::netbox::pagination::Page<Value> = nbox
+        .list(nbox::netbox::endpoints::Endpoint::Sites, vec![])
+        .await
+        .unwrap();
+}
+
+fn empty_page() -> Value {
+    json!({ "count": 0, "next": null, "previous": null, "results": [] })
+}


### PR DESCRIPTION
Pins the NetBox version-specific behaviors nbox already handles (4.2–4.5) as wiremock-backed tests, and documents them as a matrix. ROADMAP "Foundation before scale" item. No behavior change.

## Tests — `tests/compat_tests.rs`
- **Min-version gating (floor 4.2):** capability report's `compatible` tracks the floor (4.1 false; 4.2/4.3/4.5 true) and `minimum_supported` is the build floor; `verify_compatible` rejects sub-4.2 `/api/status/` and accepts 4.2+.
- **Client-side container utilization (4.5):** when the prefix payload omits `utilization`, a container fills it from direct-child coverage (`Σ 2^(parent−child)`), a leaf stays `None`; an API-provided value (older NetBox) is preserved. Pure `build_nodes`/`fill_child_coverage` path, no wiremock.
- **Search is REST regardless of version (4.3 dropped GraphQL `q`):** the search surface resolves to a REST fallback without probing the schema, carrying the product-rule reason; routing/capabilities agree across 4.2/4.3/4.5.
- **Scope filtering shape (4.2 polymorphic scope):** `--site` resolves to an id and filters prefixes by `scope_type=dcim.site` + `scope_id=<id>` (asserted via wiremock request matching).
- **Token scheme:** v2 `nbt_…` → `Bearer`, v1 → `Token` (auto-detected).

## Docs — `docs/COMPATIBILITY.md`
Matrix table (rows 4.2 / 4.3 / 4.5+; columns: scope model, search backend, prefix `utilization` source, `/api/status/` auth, token scheme, GraphQL filter shape) plus a terse "how nbox adapts" note. Linked from the README Documentation list and cross-referenced from the existing NetBox Compatibility section.

## Gate
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo clippy --all-targets --no-default-features -- -D warnings`, `cargo test --all-features` — all green (9 new tests).