### PR TITLE
feat(tui): kind-aware browse list columns for site-less kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   block and the `capabilities` report. (Also fixes the GraphQL filter probe to
   introspect `RouteTargetFilter`, so the `id` filter is shaped correctly.)
 
+### Changed
+- **Browsing one kind shows kind-aware list columns.** Opening a kind from the Nav
+  rail (e.g. VRFs, Route Targets) now drops the redundant per-row KIND tag — the
+  pane title already names the kind — and labels the second column for that kind
+  (`RD` for VRFs, `TENANT` for route targets, `RIR` for ASNs, `SCOPE` for
+  prefixes/VLANs, and so on) instead of a fixed, often-empty `SITE` column, so a
+  site-less kind no longer reads as a ragged, empty column. Mixed search results
+  and Recent keep the `KIND / DISPLAY / SITE` layout.
+
 ## [0.4.0] - 2026-06-19
 
 ### Documentation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,6 +64,11 @@ Polish the read experience. No writes here.
   device→rack) without re-searching; an object-level back-stack to walk the drill path. Lands TUI-open +
   cross-nav for racks (see *full rack integration* below).
 - ☐ **Demo recording** — an asciinema/VHS cast for the README.
+- ☐ **Deepen the in-app Config modal.** Surface the profile/settings knobs that still need a hand-edited
+  `config.toml`: per-surface API backends (`[profiles.<name>.api]` `search`/`vrf`/`route_target` =
+  `rest`|`graphql`), `timeout_secs`, `page_size`, `exclude_config_context`, and `confirm_writes` — each
+  hot-applied where it can be, with the existing test-connect on profile fields. The modal is the
+  onboarding/edit path; it shouldn't bottom out at "now go edit the TOML by hand."
 - ☑ **Release `0.2.0`** — banked the large read surface accumulated since `0.1.1` (MCP HTTP/OAuth, the new
   read commands, MCP resources, the in-app config layer, three hardening rounds).
 - ☑ **Release `0.4.0`** — per-surface API backends (breaking), REST-canonical search (GraphQL search
@@ -165,10 +170,13 @@ Consolidated future scope:
   highlighted kind into the results pane — debounced until the cursor settles so a fast scroll doesn't
   flash intermediate lists; focus stays on Nav, `Enter` still commits + jumps into the list), and a
   Nav-focused footer hint (`j/k browse · Enter results`).
-- ☐ **Browse list pane look for site-less kinds.** The list (middle) pane renders a fixed column set
-  geared to site-bearing objects; kinds with no site (route targets, and to a degree VRFs/ASNs/tenants)
-  leave the SITE column empty, so the row reads sparse/ragged. Letting it truncate for now — revisit with
-  per-kind columns (e.g. tenant/RD for route targets/VRFs) or a kind-aware column layout.
+- ☑ **Kind-aware browse list columns.** A homogeneous browse (the Nav rail opening one kind) now drops
+  the redundant per-row KIND tag — the pane title already names the kind — and labels the secondary column
+  for that kind (`RD` for VRFs, `TENANT` for route targets, `RIR` for ASNs, `SCOPE` for prefixes/VLANs, …,
+  via `ObjectKind::subtitle_header`), tinting the header with the kind's domain color. Site-less kinds no
+  longer read as a ragged, empty SITE column; mixed search results + Recent keep the generic
+  `KIND/DISPLAY/SITE` layout. (A richer multi-column layout — e.g. device name/site/role/status — would
+  need `SearchResult` enriched with those fields; deferred.)
 - ☑ **VRF-pivoted navigation (a dedicated VRF view).** VRF is now a first-class `ObjectKind`:
   searchable (REST + GraphQL), browsable from the Nav rail with a live count, `nbox vrf <name|rd|id>`,
   palette `vrf`, `open`/`journal` resolvers, and MCP `nbox_get`/`nbox://vrf/<ref>`. The TUI detail is a

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -79,6 +79,29 @@ impl ObjectKind {
             ObjectKind::RouteTarget => "route-target",
         }
     }
+
+    /// Header for the secondary column of a homogeneous (single-kind) browse list:
+    /// the attribute each `search_*` builder puts in [`SearchResult::subtitle`]
+    /// (e.g. a VRF's RD, a route target's tenant, a device's site). A *mixed*
+    /// search keeps the generic `SITE` header instead, since one header can't name
+    /// every kind's subtitle at once. Keep in sync with the `search_*` subtitles.
+    pub fn subtitle_header(self) -> &'static str {
+        match self {
+            ObjectKind::Device | ObjectKind::Rack => "SITE",
+            ObjectKind::Site => "SLUG",
+            ObjectKind::IpAddress => "DNS",
+            ObjectKind::Prefix | ObjectKind::Vlan => "SCOPE",
+            ObjectKind::Circuit => "PROVIDER",
+            ObjectKind::Aggregate | ObjectKind::Asn => "RIR",
+            ObjectKind::IpRange => "VRF",
+            ObjectKind::Tenant | ObjectKind::Contact => "GROUP",
+            ObjectKind::Provider => "ASN",
+            ObjectKind::Vm => "CLUSTER",
+            ObjectKind::Cluster => "TYPE",
+            ObjectKind::Vrf => "RD",
+            ObjectKind::RouteTarget => "TENANT",
+        }
+    }
 }
 
 /// Structured filters for a search, mapped to NetBox query params (by slug/value).
@@ -1148,6 +1171,44 @@ mod tests {
         assert!(score_match("edge01", "edge01") > score_match("edge", "edge01"));
         assert!(score_match("edge", "edge01") > score_match("dge", "edge01"));
         assert!(score_match("dge", "edge01") > score_match("zzz", "edge01"));
+    }
+
+    #[test]
+    fn subtitle_header_names_each_kinds_secondary_field() {
+        // The site-less kinds the kind-aware browse columns target get a meaningful
+        // header instead of an empty "SITE" — matching what `search_*` puts in the
+        // subtitle (VRF → its RD, route target → tenant, ASN → RIR, tenant → group).
+        assert_eq!(ObjectKind::Vrf.subtitle_header(), "RD");
+        assert_eq!(ObjectKind::RouteTarget.subtitle_header(), "TENANT");
+        assert_eq!(ObjectKind::Asn.subtitle_header(), "RIR");
+        assert_eq!(ObjectKind::Tenant.subtitle_header(), "GROUP");
+        // Site-bearing kinds keep "SITE".
+        assert_eq!(ObjectKind::Device.subtitle_header(), "SITE");
+        assert_eq!(ObjectKind::Rack.subtitle_header(), "SITE");
+        // Every kind yields a short, non-empty, uppercase header.
+        for kind in [
+            ObjectKind::Device,
+            ObjectKind::Site,
+            ObjectKind::IpAddress,
+            ObjectKind::Prefix,
+            ObjectKind::Vlan,
+            ObjectKind::Circuit,
+            ObjectKind::Aggregate,
+            ObjectKind::Asn,
+            ObjectKind::IpRange,
+            ObjectKind::Tenant,
+            ObjectKind::Contact,
+            ObjectKind::Provider,
+            ObjectKind::Vm,
+            ObjectKind::Cluster,
+            ObjectKind::Rack,
+            ObjectKind::Vrf,
+            ObjectKind::RouteTarget,
+        ] {
+            let h = kind.subtitle_header();
+            assert!(!h.is_empty(), "{kind:?} has an empty subtitle header");
+            assert_eq!(h, h.to_uppercase(), "{kind:?} header should be uppercase");
+        }
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -783,6 +783,28 @@ fn render_home_list(frame: &mut Frame, area: Rect, app: &mut App) {
         if let Some(pos) = position {
             block = block.title(Line::from(pos).right_aligned().style(theme.text_dim));
         }
+        // A homogeneous browse (the Nav rail picked one kind) drops the redundant
+        // per-row KIND tag — the pane title already names the kind — and labels the
+        // secondary column for that kind (RD/tenant/scope/…), so a site-less kind
+        // no longer reads as a ragged, empty SITE column.
+        if let Some(kind) = app.browse_kind {
+            let accent = kind_accent(kind.as_str(), theme);
+            let rows: Vec<Row> = app
+                .view
+                .iter()
+                .filter_map(|&idx| app.results.get(idx))
+                .map(|r| {
+                    Row::new([
+                        Cell::from(r.display.clone()),
+                        Cell::from(r.subtitle.clone().unwrap_or_default())
+                            .style(Style::default().fg(theme.text_dim)),
+                    ])
+                })
+                .collect();
+            let table = browse_table(rows, block, kind, accent, theme);
+            frame.render_stateful_widget(table, area, &mut app.table_state);
+            return;
+        }
         let rows: Vec<Row> = app
             .view
             .iter()
@@ -1006,6 +1028,41 @@ fn results_table<'a>(rows: Vec<Row<'a>>, block: Block<'a>, theme: &Theme) -> Tab
     ];
     Table::new(rows, widths)
         .header(results_header(theme))
+        .block(block)
+        .style(Style::default().fg(theme.text))
+        .highlight_symbol("▌ ")
+        .row_highlight_style(Style::default().fg(theme.text).bg(theme.highlight_bg))
+}
+
+/// The header row for a homogeneous browse list: the kind's name (tinted with its
+/// domain [`kind_accent`] — the one spot of color now the per-row KIND tag is
+/// gone) over its [`ObjectKind::subtitle_header`] secondary column. Dim + bold
+/// like [`results_header`] so it reads as a label band.
+fn browse_header<'a>(kind: ObjectKind, accent: Color, theme: &Theme) -> Row<'a> {
+    let primary = kind.as_str().to_uppercase().replace('-', " ");
+    Row::new([
+        Cell::from(primary).style(Style::default().fg(accent).add_modifier(Modifier::BOLD)),
+        Cell::from(kind.subtitle_header()).style(
+            Style::default()
+                .fg(theme.text_dim)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+/// A stateful table for a homogeneous browse: two columns (DISPLAY + the kind's
+/// secondary field), without the redundant KIND column. Same selection marker and
+/// highlight as [`results_table`]; the secondary column reuses [`SITE_COL`]'s width.
+fn browse_table<'a>(
+    rows: Vec<Row<'a>>,
+    block: Block<'a>,
+    kind: ObjectKind,
+    accent: Color,
+    theme: &Theme,
+) -> Table<'a> {
+    let widths = [Constraint::Min(1), Constraint::Length(SITE_COL)];
+    Table::new(rows, widths)
+        .header(browse_header(kind, accent, theme))
         .block(block)
         .style(Style::default().fg(theme.text))
         .highlight_symbol("▌ ")


### PR DESCRIPTION
## What

When you open a single kind from the Nav rail (VRFs, Route Targets, ASNs, …) the Results pane is homogeneous, but it was still drawing the generic `KIND / DISPLAY / SITE` layout — so site-less kinds left the `SITE` column empty and the per-row `KIND` tag just repeated the kind the pane title already names. The row read sparse and ragged.

A homogeneous browse now:
- **drops the redundant per-row KIND column** (the pane title already says e.g. *VRFs*), and
- **labels the secondary column for that kind** via `ObjectKind::subtitle_header` — `RD` for VRFs, `TENANT` for route targets, `RIR` for ASNs, `SCOPE` for prefixes/VLANs, `SITE` for devices/racks, etc. — matching the value each `search_*` builder already puts in `SearchResult::subtitle`.
- The header's kind name is tinted with the kind's domain color (the one spot of color now the KIND tag is gone).

Mixed **search** results and **Recent** are unchanged — they keep `KIND / DISPLAY / SITE`, since one header can't name every kind's subtitle.

No data-model or network changes: the secondary value was already carried in `subtitle`; this is purely the render layer plus one pure `ObjectKind` helper.

## Notes
- A richer multi-column layout (e.g. device `name / site / role / status`) would need `SearchResult` enriched with those fields — deferred, noted on the roadmap.
- Also adds a roadmap backlog item to deepen the in-app Config modal (surface the `api`/`timeout_secs`/`page_size`/`exclude_config_context` knobs that still need a hand-edited `config.toml`), per request.

## Test
- New `subtitle_header_names_each_kinds_secondary_field` unit test (labels + exhaustive non-empty/uppercase check).
- Gate green: `fmt`, `clippy --all-targets --all-features -D warnings`, `clippy --no-default-features -D warnings`, `cargo test --all-features`.