### PR TITLE
ci(release): build the GitHub Release body from the CHANGELOG section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,11 +250,33 @@ jobs:
           cat SHA256SUMS
           cd -
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          # Pull the section between "## [<version>]" and the next "## [" heading,
+          # so the published notes are the curated changelog — not a bare PR list.
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" {f=1; next}
+            f && /^## \[/ {exit}
+            f {print}
+          ' CHANGELOG.md > release-notes.md
+          # Drop the leading blank line(s) after the heading.
+          sed -i -e '/./,$!d' release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::warning::no CHANGELOG entry for ${version}; using auto-generated notes only"
+            printf 'Release %s.\n' "${version}" > release-notes.md
+          fi
+          echo "----- release notes -----"
+          cat release-notes.md
+
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/*
+          # Curated CHANGELOG section as the body; GitHub appends its auto-generated
+          # "What's Changed" PR list + full-changelog link below it.
+          body_path: release-notes.md
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,13 +324,14 @@ Consolidated future scope:
 - ☑ Completions + the full man-page set shipped as a release artifact.
 - ☑ MSRV CI job (pins `rust-version` 1.88).
 - ☑ Real-NetBox integration workflow (`netbox-integration.yml`).
-- ☐ **Auto-populate the GitHub Release body from the CHANGELOG.** The `release` job
-  currently uses GitHub's `generate_release_notes` (a bare commit-compare link); the
-  curated `## [X.Y.Z]` section from `CHANGELOG.md` is added by hand after the fact.
-  Extract that section in the workflow (awk between the `## [X.Y.Z]` and the next
-  `## [` heading, keyed off the tag) and pass it as the release `body`, so the
-  published notes match the changelog automatically. A CHANGELOG-has-an-entry check
-  in CI would also fail a tag that forgot to add its section.
+- ☑ **Auto-populate the GitHub Release body from the CHANGELOG.** The `release` job now
+  extracts the curated `## [X.Y.Z]` section from `CHANGELOG.md` (awk between the tag's
+  heading and the next `## [`) into `body_path`, with `generate_release_notes: true`
+  appending GitHub's "What's Changed" PR list + full-changelog link below it — so the
+  published notes match the changelog automatically, no by-hand patching. Falls back to
+  auto-notes (with a `::warning::`) if the section is missing. ☐ Optional follow-up: a
+  hard CHANGELOG-has-an-entry check that *fails* a tag missing its section (needs its
+  own tag-triggered job, since `ci.yml` only runs on branch pushes).
 - ☑ `clippy::pedantic` enforced whole-project (incl. test crates) via a `Cargo.toml [lints]` table.
 - ☑ Golden output contracts + shared integration-test support (`tests/golden/`, `tests/support/`).
 - ☑ Binary-level error contracts for stable exit codes and stdout cleanliness.


### PR DESCRIPTION
## Problem
The `release` job (`release.yml`) created the GitHub Release with **`generate_release_notes: true` only** — GitHub's bare auto PR-list — and never read `CHANGELOG.md`. So every release shipped thin notes until someone hand-patched the body with the curated `## [X.Y.Z]` section. (v0.5.0 only looked right because I set it by hand during the ship.)

## Fix
Add an **Extract release notes from CHANGELOG** step that pulls the section between the tag's `## [<version>]` heading and the next `## [` (validated locally against the 106-line 0.4.0 section — all 5 subsections, no truncation), and feed it as `body_path`. Keep `generate_release_notes: true` so GitHub appends its "What's Changed" PR list + full-changelog link **below** the curated notes — best of both.

Falls back to auto-notes with a `::warning::` if the tag has no CHANGELOG entry.

## Notes
- Takes effect on the **next** release; v0.5.0's notes are already correct.
- Closes the "auto-populate the GitHub Release body from the CHANGELOG" roadmap item. A *hard* CHANGELOG-presence check that fails a tag (vs. warns) is noted as an optional follow-up — it needs its own tag-triggered job since `ci.yml` only runs on branch pushes.
- No Rust changed; YAML validated (`yaml.safe_load`).