### PR TITLE
ci: skip CI on doc-only (Markdown) changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 name: CI
 
 on:
+  # Skip doc-only changes (Markdown anywhere) — no need to run fmt/clippy/build/test
+  # when nothing compilable changed. A commit touching any non-.md file still runs.
   push:
     branches: [master]
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/netbox-integration.yml
+++ b/.github/workflows/netbox-integration.yml
@@ -10,9 +10,15 @@ name: NetBox Integration
 # setting configured in the repo UI, not in this file.
 
 on:
+  # Skip doc-only (Markdown) changes — this boots a full NetBox stack, so there's
+  # nothing to validate when only docs changed.
   push:
     branches: [master]
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Adds `paths-ignore: ['**.md']` to the `push` and `pull_request` triggers of **ci.yml** and **netbox-integration.yml**, so doc-only commits don't run fmt/clippy/build/test or boot a NetBox stack.

- A commit touching **any non-`.md` file still runs everything** (mixed code+docs commits are unaffected).
- `master` has no branch protection, so there's no "required check never runs" problem. If required checks are added later, switch to an always-pass skip job for the ignored paths.

This PR itself changes `.yml` (not `.md`), so CI runs on it.