### PR TITLE
fix(tui): browse column headers now match their values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Browsing one kind shows kind-aware list columns.** Opening a kind from the Nav
-  rail (e.g. VRFs, Route Targets) now drops the redundant per-row KIND tag — the
-  pane title already names the kind — and labels the second column for that kind
-  (`RD` for VRFs, `TENANT` for route targets, `RIR` for ASNs, `SCOPE` for
-  prefixes/VLANs, and so on) instead of a fixed, often-empty `SITE` column, so a
-  site-less kind no longer reads as a ragged, empty column. Mixed search results
-  and Recent keep the `KIND / DISPLAY / SITE` layout.
+  rail now drops the redundant per-row KIND tag — the pane title already names the
+  kind — and labels the second column with the attribute that kind actually carries:
+  `STATUS` for prefixes/IPs, `VID` for VLANs, `RD/TENANT` for VRFs, `TENANT` for
+  route targets, `SITE` for devices/racks, `SLUG` for sites. The column sizes to its
+  content. This replaces the fixed, often-empty `SITE` column, so a site-less kind no
+  longer reads as a ragged, empty row. Mixed search results and Recent keep the
+  `KIND / DISPLAY / SITE` layout.
 
 ## [0.4.0] - 2026-06-19
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,11 +172,13 @@ Consolidated future scope:
   Nav-focused footer hint (`j/k browse · Enter results`).
 - ☑ **Kind-aware browse list columns.** A homogeneous browse (the Nav rail opening one kind) now drops
   the redundant per-row KIND tag — the pane title already names the kind — and labels the secondary column
-  for that kind (`RD` for VRFs, `TENANT` for route targets, `RIR` for ASNs, `SCOPE` for prefixes/VLANs, …,
-  via `ObjectKind::subtitle_header`), tinting the header with the kind's domain color. Site-less kinds no
-  longer read as a ragged, empty SITE column; mixed search results + Recent keep the generic
-  `KIND/DISPLAY/SITE` layout. (A richer multi-column layout — e.g. device name/site/role/status — would
-  need `SearchResult` enriched with those fields; deferred.)
+  with the attribute that kind carries in `browse.rs` (`STATUS` for prefixes/IPs, `VID` for VLANs,
+  `RD/TENANT` for VRFs, `TENANT` for route targets, `SITE` for devices/racks, `SLUG` for sites — via
+  `ObjectKind::subtitle_header`), tinting the header with the kind's domain color and sizing the column to
+  its content. Header and values agree (the labels match what `browse.rs` actually puts in the subtitle).
+  Site-less kinds no longer read as a ragged, empty SITE column; mixed search results + Recent keep the
+  generic `KIND/DISPLAY/SITE` layout. (A richer multi-column layout — e.g. device name/site/role/status —
+  would need `SearchResult` enriched with those fields; deferred.)
 - ☑ **VRF-pivoted navigation (a dedicated VRF view).** VRF is now a first-class `ObjectKind`:
   searchable (REST + GraphQL), browsable from the Nav rail with a live count, `nbox vrf <name|rd|id>`,
   palette `vrf`, `open`/`journal` resolvers, and MCP `nbox_get`/`nbox://vrf/<ref>`. The TUI detail is a

--- a/src/netbox/browse.rs
+++ b/src/netbox/browse.rs
@@ -88,10 +88,10 @@ pub async fn browse(
                 .map(|ip| SearchResult {
                     kind: ObjectKind::IpAddress,
                     id: ip.id,
-                    subtitle: ip
-                        .dns_name
-                        .filter(|s| !s.is_empty())
-                        .or_else(|| ip.status.map(|c| c.value)),
+                    // Status (always set) over a sparse DNS name: a browse index
+                    // reads cleaner with a column that's never empty, and the DNS
+                    // name is in the detail view. Header: STATUS (subtitle_header).
+                    subtitle: ip.status.map(|c| c.value),
                     url: api_to_web_url(&ip.url),
                     display: ip.address,
                     score: 0,
@@ -104,7 +104,9 @@ pub async fn browse(
                 .map(|v| SearchResult {
                     kind: ObjectKind::Vlan,
                     id: v.id,
-                    subtitle: Some(format!("vlan {}", v.vid)),
+                    // The VID identifies the VLAN (the name is the display); show
+                    // the bare number under a VID header (see subtitle_header).
+                    subtitle: Some(v.vid.to_string()),
                     url: api_to_web_url(&v.url),
                     display: v.name,
                     score: 0,

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -80,17 +80,25 @@ impl ObjectKind {
         }
     }
 
-    /// Header for the secondary column of a homogeneous (single-kind) browse list:
-    /// the attribute each `search_*` builder puts in [`SearchResult::subtitle`]
-    /// (e.g. a VRF's RD, a route target's tenant, a device's site). A *mixed*
-    /// search keeps the generic `SITE` header instead, since one header can't name
-    /// every kind's subtitle at once. Keep in sync with the `search_*` subtitles.
+    /// Header for the secondary column of a homogeneous browse list — the attribute
+    /// [`crate::netbox::browse::browse`] puts in [`SearchResult::subtitle`] for that
+    /// kind (a VRF's RD, a route target's tenant, a prefix's/IP's status, a VLAN's
+    /// VID). Only the kinds the Nav rail actually browses are reachable here (the
+    /// two-column layout is gated on a `browse_kind`); the rest are best-effort and
+    /// never rendered. Keep the browsable kinds in sync with `browse.rs`. A *mixed*
+    /// search keeps the generic `SITE` header, since one header can't name every
+    /// kind's subtitle at once.
     pub fn subtitle_header(self) -> &'static str {
         match self {
             ObjectKind::Device | ObjectKind::Rack => "SITE",
             ObjectKind::Site => "SLUG",
-            ObjectKind::IpAddress => "DNS",
-            ObjectKind::Prefix | ObjectKind::Vlan => "SCOPE",
+            // Browse shows status for prefixes/IPs (always set) and the bare VID for
+            // VLANs; VRFs show the RD, falling back to the tenant when RD-less.
+            ObjectKind::Prefix | ObjectKind::IpAddress => "STATUS",
+            ObjectKind::Vlan => "VID",
+            ObjectKind::Vrf => "RD/TENANT",
+            ObjectKind::RouteTarget => "TENANT",
+            // Not Nav-browsable today — never rendered; labelled for completeness.
             ObjectKind::Circuit => "PROVIDER",
             ObjectKind::Aggregate | ObjectKind::Asn => "RIR",
             ObjectKind::IpRange => "VRF",
@@ -98,8 +106,6 @@ impl ObjectKind {
             ObjectKind::Provider => "ASN",
             ObjectKind::Vm => "CLUSTER",
             ObjectKind::Cluster => "TYPE",
-            ObjectKind::Vrf => "RD",
-            ObjectKind::RouteTarget => "TENANT",
         }
     }
 }
@@ -1175,16 +1181,19 @@ mod tests {
 
     #[test]
     fn subtitle_header_names_each_kinds_secondary_field() {
-        // The site-less kinds the kind-aware browse columns target get a meaningful
-        // header instead of an empty "SITE" — matching what `search_*` puts in the
-        // subtitle (VRF → its RD, route target → tenant, ASN → RIR, tenant → group).
-        assert_eq!(ObjectKind::Vrf.subtitle_header(), "RD");
+        // The browsable kinds' headers name exactly what `browse.rs` puts in the
+        // subtitle, so the header and the values under it agree: prefixes/IPs show
+        // status, VLANs their VID, VRFs the RD (tenant fallback), route targets the
+        // tenant. (These four are the kinds the Nav rail actually browses.)
+        assert_eq!(ObjectKind::Prefix.subtitle_header(), "STATUS");
+        assert_eq!(ObjectKind::IpAddress.subtitle_header(), "STATUS");
+        assert_eq!(ObjectKind::Vlan.subtitle_header(), "VID");
+        assert_eq!(ObjectKind::Vrf.subtitle_header(), "RD/TENANT");
         assert_eq!(ObjectKind::RouteTarget.subtitle_header(), "TENANT");
-        assert_eq!(ObjectKind::Asn.subtitle_header(), "RIR");
-        assert_eq!(ObjectKind::Tenant.subtitle_header(), "GROUP");
-        // Site-bearing kinds keep "SITE".
+        // Site-bearing kinds keep "SITE"; sites show their slug.
         assert_eq!(ObjectKind::Device.subtitle_header(), "SITE");
         assert_eq!(ObjectKind::Rack.subtitle_header(), "SITE");
+        assert_eq!(ObjectKind::Site.subtitle_header(), "SLUG");
         // Every kind yields a short, non-empty, uppercase header.
         for kind in [
             ObjectKind::Device,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -24,6 +24,10 @@ use crate::tui::theme::{Severity, Theme};
 /// give ratatui the [`Constraint`]s it needs to align the cells into columns.
 const KIND_COL: u16 = 8;
 const SITE_COL: u16 = 14;
+/// Upper bound on the homogeneous-browse secondary column. It sizes to its content
+/// (status/RD/tenant/…), floored at the header width, but never grows past this so a
+/// long value can't crowd out the display column.
+const SUBTITLE_COL_CAP: usize = 28;
 
 /// A compact scroll-position hint for a scrollable pane's title, e.g. `" 23% "`,
 /// or `None` when all the content fits (nothing scrolls, so no hint is shown).
@@ -789,6 +793,19 @@ fn render_home_list(frame: &mut Frame, area: Rect, app: &mut App) {
         // no longer reads as a ragged, empty SITE column.
         if let Some(kind) = app.browse_kind {
             let accent = kind_accent(kind.as_str(), theme);
+            // Size the secondary column to its widest value (RD ≈ short, tenant/
+            // status ≈ longer), floored at the header width and capped so a long
+            // value can't crowd out the display column.
+            let sub_w = app
+                .view
+                .iter()
+                .filter_map(|&idx| app.results.get(idx))
+                .filter_map(|r| r.subtitle.as_deref())
+                .map(UnicodeWidthStr::width)
+                .max()
+                .unwrap_or(0)
+                .max(kind.subtitle_header().len())
+                .min(SUBTITLE_COL_CAP) as u16;
             let rows: Vec<Row> = app
                 .view
                 .iter()
@@ -801,7 +818,7 @@ fn render_home_list(frame: &mut Frame, area: Rect, app: &mut App) {
                     ])
                 })
                 .collect();
-            let table = browse_table(rows, block, kind, accent, theme);
+            let table = browse_table(rows, block, kind, accent, sub_w, theme);
             frame.render_stateful_widget(table, area, &mut app.table_state);
             return;
         }
@@ -1052,15 +1069,16 @@ fn browse_header<'a>(kind: ObjectKind, accent: Color, theme: &Theme) -> Row<'a> 
 
 /// A stateful table for a homogeneous browse: two columns (DISPLAY + the kind's
 /// secondary field), without the redundant KIND column. Same selection marker and
-/// highlight as [`results_table`]; the secondary column reuses [`SITE_COL`]'s width.
+/// highlight as [`results_table`]; `sub_w` is the content-fit secondary width.
 fn browse_table<'a>(
     rows: Vec<Row<'a>>,
     block: Block<'a>,
     kind: ObjectKind,
     accent: Color,
+    sub_w: u16,
     theme: &Theme,
 ) -> Table<'a> {
-    let widths = [Constraint::Min(1), Constraint::Length(SITE_COL)];
+    let widths = [Constraint::Min(1), Constraint::Length(sub_w)];
     Table::new(rows, widths)
         .header(browse_header(kind, accent, theme))
         .block(block)


### PR DESCRIPTION
Follow-up to #25 (review feedback).

## The bug
The kind-aware browse columns labelled the secondary column from the **search.rs** subtitle semantics — but the Nav-rail browse path is a *separate* builder (`browse.rs`) that puts **different** values in `subtitle`. So:
- **Prefix** browse shows `status` → was labelled `SCOPE` ❌
- **VLAN** browse shows the VID → was labelled `SCOPE` ❌
- **IP** browse shows `dns.or(status)` → labelled `DNS` (lied on the status-fallback rows)
- **VRF** browse shows `rd.or(tenant)` → labelled `RD` (lied on the tenant-fallback rows)

Header and values must agree. The 2-col layout only ever renders the 8 Nav-browsable kinds (it's gated on `browse_kind`), so `subtitle_header` is now aligned to **`browse.rs`** (not search), and two browse subtitles are tidied so the headers read cleanly:

| Kind | column | header |
|---|---|---|
| Prefix | status | `STATUS` |
| IP | **status** (was `dns.or(status)`) | `STATUS` |
| VLAN | **bare VID** (was `"vlan {vid}"`) | `VID` |
| VRF | `rd.or(tenant)` | `RD/TENANT` |
| Route target | tenant | `TENANT` |
| Device / Rack | site | `SITE` |
| Site | slug | `SLUG` |

## Decisions
- **IP → status only** (dropped the sparse DNS fallback): a browse index reads cleaner with an always-populated, scannable column; the DNS name is in the detail view.
- **VRF → keep the RD→tenant fallback** (RD-less VRFs are common) but relabel `RD/TENANT` so it's honest.
- **Width is now content-fit** (sized to the widest value, floored at the header, capped at 28) instead of a fixed 14 — short RDs and longer tenant/status values both read cleanly. (Review point 2.)

## Test
- `subtitle_header_names_each_kinds_secondary_field` updated to assert the browse-aligned labels (STATUS/VID/RD-TENANT/…).
- Gate green: `fmt`, `clippy --all-targets --all-features -D warnings`, `clippy --no-default-features -D warnings`, `cargo test --all-features`.