### PR TITLE
feat(graphql): route-target relation graph as a GraphQL accelerator surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Route-target view can use GraphQL.** Set `[profiles.<name>.api] route_target =
+  "graphql"` to fetch a route target's importing + exporting VRFs in one `/graphql/`
+  query instead of two REST `vrfs` list calls. Identity resolution stays REST (so
+  not-found/ambiguous exit codes are unchanged) and the result is byte-identical to
+  the REST path; an instance whose schema can't support it transparently falls back
+  to REST, with the reason in `nbox status`. The surface joins the per-surface `api`
+  block and the `capabilities` report. (Also fixes the GraphQL filter probe to
+  introspect `RouteTargetFilter`, so the `id` filter is shaped correctly.)
+
 ## [0.4.0] - 2026-06-19
 
 ### Documentation

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,10 +35,11 @@ timeout_secs = 15
 page_size = 100
 exclude_config_context = true
 
-# Per-surface backend (optional; omit for all-REST). Only the VRF view can use
-# GraphQL today; search is always REST (see "Backends" below).
+# Per-surface backend (optional; omit for all-REST). The VRF and route-target
+# views can use GraphQL today; search is always REST (see "Backends" below).
 [profiles.work.api]
 vrf = "graphql"               # rest | graphql
+route_target = "graphql"      # rest | graphql
 ```
 
 `config_version` is written by `config init`. A config with a *newer* version
@@ -91,13 +92,20 @@ scheme marker.
 REST is the **canonical** backend — it covers every operation (search, detail
 lookups, journals, raw reads, available IP/prefix queries, and identity
 resolution). GraphQL is an **opt-in per-surface accelerator**, configured under
-`[profiles.<name>.api]`. Today the **VRF view** is the only GraphQL-capable
-surface:
+`[profiles.<name>.api]`. Today the **VRF view** and the **route-target view** are
+the GraphQL-capable surfaces:
 
 ```toml
 [profiles.work.api]
-vrf = "graphql"   # rest | graphql — the VRF view's prefix/address bundle
+vrf = "graphql"            # rest | graphql — the VRF view's prefix/address bundle
+route_target = "graphql"   # rest | graphql — the route target's importing/exporting VRFs
 ```
+
+Each replaces a multi-call REST fan-out with one filtered `/graphql/` query: the
+VRF view bundles its prefixes + addresses; the route-target view bundles its
+importing + exporting VRFs (two `vrfs` list calls → one query). Identity
+resolution stays REST (so not-found/ambiguous exit codes are unchanged), and the
+output is byte-identical to the REST path either way.
 
 **Search is always REST.** `nbox search` means canonical NetBox search semantics,
 and NetBox's GraphQL API has no equivalent to REST's full-text `q` quick-search —
@@ -125,8 +133,9 @@ Rules:
 `nbox status` reports the configured vs effective backend per surface:
 
 ```
-api search  rest (NetBox GraphQL exposes no REST-equivalent full-text (q) search)
-api vrf     graphql
+api search        rest (NetBox GraphQL exposes no REST-equivalent full-text (q) search)
+api vrf           graphql
+api route_target  graphql
 ```
 
 ## UI settings

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -36,10 +36,11 @@ exclude_config_context = true   # drop the large config_context on devices/VMs
 # Per-surface backend. REST is canonical; opt a read surface into GraphQL here
 # (falls back to REST if the instance's GraphQL schema can't support it). Omit
 # the table for all-REST. `nbox status` shows the configured vs effective backend.
-# Only the VRF view can use GraphQL today — search is always REST (NetBox GraphQL
-# has no equivalent to REST's full-text `q`).
+# The VRF and route-target views can use GraphQL today — search is always REST
+# (NetBox GraphQL has no equivalent to REST's full-text `q`).
 [profiles.work.api]
 vrf = "graphql"              # rest | graphql
+# route_target = "graphql"   # rest | graphql — the route target's importing/exporting VRFs
 
 [profiles.lab]
 url = "https://netbox.lab.example.com"

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,7 @@ exclude_config_context = true
 # instance's GraphQL schema doesn't support that surface). Search is always REST.
 # [profiles.default.api]
 # vrf = "graphql"           # rest | graphql
+# route_target = "graphql"  # rest | graphql
 "#;
 
 /// The config schema version this build writes and understands. Bump when the
@@ -282,6 +283,8 @@ pub enum ApiSurface {
     Search,
     /// The VRF routing-context view (its prefixes/addresses bundle).
     Vrf,
+    /// The route-target relation graph (its importing/exporting VRFs).
+    RouteTarget,
 }
 
 impl ApiSurface {
@@ -291,6 +294,7 @@ impl ApiSurface {
         match self {
             Self::Search => "search",
             Self::Vrf => "vrf",
+            Self::RouteTarget => "route_target",
         }
     }
 }
@@ -305,6 +309,8 @@ pub struct ApiConfig {
     pub search: Option<BackendPreference>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vrf: Option<BackendPreference>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route_target: Option<BackendPreference>,
 }
 
 impl ProfileConfig {
@@ -316,6 +322,7 @@ impl ProfileConfig {
             .and_then(|a| match surface {
                 ApiSurface::Search => a.search,
                 ApiSurface::Vrf => a.vrf,
+                ApiSurface::RouteTarget => a.route_target,
             })
             .unwrap_or_default()
     }
@@ -1189,6 +1196,10 @@ search = "graphql"
             work.api_preference(ApiSurface::Vrf),
             BackendPreference::Rest
         );
+        assert_eq!(
+            work.api_preference(ApiSurface::RouteTarget),
+            BackendPreference::Rest
+        );
         assert_eq!(work.page_size, Some(250));
         assert_eq!(work.verify_tls, None);
     }
@@ -1219,12 +1230,16 @@ search = "graphql"
             profile.api_preference(ApiSurface::Vrf),
             BackendPreference::Rest
         );
+        assert_eq!(
+            profile.api_preference(ApiSurface::RouteTarget),
+            BackendPreference::Rest
+        );
     }
 
     #[test]
     fn api_surface_preferences_parse() {
         let profile: ProfileConfig = toml::from_str(
-            "url = \"https://nb.example\"\n[api]\nsearch = \"graphql\"\nvrf = \"rest\"\n",
+            "url = \"https://nb.example\"\n[api]\nsearch = \"graphql\"\nvrf = \"rest\"\nroute_target = \"graphql\"\n",
         )
         .unwrap();
         assert_eq!(
@@ -1234,6 +1249,10 @@ search = "graphql"
         assert_eq!(
             profile.api_preference(ApiSurface::Vrf),
             BackendPreference::Rest
+        );
+        assert_eq!(
+            profile.api_preference(ApiSurface::RouteTarget),
+            BackendPreference::Graphql
         );
     }
 

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -850,32 +850,64 @@ fn route_target_links(rt: &RouteTarget) -> Vec<ObjectLink> {
     l
 }
 
+/// Sort a route target's VRF references into NetBox's VRF model order — by
+/// `(name, rd)` — so the importing/exporting lists are deterministic. The REST
+/// `/api/ipam/vrfs/` list already returns name order; the GraphQL bundle sorts to
+/// match. Applied to both backends so their output is byte-identical.
+fn sort_vrf_refs(refs: &mut [VrfRef]) {
+    refs.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.rd.cmp(&b.rd)));
+}
+
 /// Build a route target's relation graph: the target's header plus the VRFs that
-/// import and export it. A route target carries no VRF list of its own, so both
-/// directions are resolved by filtering `/api/ipam/vrfs/` — independent, so they
-/// run concurrently.
+/// import and export it. A route target carries the relation on the VRF side, so
+/// when the route-target surface resolves to GraphQL one filtered
+/// `route_target_list` query returns both directions; otherwise canonical REST
+/// fans out two `/api/ipam/vrfs/` list calls concurrently (independent, so they
+/// run together). The resulting [`RouteTargetDetail`] is byte-identical between
+/// the two paths. A real GraphQL/transport error propagates (fail closed) rather
+/// than degrading to empty data — only a capability mismatch (handled by
+/// `effective_backend`) routes to REST.
 async fn build_route_target_detail(
     client: &NetBoxClient,
     rt: RouteTarget,
 ) -> Result<RouteTargetDetail> {
     let id = rt.id;
     let summary = RouteTargetView::from_model(rt);
-    let (importing, exporting): (Vec<Vrf>, Vec<Vrf>) = tokio::try_join!(
-        client.list_all(
-            Endpoint::Vrfs,
-            vec![("import_target_id", id.to_string())],
-            VRF_SECTION_CAP,
-        ),
-        client.list_all(
-            Endpoint::Vrfs,
-            vec![("export_target_id", id.to_string())],
-            VRF_SECTION_CAP,
-        ),
-    )?;
+
+    let (mut importing_vrfs, mut exporting_vrfs): (Vec<VrfRef>, Vec<VrfRef>) = if client
+        .effective_backend(ApiSurface::RouteTarget)
+        .await
+        .uses_graphql()
+    {
+        client.graphql_route_target_bundle(id).await?
+    } else {
+        // REST: fetch the two VRF collections concurrently — they're independent
+        // and this halves the detail's latency on a high-RTT link.
+        let (importing, exporting): (Vec<Vrf>, Vec<Vrf>) = tokio::try_join!(
+            client.list_all(
+                Endpoint::Vrfs,
+                vec![("import_target_id", id.to_string())],
+                VRF_SECTION_CAP,
+            ),
+            client.list_all(
+                Endpoint::Vrfs,
+                vec![("export_target_id", id.to_string())],
+                VRF_SECTION_CAP,
+            ),
+        )?;
+        (
+            importing.iter().map(VrfRef::from_model).collect(),
+            exporting.iter().map(VrfRef::from_model).collect(),
+        )
+    };
+
+    sort_vrf_refs(&mut importing_vrfs);
+    sort_vrf_refs(&mut exporting_vrfs);
+
     Ok(RouteTargetDetail {
         summary,
-        importing_vrfs: importing.iter().map(VrfRef::from_model).collect(),
-        exporting_vrfs: exporting.iter().map(VrfRef::from_model).collect(),
+        importing_vrfs,
+        exporting_vrfs,
     })
 }
 
@@ -1636,5 +1668,304 @@ mod tests {
         assert_eq!(back.tabs[0].key, 'i');
         assert_eq!(back.links[0].relation, "site");
         assert_eq!(back.links[0].kind, ObjectKind::Site);
+    }
+
+    // --- Route-target relation graph: GraphQL accelerator vs REST ---
+
+    mod route_target_backends {
+        use super::super::*;
+        use crate::config::{ApiConfig, BackendPreference, ProfileConfig};
+        use serde_json::json;
+        use wiremock::matchers::{body_string_contains, method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn not_found(noun: &str, value: &str) -> anyhow::Error {
+            NboxError::NotFound(format!("no {noun} matched \"{value}\"")).into()
+        }
+
+        /// The route-target identity GET (id fast-path) the REST resolver hits
+        /// first on both backends — identity stays canonical REST.
+        async fn mount_rt_identity(server: &MockServer) {
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/route-targets/5/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "id": 5, "url": "http://nb/api/ipam/route-targets/5/",
+                    "name": "65000:100", "tenant": {"id": 1, "display": "Acme"}
+                })))
+                .mount(server)
+                .await;
+        }
+
+        fn rest_client(server: &MockServer) -> NetBoxClient {
+            NetBoxClient::new(
+                &ProfileConfig {
+                    url: server.uri(),
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap()
+        }
+
+        fn graphql_client(server: &MockServer) -> NetBoxClient {
+            NetBoxClient::new(
+                &ProfileConfig {
+                    url: server.uri(),
+                    api: Some(ApiConfig {
+                        search: None,
+                        vrf: None,
+                        route_target: Some(BackendPreference::Graphql),
+                    }),
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap()
+        }
+
+        /// Mount the GraphQL schema + filter probes that expose route_target_list
+        /// with an `id` lookup (so the bundle scopes to one target).
+        async fn mount_graphql_probe(server: &MockServer) {
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("__schema"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"__schema": {"queryType": {"fields": [
+                        {"name": "route_target_list", "args": [
+                            {"name": "filters", "type": {"kind": "INPUT_OBJECT", "name": "RouteTargetFilter"}}
+                        ]}
+                    ]}}}
+                })))
+                .mount(server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("DeviceFilter"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": {}})))
+                .mount(server)
+                .await;
+            let id_field =
+                json!({"name": "id", "type": {"kind": "INPUT_OBJECT", "name": "IDFilterLookup"}});
+            // Match the filter probe on its batch marker ("ASNFilter"), not
+            // "RouteTargetFilter" — the bundle query's `$rt: RouteTargetFilter`
+            // variable would otherwise be captured by this probe mock.
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("ASNFilter"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"routeTarget": {"inputFields": [id_field]}}
+                })))
+                .mount(server)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn graphql_bundle_assembles_route_target_detail() {
+            let server = MockServer::start().await;
+            mount_rt_identity(&server).await;
+            mount_graphql_probe(&server).await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("route_target_list(filters"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"route_target_list": [{
+                        "importing_vrfs": [
+                            {"id": "1", "name": "customer-prod", "rd": "65000:100"},
+                            {"id": "2", "name": "customer-dev", "rd": null}
+                        ],
+                        "exporting_vrfs": [
+                            {"id": "1", "name": "customer-prod", "rd": "65000:100"}
+                        ]
+                    }]}
+                })))
+                .mount(&server)
+                .await;
+
+            let detail = route_target_detail_by_ref(&graphql_client(&server), "5", &not_found)
+                .await
+                .expect("graphql detail");
+
+            assert_eq!(detail.summary.name, "65000:100");
+            assert_eq!(detail.summary.tenant.as_deref(), Some("Acme"));
+            // Sorted by (name, rd): customer-dev before customer-prod.
+            assert_eq!(
+                detail
+                    .importing_vrfs
+                    .iter()
+                    .map(|v| v.name.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["customer-dev", "customer-prod"]
+            );
+            assert_eq!(detail.exporting_vrfs.len(), 1);
+            assert_eq!(detail.exporting_vrfs[0].id, 1);
+        }
+
+        /// The REST-built and GraphQL-built `RouteTargetDetail` are byte-identical
+        /// for the same data: identical `to_plain()` and identical serialized JSON.
+        #[tokio::test]
+        async fn rest_and_graphql_detail_are_byte_identical() {
+            // REST server: identity GET + two vrfs list calls. NetBox returns the
+            // vrfs name-ordered already; supply them so the result matches GraphQL.
+            let rest = MockServer::start().await;
+            mount_rt_identity(&rest).await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/"))
+                .and(query_param("import_target_id", "5"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 2, "next": null, "previous": null,
+                    "results": [
+                        {"id": 2, "url": "u", "name": "customer-dev"},
+                        {"id": 1, "url": "u", "name": "customer-prod", "rd": "65000:100"}
+                    ]
+                })))
+                .mount(&rest)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/"))
+                .and(query_param("export_target_id", "5"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 1, "next": null, "previous": null,
+                    "results": [
+                        {"id": 1, "url": "u", "name": "customer-prod", "rd": "65000:100"}
+                    ]
+                })))
+                .mount(&rest)
+                .await;
+
+            // GraphQL server: identity GET + probes + bundle. The nested rows are
+            // deliberately given in a DIFFERENT order than REST to prove the sort
+            // makes the two paths converge.
+            let gql = MockServer::start().await;
+            mount_rt_identity(&gql).await;
+            mount_graphql_probe(&gql).await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("route_target_list(filters"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"route_target_list": [{
+                        "importing_vrfs": [
+                            {"id": "1", "name": "customer-prod", "rd": "65000:100"},
+                            {"id": "2", "name": "customer-dev", "rd": ""}
+                        ],
+                        "exporting_vrfs": [
+                            {"id": "1", "name": "customer-prod", "rd": "65000:100"}
+                        ]
+                    }]}
+                })))
+                .mount(&gql)
+                .await;
+
+            let rest_detail = route_target_detail_by_ref(&rest_client(&rest), "5", &not_found)
+                .await
+                .expect("rest detail");
+            let gql_detail = route_target_detail_by_ref(&graphql_client(&gql), "5", &not_found)
+                .await
+                .expect("graphql detail");
+
+            assert_eq!(
+                rest_detail.to_plain(),
+                gql_detail.to_plain(),
+                "plain output must be byte-identical across backends"
+            );
+            assert_eq!(
+                serde_json::to_string(&rest_detail).unwrap(),
+                serde_json::to_string(&gql_detail).unwrap(),
+                "serialized JSON must be byte-identical across backends"
+            );
+        }
+
+        /// Capability gating: `route_target = "graphql"` with a supporting probe
+        /// routes through GraphQL (the REST vrfs list calls are NEVER made).
+        #[tokio::test]
+        async fn graphql_preference_with_support_uses_graphql_path() {
+            let server = MockServer::start().await;
+            mount_rt_identity(&server).await;
+            mount_graphql_probe(&server).await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("route_target_list(filters"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"route_target_list": [{"importing_vrfs": [], "exporting_vrfs": []}]}
+                })))
+                .mount(&server)
+                .await;
+            // The REST relation calls must NOT happen on the GraphQL path.
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 0, "next": null, "previous": null, "results": []
+                })))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let client = graphql_client(&server);
+            assert!(
+                client
+                    .effective_backend(ApiSurface::RouteTarget)
+                    .await
+                    .uses_graphql()
+            );
+            let detail = route_target_detail_by_ref(&client, "5", &not_found)
+                .await
+                .expect("graphql detail");
+            assert!(detail.importing_vrfs.is_empty());
+            assert!(detail.exporting_vrfs.is_empty());
+        }
+
+        /// Capability gating: `route_target = "graphql"` but the schema lacks
+        /// route_target_list → REST fallback, with the reason surfaced. The REST
+        /// vrfs list calls are made; no GraphQL bundle query is issued.
+        #[tokio::test]
+        async fn graphql_preference_without_support_falls_back_to_rest() {
+            let server = MockServer::start().await;
+            mount_rt_identity(&server).await;
+            // Schema probe exposes no route_target_list at all.
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("__schema"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"__schema": {"queryType": {"fields": []}}}
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": {}})))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 0, "next": null, "previous": null, "results": []
+                })))
+                .mount(&server)
+                .await;
+
+            let client = graphql_client(&server);
+            let effective = client.effective_backend(ApiSurface::RouteTarget).await;
+            assert!(!effective.uses_graphql(), "missing schema → REST fallback");
+            assert!(
+                effective
+                    .reason()
+                    .is_some_and(|r| r.contains("route_target_list")),
+                "fallback reason names the missing schema piece"
+            );
+
+            // The REST path still assembles the detail (empty relations here).
+            let detail = route_target_detail_by_ref(&client, "5", &not_found)
+                .await
+                .expect("rest fallback detail");
+            assert!(detail.importing_vrfs.is_empty());
+
+            // No GraphQL bundle query was issued (only schema/filter probes).
+            let requests = server.received_requests().await.unwrap();
+            assert!(
+                !requests
+                    .iter()
+                    .any(|r| String::from_utf8_lossy(&r.body).contains("route_target_list(filters")),
+                "a fallback must not issue the GraphQL bundle query"
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -866,6 +866,7 @@ async fn run_status(ctx: &Ctx) -> Result<()> {
     let url = client.base_url().as_str().to_string();
     let search_line = surface_routing_plain(&api.search);
     let vrf_line = surface_routing_plain(&api.vrf);
+    let route_target_line = surface_routing_plain(&api.route_target);
 
     let report = serde_json::json!({
         "netbox_url": url,
@@ -881,6 +882,7 @@ async fn run_status(ctx: &Ctx) -> Result<()> {
         kv.push("netbox_url", url.clone())
             .push("api search", search_line.clone())
             .push("api vrf", vrf_line.clone())
+            .push("api route_target", route_target_line.clone())
             .push("netbox_version", status.netbox_version.clone())
             .push_opt("django", status.django_version.clone())
             .push_opt("python", status.python_version.clone())

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1688,9 +1688,10 @@ mod contracts {
 
         // Per-surface routing: each surface reports configured + effective; the
         // optional `reason` is omitted when there is no fallback (REST profile).
-        assert_keys(&value["api"], &["search", "vrf"]);
+        assert_keys(&value["api"], &["search", "vrf", "route_target"]);
         assert_keys(&value["api"]["search"], &["configured", "effective"]);
         assert_keys(&value["api"]["vrf"], &["configured", "effective"]);
+        assert_keys(&value["api"]["route_target"], &["configured", "effective"]);
 
         // Capability summary: the three blocks and their stable inner keys.
         assert_keys(&value["capabilities"], &["version", "rest", "graphql"]);

--- a/src/netbox/capabilities.rs
+++ b/src/netbox/capabilities.rs
@@ -66,6 +66,7 @@ impl EffectiveBackend {
 pub struct ApiRouting {
     pub search: SurfaceRouting,
     pub vrf: SurfaceRouting,
+    pub route_target: SurfaceRouting,
 }
 
 /// One surface's routing: what was configured, what is effective, and (on a
@@ -139,6 +140,7 @@ pub struct GraphqlBackendCapabilities {
 pub struct GraphqlSurfaces {
     pub search: SurfaceSupport,
     pub vrf: SurfaceSupport,
+    pub route_target: SurfaceSupport,
 }
 
 /// Whether a GraphQL surface is usable, recommended, and what (if anything) the
@@ -200,10 +202,33 @@ fn vrf_support(caps: &GraphqlCapabilities) -> SurfaceSupport {
     }
 }
 
+/// GraphQL route-target support requires the route-target list plus `id`
+/// filtering (the single filtered selection that carries the importing/exporting
+/// VRF relations). All-or-nothing — a partial schema falls back to REST with the
+/// missing pieces named. The nested `importing_vrfs`/`exporting_vrfs` fields are
+/// standard on NetBox's RouteTargetType across the 4.x line, so the list + id
+/// filter is the practical gate (mirroring `vrf_support`).
+fn route_target_support(caps: &GraphqlCapabilities) -> SurfaceSupport {
+    let mut missing = Vec::new();
+    if caps.list("route_target_list").is_none() {
+        missing.push("route_target_list".to_string());
+    }
+    if !list_has_filter(caps, "route_target_list", "id") {
+        missing.push("route_target_list.id".to_string());
+    }
+    let supported = missing.is_empty();
+    SurfaceSupport {
+        supported,
+        recommended: supported,
+        missing,
+    }
+}
+
 fn surface_support(caps: &GraphqlCapabilities, surface: ApiSurface) -> SurfaceSupport {
     match surface {
         ApiSurface::Search => search_support(),
         ApiSurface::Vrf => vrf_support(caps),
+        ApiSurface::RouteTarget => route_target_support(caps),
     }
 }
 
@@ -243,11 +268,12 @@ impl NetBoxClient {
         }
     }
 
-    /// Configured-vs-effective routing for both surfaces (`status.api`).
+    /// Configured-vs-effective routing for every surface (`status.api`).
     pub async fn api_routing(&self) -> ApiRouting {
         ApiRouting {
             search: self.surface_routing(ApiSurface::Search).await,
             vrf: self.surface_routing(ApiSurface::Vrf).await,
+            route_target: self.surface_routing(ApiSurface::RouteTarget).await,
         }
     }
 
@@ -275,6 +301,7 @@ impl NetBoxClient {
                     surfaces: Some(GraphqlSurfaces {
                         search: search_support(),
                         vrf: vrf_support(&caps),
+                        route_target: route_target_support(&caps),
                     }),
                 },
                 Err(err) => GraphqlBackendCapabilities {
@@ -369,6 +396,7 @@ mod tests {
                 api: Some(ApiConfig {
                     search: Some(BackendPreference::Graphql),
                     vrf: Some(BackendPreference::Graphql),
+                    route_target: Some(BackendPreference::Graphql),
                 }),
                 ..Default::default()
             },

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -109,6 +109,7 @@ impl NetBoxClient {
         match surface {
             ApiSurface::Search => self.api.search,
             ApiSurface::Vrf => self.api.vrf,
+            ApiSurface::RouteTarget => self.api.route_target,
         }
         .unwrap_or_default()
     }
@@ -119,6 +120,7 @@ impl NetBoxClient {
     /// a `search = "graphql"` preference never triggers a probe.
     pub(crate) fn any_graphql_preferred(&self) -> bool {
         self.api.vrf == Some(BackendPreference::Graphql)
+            || self.api.route_target == Some(BackendPreference::Graphql)
     }
 
     pub(crate) fn graphql_capability_cache(&self) -> &tokio::sync::OnceCell<GraphqlCapabilities> {

--- a/src/netbox/graphql.rs
+++ b/src/netbox/graphql.rs
@@ -12,6 +12,8 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
+use crate::domain::route_target_view::VrfRef;
+use crate::domain::util::non_empty;
 use crate::netbox::client::{MAX_PAGE_SIZE, NetBoxClient};
 use crate::netbox::models::common::Choice;
 use crate::netbox::models::ipam::{IpAddress, Prefix};
@@ -53,6 +55,7 @@ query {
   provider: __type(name: "ProviderFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
   virtualMachine: __type(name: "VirtualMachineFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
   cluster: __type(name: "ClusterFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
+  routeTarget: __type(name: "RouteTargetFilter") { inputFields { name type { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } }
 }
 "#;
 
@@ -231,6 +234,69 @@ impl NetBoxClient {
             .collect();
         Ok((prefixes, addresses))
     }
+
+    /// Fetch a route target's importing/exporting VRFs in a single GraphQL query
+    /// (the route-target detail "bundle"), normalized into the same [`VrfRef`]
+    /// shape the REST path produces so the downstream `RouteTargetDetail` build is
+    /// byte-identical. The caller resolves the route target's identity + header
+    /// over REST first (identity stays canonical); this fetches only the relation
+    /// graph. A real GraphQL/transport error propagates (fail closed) rather than
+    /// degrading to empty data.
+    ///
+    /// A route target carries its VRF relations on both sides
+    /// (`importing_vrfs`/`exporting_vrfs`), so one filtered `route_target_list`
+    /// selection replaces the REST path's two `vrfs` list calls.
+    pub(crate) async fn graphql_route_target_bundle(
+        &self,
+        route_target_id: u64,
+    ) -> Result<(Vec<VrfRef>, Vec<VrfRef>)> {
+        let caps = self.graphql_capabilities().await?;
+        let mut filters = Map::new();
+        gql_add_filter(
+            &caps,
+            "route_target_list",
+            &mut filters,
+            "id",
+            json!(route_target_id),
+        );
+        let filter_type = caps
+            .list("route_target_list")
+            .and_then(|f| f.filter_type())
+            .context("GraphQL schema is missing the route_target_list filter type")?;
+
+        let query = format!(
+            "query($rt: {filter_type}) {{ \
+             route_target_list(filters: $rt) {{ \
+             importing_vrfs {{ id name rd }} exporting_vrfs {{ id name rd }} }} }}"
+        );
+        let bundle: RouteTargetBundleResponse = self
+            .graphql(&query, json!({ "rt": Value::Object(filters) }))
+            .await?;
+
+        // The filter targets a single route target by id; take the one row (none
+        // ⇒ empty relation graph, matching the REST path on an isolated target).
+        let row = bundle.route_target_list.into_iter().next();
+        let (importing, exporting) = row.map_or_else(
+            || (Vec::new(), Vec::new()),
+            |r| {
+                (
+                    gql_vrf_refs(r.importing_vrfs),
+                    gql_vrf_refs(r.exporting_vrfs),
+                )
+            },
+        );
+        Ok((importing, exporting))
+    }
+}
+
+/// Reshape the GraphQL nested VRF rows into the REST path's [`VrfRef`] order:
+/// numeric ids (GraphQL gives strings), empty RDs dropped, and sorted by
+/// `(name, rd)` to match NetBox's VRF model ordering — the same order the REST
+/// `/api/ipam/vrfs/` list returns — so the two backends produce identical output.
+fn gql_vrf_refs(rows: Vec<GqlRtVrf>) -> Vec<VrfRef> {
+    let mut refs: Vec<VrfRef> = rows.into_iter().filter_map(GqlRtVrf::into_ref).collect();
+    refs.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.rd.cmp(&b.rd)));
+    refs
 }
 
 /// Pagination clause for a GraphQL list field, empty when it isn't paginated.
@@ -291,6 +357,44 @@ struct GqlVrfAddress {
     status: Option<String>,
     dns_name: Option<String>,
     description: Option<String>,
+}
+
+/// The route-target-bundle response. The single filtered `route_target_list` row
+/// carries the importing/exporting VRF relations; each VRF row deserializes into
+/// a typed struct, then maps into the domain [`VrfRef`] (string id → numeric,
+/// empty RD dropped) so REST and GraphQL converge on one downstream view-build.
+#[derive(Debug, Deserialize)]
+struct RouteTargetBundleResponse {
+    #[serde(default)]
+    route_target_list: Vec<GqlRouteTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlRouteTarget {
+    #[serde(default)]
+    importing_vrfs: Vec<GqlRtVrf>,
+    #[serde(default)]
+    exporting_vrfs: Vec<GqlRtVrf>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GqlRtVrf {
+    id: String,
+    name: String,
+    rd: Option<String>,
+}
+
+impl GqlRtVrf {
+    /// Map into the navigable [`VrfRef`]. A non-numeric id drops the row rather
+    /// than failing the bundle; an empty RD is normalized to `None`, exactly as
+    /// the REST [`VrfRef::from_model`] path does.
+    fn into_ref(self) -> Option<VrfRef> {
+        Some(VrfRef {
+            id: self.id.parse().ok()?,
+            name: self.name,
+            rd: self.rd.and_then(non_empty),
+        })
+    }
 }
 
 /// A GraphQL plain-string `status` (`"active"`) becomes the REST `Choice` shape
@@ -386,6 +490,7 @@ struct FilterResponse {
     provider: Option<InputType>,
     virtual_machine: Option<InputType>,
     cluster: Option<InputType>,
+    route_target: Option<InputType>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -565,6 +670,9 @@ impl FilterResponse {
         }
         if let Some(input) = self.cluster {
             inputs.push(("ClusterFilter", input));
+        }
+        if let Some(input) = self.route_target {
+            inputs.push(("RouteTargetFilter", input));
         }
         inputs
     }
@@ -824,6 +932,7 @@ mod tests {
                 api: Some(ApiConfig {
                     search: None,
                     vrf: Some(BackendPreference::Graphql),
+                    route_target: None,
                 }),
                 ..Default::default()
             },
@@ -861,5 +970,160 @@ mod tests {
         let body: Value = serde_json::from_slice(&bundles[0].body).unwrap();
         assert_eq!(body["variables"]["pf"]["vrf_id"], json!({"exact": 42}));
         assert_eq!(body["variables"]["if"]["vrf_id"], json!({"exact": 42}));
+    }
+
+    #[test]
+    fn gql_rt_vrf_maps_string_id_and_drops_empty_rd() {
+        // GraphQL gives a string id and may carry an empty rd; the VrfRef wants a
+        // numeric id and a None rd (matching the REST `VrfRef::from_model` path).
+        let row: GqlRtVrf =
+            serde_json::from_value(json!({"id": "7", "name": "blue", "rd": "65000:7"})).unwrap();
+        let r = row.into_ref().expect("vrf ref");
+        assert_eq!(r.id, 7);
+        assert_eq!(r.name, "blue");
+        assert_eq!(r.rd.as_deref(), Some("65000:7"));
+
+        let empty_rd: GqlRtVrf =
+            serde_json::from_value(json!({"id": "8", "name": "green", "rd": ""})).unwrap();
+        assert!(empty_rd.into_ref().expect("vrf ref").rd.is_none());
+
+        let null_rd: GqlRtVrf =
+            serde_json::from_value(json!({"id": "9", "name": "red", "rd": null})).unwrap();
+        assert!(null_rd.into_ref().expect("vrf ref").rd.is_none());
+
+        // A non-numeric id drops the row rather than panicking.
+        let bad: GqlRtVrf =
+            serde_json::from_value(json!({"id": "abc", "name": "x", "rd": null})).unwrap();
+        assert!(bad.into_ref().is_none());
+    }
+
+    #[test]
+    fn gql_vrf_refs_sorts_by_name_then_rd() {
+        let rows = vec![
+            GqlRtVrf {
+                id: "3".into(),
+                name: "zeta".into(),
+                rd: Some("65000:3".into()),
+            },
+            GqlRtVrf {
+                id: "1".into(),
+                name: "alpha".into(),
+                rd: Some("65000:2".into()),
+            },
+            GqlRtVrf {
+                id: "2".into(),
+                name: "alpha".into(),
+                rd: Some("65000:1".into()),
+            },
+        ];
+        let refs = gql_vrf_refs(rows);
+        // Sorted by (name, rd): alpha/65000:1, alpha/65000:2, then zeta.
+        assert_eq!(refs.iter().map(|r| r.id).collect::<Vec<_>>(), vec![2, 1, 3]);
+    }
+
+    #[tokio::test]
+    async fn graphql_route_target_bundle_fetches_both_directions_in_one_query() {
+        use crate::config::{ApiConfig, BackendPreference, ProfileConfig};
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        // Schema probe: route_target_list with a filters arg (no pagination — the
+        // bundle selects a single id-filtered row).
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("__schema"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {"__schema": {"queryType": {"fields": [
+                    {"name": "route_target_list", "args": [
+                        {"name": "filters", "type": {"kind": "INPUT_OBJECT", "name": "RouteTargetFilter"}}
+                    ]}
+                ]}}}
+            })))
+            .mount(&server)
+            .await;
+
+        // Filter probe: batch A (DeviceFilter…) is empty; batch B (ASNFilter…)
+        // carries RouteTargetFilter, which exposes an `id` lookup (4.5 shape) so
+        // the bundle can scope to one target. Match the probe on the batch's own
+        // marker types (NOT "RouteTargetFilter", which the bundle query's
+        // `$rt: RouteTargetFilter` variable would also match).
+        let id_field =
+            json!({"name": "id", "type": {"kind": "INPUT_OBJECT", "name": "IDFilterLookup"}});
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("DeviceFilter"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": {}})))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("ASNFilter"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {"routeTarget": {"inputFields": [id_field]}}
+            })))
+            .mount(&server)
+            .await;
+
+        // The bundle itself: one POST carrying the route_target_list selection.
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("route_target_list(filters"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "route_target_list": [{
+                        "importing_vrfs": [
+                            {"id": "2", "name": "customer-prod", "rd": "65000:100"},
+                            {"id": "5", "name": "customer-dev", "rd": ""}
+                        ],
+                        "exporting_vrfs": [
+                            {"id": "2", "name": "customer-prod", "rd": "65000:100"}
+                        ]
+                    }]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let client = NetBoxClient::new(
+            &ProfileConfig {
+                url: server.uri(),
+                api: Some(ApiConfig {
+                    search: None,
+                    vrf: None,
+                    route_target: Some(BackendPreference::Graphql),
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        let (importing, exporting) = client
+            .graphql_route_target_bundle(42)
+            .await
+            .expect("bundle");
+
+        // String ids → numeric; empty rd → None; sorted by (name, rd).
+        assert_eq!(importing.len(), 2);
+        assert_eq!(importing[0].name, "customer-dev");
+        assert_eq!(importing[0].id, 5);
+        assert!(importing[0].rd.is_none());
+        assert_eq!(importing[1].name, "customer-prod");
+        assert_eq!(importing[1].id, 2);
+        assert_eq!(importing[1].rd.as_deref(), Some("65000:100"));
+        assert_eq!(exporting.len(), 1);
+        assert_eq!(exporting[0].id, 2);
+
+        // Both directions come back in a SINGLE round-trip, scoped by the id.
+        let requests = server.received_requests().await.unwrap();
+        let bundles: Vec<_> = requests
+            .iter()
+            .filter(|r| String::from_utf8_lossy(&r.body).contains("route_target_list(filters"))
+            .collect();
+        assert_eq!(bundles.len(), 1, "RT relations must be one bundled POST");
+        let body: Value = serde_json::from_slice(&bundles[0].body).unwrap();
+        assert_eq!(body["variables"]["rt"]["id"], json!({"exact": 42}));
     }
 }

--- a/tests/compat_tests.rs
+++ b/tests/compat_tests.rs
@@ -190,6 +190,7 @@ async fn search_surface_is_rest_even_when_graphql_is_preferred() {
         api: Some(ApiConfig {
             search: Some(BackendPreference::Graphql),
             vrf: Some(BackendPreference::Rest),
+            route_target: None,
         }),
         ..Default::default()
     };

--- a/tests/golden/status.json
+++ b/tests/golden/status.json
@@ -1,5 +1,9 @@
 {
   "api": {
+    "route_target": {
+      "configured": "graphql",
+      "effective": "graphql"
+    },
     "search": {
       "configured": "graphql",
       "effective": "rest",
@@ -15,6 +19,11 @@
       "available": true,
       "probed": true,
       "surfaces": {
+        "route_target": {
+          "missing": [],
+          "recommended": true,
+          "supported": true
+        },
         "search": {
           "missing": [
             "NetBox GraphQL exposes no REST-equivalent full-text (q) search"

--- a/tests/support/fixtures.rs
+++ b/tests/support/fixtures.rs
@@ -218,7 +218,8 @@ pub fn status_report() -> Value {
                 "effective": "rest",
                 "reason": "NetBox GraphQL exposes no REST-equivalent full-text (q) search"
             },
-            "vrf": { "configured": "graphql", "effective": "graphql" }
+            "vrf": { "configured": "graphql", "effective": "graphql" },
+            "route_target": { "configured": "graphql", "effective": "graphql" }
         },
         "netbox_version": "4.5.5",
         "django_version": "5.2.1",
@@ -245,7 +246,8 @@ pub fn status_report() -> Value {
                         "recommended": false,
                         "missing": ["NetBox GraphQL exposes no REST-equivalent full-text (q) search"]
                     },
-                    "vrf": { "supported": true, "recommended": true, "missing": [] }
+                    "vrf": { "supported": true, "recommended": true, "missing": [] },
+                    "route_target": { "supported": true, "recommended": true, "missing": [] }
                 }
             }
         }


### PR DESCRIPTION
Add a route-target GraphQL accelerator surface, mirroring the shipped VRF bundle exactly.

## What

The route-target detail (`nbox route-target`, MCP `nbox_get route_target`, TUI) builds its importing/exporting VRFs. Today that is two concurrent REST `vrfs` list calls (`import_target_id` / `export_target_id`). This adds a per-surface GraphQL accelerator that replaces those two calls with **one** filtered `route_target_list` query:

```graphql
{ route_target_list(filters: {id: {exact: "<id>"}}) {
    importing_vrfs { id name rd } exporting_vrfs { id name rd } } }
```

REST stays canonical and is the **byte-identical fallback**. Identity resolution stays REST (`route_target_by_ref`), so not-found/ambiguous exit codes are unchanged.

## How

- **config**: `ApiSurface::RouteTarget` (key `"route_target"`), `ApiConfig.route_target`, `api_preference` extended. `[profiles.<name>.api] route_target = "graphql"` opts in; a missing key = REST.
- **graphql**: `graphql_route_target_bundle(id)` returns the assembled `(importing, exporting)` `VrfRef` lists. GraphQL string ids → numeric, empty `rd` dropped (matching `VrfRef::from_model`), and sorted by `(name, rd)` to match NetBox's VRF model order = the REST list order. `RouteTargetFilter` added to the filter introspection so the `id` lookup shapes correctly (`{exact}` on 4.5).
- **capabilities**: `route_target_support` probe (requires `route_target_list` + `id` filter), `effective_backend(RouteTarget)` resolution with fallback reason, and `route_target` in the `surfaces` report.
- **detail**: `build_route_target_detail` branches GraphQL vs REST; both paths run through the same `(name, rd)` sort so `RouteTargetDetail` is byte-identical (`to_plain()` + JSON).
- **status**: `route_target` joins the per-surface `api` block and `capabilities.graphql.surfaces` (plain + JSON). Golden `status.json`, the `status_report()` fixture, and the MCP pinned-shape test updated.
- **docs**: CONFIG.md "Backends (per surface)", `examples/config.toml`, and the `config init` template.

## Tests

- wiremock GraphQL route-target bundle (one POST carries both directions, scoped by id) + the `GqlRtVrf` conversion / sort unit tests.
- **byte-identical** test: REST-built and GraphQL-built `RouteTargetDetail` produce identical `to_plain()` and identical JSON for the same data (GraphQL rows fed in a different order to prove the sort converges them).
- capability gating: supporting probe → GraphQL path (no REST vrfs calls); unsupporting probe → REST fallback with the reason surfaced (no bundle query issued).

## Notes

- The GraphQL filter introspection covers a fixed set of `*Filter` types; `RouteTargetFilter` was not among them, so the bundle's `id` filter would not have been shaped (the query would have fetched *all* route targets). Adding `RouteTargetFilter` to the introspection batch fixes this — a real correctness fix, not papered over.