### PR TITLE
feat(tui): navigable device IPs + VLANs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `a` addresses): select a row and press Enter to open that prefix or IP, with
   `b`/`Esc` walking back through the drill path. The `nbox prefix` CLI/JSON output
   is unchanged.
+- **Drill into a device's IPs and VLANs from the TUI.** The device detail's
+  IP-address (`p`) and VLAN (`v`) tabs are now navigable — Enter opens that IP or
+  VLAN, `b`/`Esc` walks back. (Interfaces, cables, and services stay plain text;
+  they aren't standalone objects.) The `nbox device` CLI/JSON output is unchanged.
 
 ## [0.5.0] - 2026-06-20
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,8 +64,8 @@ Polish the read experience. No writes here.
   object-level back-stack (`detail_nav`, `b`/`Esc` walks the drill path) and header-relation jumps (the
   `R` modal: device→site/rack, ip→parent-prefix, prefix→vlan, …) already ship. Remaining work: make the
   *contained-object lists* navigable like the VRF view does, one kind per PR. ☑ Prefix → children +
-  contained IPs (navigable `c`/`a` tabs). ☐ Device → IP addresses · ☐ VLAN → prefixes · ☐ Site/Rack →
-  devices.
+  contained IPs (navigable `c`/`a` tabs). ☑ Device → IP addresses + VLANs (`p`/`v` tabs). ☐ VLAN →
+  prefixes · ☐ Site/Rack → devices.
 - ☐ **Demo recording** — an asciinema/VHS cast for the README.
 - ☐ **Deepen the in-app Config modal.** Surface the profile/settings knobs that still need a hand-edited
   `config.toml`: per-surface API backends (`[profiles.<name>.api]` `search`/`vrf`/`route_target` =

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -20,7 +20,7 @@ use crate::domain::asn_view::AsnView;
 use crate::domain::circuit_view::CircuitView;
 use crate::domain::cluster_view::ClusterView;
 use crate::domain::contact_view::ContactView;
-use crate::domain::device_detail::DeviceDetail;
+use crate::domain::device_detail::{DeviceDetail, IpRow, VlanRow};
 use crate::domain::interface_view::InterfaceView;
 use crate::domain::ip_range_view::IpRangeView;
 use crate::domain::ip_view::{IpView, assigned_label, most_specific};
@@ -632,9 +632,34 @@ impl DetailView {
     }
 }
 
+/// Navigable rows for a device's assigned IP addresses — each opens that IP on
+/// Enter. The interface trails the address, matching the plain `ip_lines` body.
+fn device_ip_rows(ips: &[IpRow]) -> Vec<DetailRow> {
+    ips.iter()
+        .map(|ip| {
+            let text = match &ip.interface {
+                Some(name) => format!("{}  {name}", ip.address),
+                None => ip.address.clone(),
+            };
+            DetailRow::link(text, ObjectKind::IpAddress, ip.id)
+        })
+        .collect()
+}
+
+/// Navigable rows for the VLANs seen on a device's interfaces — each opens that
+/// VLAN on Enter.
+fn device_vlan_rows(vlans: &[VlanRow]) -> Vec<DetailRow> {
+    vlans
+        .iter()
+        .map(|v| DetailRow::link(v.vlan.clone(), ObjectKind::Vlan, v.id))
+        .collect()
+}
+
 /// Build a device detail (summary body + i/p/c/v tabs) from its sub-resources.
 /// Reuses the same fan-out + compose path as the CLI/MCP device lookup, then
-/// derives the TUI's title, summary body, and per-section tabs from it.
+/// derives the TUI's title, summary body, and per-section tabs from it. The IP
+/// (`p`) and VLAN (`v`) tabs get navigable rows so Enter drills into that IP/VLAN;
+/// the others (interfaces, cables, services) stay plain text (not object kinds).
 async fn load_device_detail(
     client: &NetBoxClient,
     device: Device,
@@ -644,11 +669,18 @@ async fn load_device_detail(
     let tabs = detail
         .sections()
         .into_iter()
-        .map(|(key, label, body)| DetailTab {
-            key,
-            label: label.to_string(),
-            body,
-            rows: Vec::new(),
+        .map(|(key, label, body)| {
+            let rows = match key {
+                'p' => device_ip_rows(&detail.ip_addresses),
+                'v' => device_vlan_rows(&detail.vlans),
+                _ => Vec::new(),
+            };
+            DetailTab {
+                key,
+                label: label.to_string(),
+                body,
+                rows,
+            }
         })
         .collect();
     Ok((format!("device {name}"), detail.summary_plain(), tabs))
@@ -1715,6 +1747,35 @@ mod tests {
         assert_eq!(addr_tab.rows[0].target, Some((ObjectKind::IpAddress, 11)));
         assert!(addr_tab.rows[0].text.contains("10.0.0.1/24"));
         assert!(addr_tab.rows[0].text.contains("edge01"));
+    }
+
+    #[test]
+    fn device_ip_and_vlan_rows_are_navigable() {
+        let ips = vec![
+            IpRow {
+                id: 11,
+                address: "10.0.0.1/24".to_string(),
+                interface: Some("eth0".to_string()),
+            },
+            IpRow {
+                id: 12,
+                address: "10.0.0.2/24".to_string(),
+                interface: None,
+            },
+        ];
+        let ip_rows = device_ip_rows(&ips);
+        assert_eq!(ip_rows[0].target, Some((ObjectKind::IpAddress, 11)));
+        assert!(ip_rows[0].text.contains("10.0.0.1/24"));
+        assert!(ip_rows[0].text.contains("eth0"));
+        assert_eq!(ip_rows[1].target, Some((ObjectKind::IpAddress, 12)));
+
+        let vlans = vec![VlanRow {
+            id: 20,
+            vlan: "20 (prod)".to_string(),
+        }];
+        let vlan_rows = device_vlan_rows(&vlans);
+        assert_eq!(vlan_rows[0].target, Some((ObjectKind::Vlan, 20)));
+        assert!(vlan_rows[0].text.contains("20 (prod)"));
     }
 
     #[test]

--- a/src/domain/device_detail.rs
+++ b/src/domain/device_detail.rs
@@ -25,6 +25,10 @@ pub struct IfaceRow {
 /// One address row in the device's IP Addresses section.
 #[derive(Debug, Clone, Serialize)]
 pub struct IpRow {
+    /// The IP's own id, for TUI navigation (Enter → open the IP). Not serialized,
+    /// so the `nbox device` JSON contract is unchanged.
+    #[serde(skip_serializing)]
+    pub id: u64,
     pub address: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interface: Option<String>,
@@ -124,6 +128,7 @@ impl DeviceDetail {
         let ip_rows = ips
             .into_iter()
             .map(|ip| IpRow {
+                id: ip.id,
                 interface: ip.assigned_object.as_ref().and_then(iface_name),
                 address: ip.address,
             })

--- a/tests/support/fixtures.rs
+++ b/tests/support/fixtures.rs
@@ -346,6 +346,7 @@ pub fn device_detail() -> DeviceDetailBuilder {
                 description: Some("uplink".to_string()),
             }],
             ip_addresses: vec![IpRow {
+                id: 9001,
                 address: "10.44.208.55/24".to_string(),
                 interface: Some("xe-0/0/0".to_string()),
             }],


### PR DESCRIPTION
Second of four **cross-object navigation** slices.

## Change
The device detail's **IP-address (`p`)** and **VLAN (`v`)** tabs are now navigable — Enter opens that IP/VLAN, `b`/`Esc` walks back — using the same `DetailRow` mechanism as the prefix/VRF views.

- Interfaces, cables, and services stay plain text (not standalone object kinds).
- `IpRow` gains an `id`, **`#[serde(skip_serializing)]`** so the `nbox device` JSON output (and its golden) is unchanged. `VlanRow` already carried an id.
- `load_device_detail` attaches navigable rows to the `p`/`v` tabs from the id-bearing rows.

## Contract safety
The IP id is skip-serialized, so the device JSON contract + golden are untouched. CLI/MCP device output unchanged.

## Test
- New `device_ip_and_vlan_rows_are_navigable`: asserts `(IpAddress, id)` / `(Vlan, id)` targets and row text. Updated the `tests/support/fixtures.rs` `IpRow` to set the new `id`.
- Gate green: fmt, both clippy passes, `cargo test --all-features` (748 lib tests).