### PR TITLE
feat(tui): editable per-surface backends + timeout/page_size/exclude in the profile editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Edit more profile knobs from the in-app Config modal.** The profile add/edit
+  form now sets the settings that used to need hand-editing `config.toml`:
+  `timeout_secs` and `page_size` (numeric fields; empty = default),
+  `exclude_config_context` (Ctrl+E), and the per-surface API backends
+  `[profiles.<name>.api] vrf` (Ctrl+B) / `route_target` (Ctrl+R), each cycling
+  `rest`/`graphql`. REST backends and default/empty values leave the file clean
+  (no `[api]` table, no redundant keys), and writes stay format-preserving. The
+  API token is still never written to `config.toml`.
 - **Drill into a prefix's children and contained IPs from the TUI.** The prefix
   detail's child-prefix and IP-address lists are now navigable tabs (`c` children,
   `a` addresses): select a row and press Enter to open that prefix or IP, with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,11 +68,12 @@ Polish the read experience. No writes here.
   Site → devices + racks (`d`/`r` tabs) and Rack → devices (`d` tab). Enter opens the highlighted row,
   `b`/`Esc` walks back through the drill path.
 - ☐ **Demo recording** — an asciinema/VHS cast for the README.
-- ☐ **Deepen the in-app Config modal.** Surface the profile/settings knobs that still need a hand-edited
-  `config.toml`: per-surface API backends (`[profiles.<name>.api]` `search`/`vrf`/`route_target` =
-  `rest`|`graphql`), `timeout_secs`, `page_size`, `exclude_config_context`, and `confirm_writes` — each
-  hot-applied where it can be, with the existing test-connect on profile fields. The modal is the
-  onboarding/edit path; it shouldn't bottom out at "now go edit the TOML by hand."
+- ☑ **Deepen the in-app Config modal.** The profile editor now sets the knobs that used to need a
+  hand-edited `config.toml`: per-surface API backends (`[profiles.<name>.api]` `vrf`/`route_target` =
+  `rest`|`graphql`, cycled with `Ctrl+B`/`Ctrl+R`), `timeout_secs` + `page_size` (numeric fields), and
+  `exclude_config_context` (`Ctrl+E`). REST/default values stay out of the file (the `[api]` table is
+  dropped when empty). Deliberately NOT surfaced (no-op toggles, like the long-excluded `confirm_writes`):
+  the `search` backend (always falls back to REST) and `confirm_writes` (writes deferred).
 - ☑ **Release `0.2.0`** — banked the large read surface accumulated since `0.1.1` (MCP HTTP/OAuth, the new
   read commands, MCP resources, the in-app config layer, three hardening rounds).
 - ☑ **Release `0.4.0`** — per-surface API backends (breaking), REST-canonical search (GraphQL search

--- a/src/config.rs
+++ b/src/config.rs
@@ -614,6 +614,96 @@ pub fn set_profile_verify_tls(
     Ok(())
 }
 
+/// Set (or clear) `profiles.<name>.timeout_secs` in a format-preserving document.
+/// `None` removes the key (falls back to the built-in default). Mirrors
+/// [`set_profile_verify_tls`]'s pattern; the in-app editor writes an empty field
+/// as `None` so a default-timeout profile stays clean.
+pub fn set_profile_timeout_secs(
+    doc: &mut DocumentMut,
+    name: &str,
+    timeout_secs: Option<u64>,
+) -> Result<()> {
+    let prof = profile_table_mut(doc, name)?;
+    match timeout_secs {
+        // toml stores integers as i64; clamp the (tiny) interval into range.
+        Some(s) => prof["timeout_secs"] = value(i64::try_from(s).unwrap_or(i64::MAX)),
+        None => {
+            prof.remove("timeout_secs");
+        }
+    }
+    Ok(())
+}
+
+/// Set (or clear) `profiles.<name>.page_size` in a format-preserving document.
+/// `None` removes the key (falls back to the built-in default).
+pub fn set_profile_page_size(
+    doc: &mut DocumentMut,
+    name: &str,
+    page_size: Option<usize>,
+) -> Result<()> {
+    let prof = profile_table_mut(doc, name)?;
+    match page_size {
+        Some(s) => prof["page_size"] = value(i64::try_from(s).unwrap_or(i64::MAX)),
+        None => {
+            prof.remove("page_size");
+        }
+    }
+    Ok(())
+}
+
+/// Set (or clear) `profiles.<name>.exclude_config_context` in a format-preserving
+/// document. `None` removes the key (falls back to the built-in default).
+pub fn set_profile_exclude_config_context(
+    doc: &mut DocumentMut,
+    name: &str,
+    exclude: Option<bool>,
+) -> Result<()> {
+    let prof = profile_table_mut(doc, name)?;
+    match exclude {
+        Some(v) => prof["exclude_config_context"] = value(v),
+        None => {
+            prof.remove("exclude_config_context");
+        }
+    }
+    Ok(())
+}
+
+/// Set `profiles.<name>.api.<surface>` in a format-preserving document. REST is
+/// the implicit default, so a `Rest` preference REMOVES the key (and the
+/// `[profiles.<name>.api]` table if it becomes empty) to keep REST profiles
+/// clean; only `Graphql` is written out. The `[api]` sub-table and its parent
+/// profile are created on demand. Comments and other keys/surfaces survive.
+pub fn set_profile_api_backend(
+    doc: &mut DocumentMut,
+    name: &str,
+    surface: ApiSurface,
+    pref: BackendPreference,
+) -> Result<()> {
+    let profile = profile_table_mut(doc, name)?;
+    let key = surface.key();
+    match pref {
+        BackendPreference::Graphql => {
+            let api = profile
+                .entry("api")
+                .or_insert_with(|| Item::Table(Table::new()))
+                .as_table_mut()
+                .with_context(|| format!("`profiles.{name}.api` is not a table"))?;
+            api[key] = value(pref.as_str());
+        }
+        // REST is the default: drop the key, and the whole `[api]` table once it
+        // holds nothing, so a REST-everywhere profile carries no `[api]` section.
+        BackendPreference::Rest => {
+            if let Some(api) = profile.get_mut("api").and_then(Item::as_table_mut) {
+                api.remove(key);
+                if api.is_empty() {
+                    profile.remove("api");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Remove `profiles.<name>` from a format-preserving document. Returns
 /// `Ok(false)` when there was no such profile (idempotent), `Ok(true)` when one
 /// was removed. Comments and other keys are preserved.
@@ -1912,6 +2002,138 @@ url = \"https://a\"
         assert_eq!(lab2.auth_scheme, None);
         assert_eq!(lab2.verify_tls, None);
         assert_eq!(lab2.token_env, None);
+    }
+
+    #[test]
+    fn profile_numeric_and_bool_setters_round_trip_and_clear() {
+        // A realistic file: a comment and a sibling key on the same profile, so the
+        // setters must touch only their own key.
+        let original = "\
+# keep me
+[profiles.lab]
+url = \"https://nb.lab\"  # keep inline
+token_env = \"LAB_TOKEN\"
+";
+        let mut doc = original.parse::<DocumentMut>().unwrap();
+        set_profile_timeout_secs(&mut doc, "lab", Some(30)).unwrap();
+        set_profile_page_size(&mut doc, "lab", Some(250)).unwrap();
+        set_profile_exclude_config_context(&mut doc, "lab", Some(true)).unwrap();
+
+        let out = doc.to_string();
+        assert!(out.contains("# keep me"), "top comment preserved: {out}");
+        assert!(out.contains("# keep inline"), "inline comment preserved");
+        assert!(
+            out.contains("token_env = \"LAB_TOKEN\""),
+            "sibling key kept"
+        );
+
+        let cfg: Config = toml::from_str(&out).unwrap();
+        let lab = &cfg.profiles["lab"];
+        assert_eq!(lab.timeout_secs, Some(30));
+        assert_eq!(lab.page_size, Some(250));
+        assert_eq!(lab.exclude_config_context, Some(true));
+
+        // Clearing each (None) drops the key back to the implicit default.
+        set_profile_timeout_secs(&mut doc, "lab", None).unwrap();
+        set_profile_page_size(&mut doc, "lab", None).unwrap();
+        set_profile_exclude_config_context(&mut doc, "lab", None).unwrap();
+        let out = doc.to_string();
+        assert!(!out.contains("timeout_secs"), "None clears timeout_secs");
+        assert!(!out.contains("page_size"), "None clears page_size");
+        assert!(
+            !out.contains("exclude_config_context"),
+            "None clears exclude_config_context"
+        );
+        // The sibling key and comments are still there.
+        assert!(out.contains("token_env = \"LAB_TOKEN\""));
+        let cfg2: Config = toml::from_str(&out).unwrap();
+        let lab2 = &cfg2.profiles["lab"];
+        assert_eq!(lab2.timeout_secs, None);
+        assert_eq!(lab2.page_size, None);
+        assert_eq!(lab2.exclude_config_context, None);
+    }
+
+    #[test]
+    fn set_profile_api_backend_writes_graphql_and_clears_to_rest() {
+        let mut doc = DocumentMut::new();
+        upsert_profile(&mut doc, "lab", "https://nb.lab", None).unwrap();
+        // GraphQL on two surfaces writes the `[api]` table with both keys.
+        set_profile_api_backend(&mut doc, "lab", ApiSurface::Vrf, BackendPreference::Graphql)
+            .unwrap();
+        set_profile_api_backend(
+            &mut doc,
+            "lab",
+            ApiSurface::RouteTarget,
+            BackendPreference::Graphql,
+        )
+        .unwrap();
+        let out = doc.to_string();
+        assert!(
+            out.contains("[profiles.lab.api]"),
+            "api table written: {out}"
+        );
+        assert!(out.contains("vrf = \"graphql\""));
+        assert!(out.contains("route_target = \"graphql\""));
+        let cfg: Config = toml::from_str(&out).unwrap();
+        assert_eq!(
+            cfg.profiles["lab"].api_preference(ApiSurface::Vrf),
+            BackendPreference::Graphql
+        );
+        assert_eq!(
+            cfg.profiles["lab"].api_preference(ApiSurface::RouteTarget),
+            BackendPreference::Graphql
+        );
+
+        // Clearing one surface back to REST removes just that key; the table stays
+        // for the other GraphQL surface.
+        set_profile_api_backend(&mut doc, "lab", ApiSurface::Vrf, BackendPreference::Rest).unwrap();
+        let out = doc.to_string();
+        assert!(!out.contains("vrf = "), "vrf key removed: {out}");
+        assert!(
+            out.contains("route_target = \"graphql\""),
+            "other surface kept"
+        );
+        assert!(
+            out.contains("[profiles.lab.api]"),
+            "table kept while non-empty"
+        );
+
+        // Clearing the last GraphQL surface drops the whole `[api]` table.
+        set_profile_api_backend(
+            &mut doc,
+            "lab",
+            ApiSurface::RouteTarget,
+            BackendPreference::Rest,
+        )
+        .unwrap();
+        let out = doc.to_string();
+        assert!(
+            !out.contains("[profiles.lab.api]"),
+            "empty api table removed: {out}"
+        );
+        let cfg2: Config = toml::from_str(&out).unwrap();
+        assert_eq!(
+            cfg2.profiles["lab"].api_preference(ApiSurface::Vrf),
+            BackendPreference::Rest
+        );
+        assert_eq!(
+            cfg2.profiles["lab"].api_preference(ApiSurface::RouteTarget),
+            BackendPreference::Rest
+        );
+    }
+
+    #[test]
+    fn set_profile_api_backend_rest_on_a_profile_with_no_api_table_is_a_noop() {
+        // Setting REST (the default) where there is no `[api]` table must not create
+        // one — a REST-everywhere profile stays clean.
+        let mut doc = DocumentMut::new();
+        upsert_profile(&mut doc, "lab", "https://nb.lab", None).unwrap();
+        set_profile_api_backend(&mut doc, "lab", ApiSurface::Vrf, BackendPreference::Rest).unwrap();
+        let out = doc.to_string();
+        assert!(
+            !out.contains("[profiles.lab.api]"),
+            "no api table created: {out}"
+        );
     }
 
     #[test]

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -4,6 +4,11 @@
 //! The Profiles section lists the configured profiles (active marked) with add /
 //! edit / select / delete actions, and an add/edit [`FormInput`] form whose token
 //! field is masked (never written to TOML; stored in the OS keyring on save). The
+//! form also carries the profile knobs that used to need hand-editing config.toml:
+//! `timeout_secs` / `page_size` (numeric text fields), `exclude_config_context`
+//! (Ctrl+E), and the per-surface API backends `vrf` (Ctrl+B) / `route_target`
+//! (Ctrl+R), each rest ↔ graphql. The `search` backend and `confirm_writes` are
+//! deliberately excluded — both would be no-op toggles here. The
 //! Settings section is a small form over the *real* `[ui]` settings — theme (a
 //! cycle), `refresh_secs` (numeric), and `open_browser_command` (text); the no-op
 //! `confirm_writes` knob is deliberately excluded.
@@ -16,6 +21,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+use crate::config::BackendPreference;
 use crate::netbox::auth::AuthScheme;
 use crate::tui::cheese::{FormInput, TextInput};
 use crate::tui::theme::Theme;
@@ -35,6 +41,8 @@ pub mod field {
     pub const URL: usize = 1;
     pub const TOKEN_ENV: usize = 2;
     pub const TOKEN: usize = 3;
+    pub const TIMEOUT_SECS: usize = 4;
+    pub const PAGE_SIZE: usize = 5;
 }
 
 /// What the profile-save path should do with the OS-keyring token, derived from
@@ -76,16 +84,37 @@ pub enum TestState {
     Failed(String),
 }
 
-/// The add/edit profile form: the masked-token-aware text fields plus the two
-/// non-text controls (auth-scheme cycle, verify-tls toggle), the edit target (if
-/// editing), and the latest test-connect state.
+/// Cycle a per-surface backend preference: rest → graphql → rest. Only the two
+/// values exist, so this is a flip; written as a cycle to mirror
+/// [`ProfileForm::cycle_auth_scheme`] (and to stay correct if a third backend is
+/// ever added).
+fn cycle_backend(pref: BackendPreference) -> BackendPreference {
+    match pref {
+        BackendPreference::Rest => BackendPreference::Graphql,
+        BackendPreference::Graphql => BackendPreference::Rest,
+    }
+}
+
+/// The add/edit profile form: the masked-token-aware text fields plus the
+/// non-text controls (auth-scheme cycle, verify-tls toggle, exclude-config-context
+/// toggle, two per-surface API backend cycles), the edit target (if editing), and
+/// the latest test-connect state.
 pub struct ProfileForm {
-    /// name, url, token_env, token(masked) — see [`field`].
+    /// name, url, token_env, token(masked), timeout_secs, page_size — see [`field`].
     pub inputs: FormInput,
     /// Cycled with the dedicated control key (auto → bearer → token → auto).
     pub auth_scheme: AuthScheme,
     /// Toggled with the dedicated control key.
     pub verify_tls: bool,
+    /// `exclude_config_context` — toggled with `Ctrl+E`. `true` (the default, both
+    /// here and at runtime when the key is absent) drops the rendered, expensive
+    /// config-context field from reads; `false` includes it. Always written
+    /// explicitly on save (like `verify_tls`), so the form is the source of truth.
+    pub exclude_config_context: bool,
+    /// `[profiles.<name>.api].vrf` backend — cycled with `Ctrl+B` (rest → graphql).
+    pub api_vrf: BackendPreference,
+    /// `[profiles.<name>.api].route_target` backend — cycled with `Ctrl+R`.
+    pub api_route_target: BackendPreference,
     /// `Some(original_name)` when editing an existing profile (so a rename can be
     /// detected and the old keyring entry migrated); `None` when adding.
     pub editing: Option<String>,
@@ -118,11 +147,22 @@ impl ProfileForm {
                 "token".to_string(),
                 TextInput::masked("paste a token to store in the keyring (optional)"),
             ),
+            (
+                "timeout_secs".to_string(),
+                TextInput::new("seconds (empty = 15 default)"),
+            ),
+            (
+                "page_size".to_string(),
+                TextInput::new("rows per page (empty = default)"),
+            ),
         ]);
         Self {
             inputs,
             auth_scheme: AuthScheme::Auto,
             verify_tls: true,
+            exclude_config_context: true,
+            api_vrf: BackendPreference::Rest,
+            api_route_target: BackendPreference::Rest,
             editing: None,
             test: TestState::Idle,
             message: None,
@@ -133,12 +173,18 @@ impl ProfileForm {
     /// An edit form prefilled from an existing profile's metadata. The token
     /// field starts empty — the stored secret is never read back into the UI;
     /// leaving it blank keeps the existing keyring entry untouched.
+    #[allow(clippy::too_many_arguments)]
     pub fn edit(
         name: &str,
         url: &str,
         token_env: Option<&str>,
         auth_scheme: AuthScheme,
         verify_tls: bool,
+        timeout_secs: Option<u64>,
+        page_size: Option<usize>,
+        exclude_config_context: bool,
+        api_vrf: BackendPreference,
+        api_route_target: BackendPreference,
     ) -> Self {
         let mut form = Self::add();
         form.inputs.input_mut(field::NAME).unwrap().set_value(name);
@@ -149,8 +195,23 @@ impl ProfileForm {
                 .unwrap()
                 .set_value(env);
         }
+        if let Some(secs) = timeout_secs {
+            form.inputs
+                .input_mut(field::TIMEOUT_SECS)
+                .unwrap()
+                .set_value(secs.to_string());
+        }
+        if let Some(size) = page_size {
+            form.inputs
+                .input_mut(field::PAGE_SIZE)
+                .unwrap()
+                .set_value(size.to_string());
+        }
         form.auth_scheme = auth_scheme;
         form.verify_tls = verify_tls;
+        form.exclude_config_context = exclude_config_context;
+        form.api_vrf = api_vrf;
+        form.api_route_target = api_route_target;
         form.editing = Some(name.to_string());
         form
     }
@@ -196,6 +257,28 @@ impl ProfileForm {
             .trim()
             .to_string();
         if v.is_empty() { None } else { Some(v) }
+    }
+
+    /// The trimmed `timeout_secs` field parsed to an optional interval: empty ⇒
+    /// `None` (use the built-in default); non-numeric or `0` ⇒ `None` too (rejected
+    /// by [`validate`](Self::validate) on save).
+    pub fn timeout_secs(&self) -> Option<u64> {
+        let t = self.inputs.value(field::TIMEOUT_SECS).unwrap_or("").trim();
+        if t.is_empty() {
+            return None;
+        }
+        t.parse::<u64>().ok().filter(|s| *s > 0)
+    }
+
+    /// The trimmed `page_size` field parsed to an optional count: empty ⇒ `None`
+    /// (use the built-in default); non-numeric or `0` ⇒ `None` too (rejected on
+    /// save by [`validate`](Self::validate)).
+    pub fn page_size(&self) -> Option<usize> {
+        let t = self.inputs.value(field::PAGE_SIZE).unwrap_or("").trim();
+        if t.is_empty() {
+            return None;
+        }
+        t.parse::<usize>().ok().filter(|s| *s > 0)
     }
 
     /// What the save path should do with the keyring token, from the form state:
@@ -250,6 +333,24 @@ impl ProfileForm {
         self.invalidate_test();
     }
 
+    /// Flip the `exclude_config_context` toggle (`Ctrl+E`).
+    pub fn toggle_exclude_config_context(&mut self) {
+        self.exclude_config_context = !self.exclude_config_context;
+        self.invalidate_test();
+    }
+
+    /// Advance the VRF API backend: rest → graphql → rest (`Ctrl+B`).
+    pub fn cycle_api_vrf(&mut self) {
+        self.api_vrf = cycle_backend(self.api_vrf);
+        self.invalidate_test();
+    }
+
+    /// Advance the route-target API backend: rest → graphql → rest (`Ctrl+R`).
+    pub fn cycle_api_route_target(&mut self) {
+        self.api_route_target = cycle_backend(self.api_route_target);
+        self.invalidate_test();
+    }
+
     /// Public wrapper for [`Self::invalidate_test`], for the onboarding wizard
     /// (which routes edits through `FormInput` directly and must invalidate a
     /// prior test result the same way the editor form does).
@@ -279,6 +380,16 @@ impl ProfileForm {
         }
         if !(url.starts_with("http://") || url.starts_with("https://")) {
             return Err("url must start with http:// or https://".to_string());
+        }
+        // The two numeric fields, when non-empty, must be positive whole numbers
+        // (empty = the built-in default). Mirrors the Settings `refresh_secs` style.
+        let timeout = self.inputs.value(field::TIMEOUT_SECS).unwrap_or("").trim();
+        if !timeout.is_empty() && !timeout.parse::<u64>().is_ok_and(|s| s > 0) {
+            return Err("timeout_secs must be a positive whole number of seconds".to_string());
+        }
+        let page = self.inputs.value(field::PAGE_SIZE).unwrap_or("").trim();
+        if !page.is_empty() && !page.parse::<usize>().is_ok_and(|s| s > 0) {
+            return Err("page_size must be a positive whole number".to_string());
         }
         Ok(())
     }
@@ -904,6 +1015,21 @@ impl ConfigModal {
                 form.toggle_verify_tls();
                 ModalOutcome::None
             }
+            // Ctrl+E toggles exclude_config_context; Ctrl+B/Ctrl+R cycle the VRF /
+            // route-target API backends (rest ↔ graphql). Ctrl-prefixed so the bare
+            // letters keep flowing into the focused text field.
+            KeyCode::Char('e') if ctrl => {
+                form.toggle_exclude_config_context();
+                ModalOutcome::None
+            }
+            KeyCode::Char('b') if ctrl => {
+                form.cycle_api_vrf();
+                ModalOutcome::None
+            }
+            KeyCode::Char('r') if ctrl => {
+                form.cycle_api_route_target();
+                ModalOutcome::None
+            }
             // Ctrl+T tests the connection; Enter saves; Ctrl+G saves + uses it.
             KeyCode::Char('t') if ctrl => match form.validate() {
                 Ok(()) => {
@@ -983,6 +1109,7 @@ impl ConfigModal {
 
     /// Open the edit form for `name`, prefilled from its metadata. Called by the
     /// app (which owns the [`ProfileConfig`]) in response to the edit request.
+    #[allow(clippy::too_many_arguments)]
     pub fn open_edit_form(
         &mut self,
         name: &str,
@@ -990,6 +1117,11 @@ impl ConfigModal {
         token_env: Option<&str>,
         auth_scheme: AuthScheme,
         verify_tls: bool,
+        timeout_secs: Option<u64>,
+        page_size: Option<usize>,
+        exclude_config_context: bool,
+        api_vrf: BackendPreference,
+        api_route_target: BackendPreference,
     ) {
         self.profiles.mode = ProfilesMode::Form(ProfileForm::edit(
             name,
@@ -997,6 +1129,11 @@ impl ConfigModal {
             token_env,
             auth_scheme,
             verify_tls,
+            timeout_secs,
+            page_size,
+            exclude_config_context,
+            api_vrf,
+            api_route_target,
         ));
     }
 
@@ -1039,6 +1176,30 @@ mod tests {
         for c in s.chars() {
             m.handle_key(key(KeyCode::Char(c)), &[], "");
         }
+    }
+
+    /// Open the edit form with the new profile knobs at their defaults — most edit
+    /// tests only care about name/url/token_env/auth/tls.
+    fn open_edit(
+        m: &mut ConfigModal,
+        name: &str,
+        url: &str,
+        token_env: Option<&str>,
+        auth_scheme: AuthScheme,
+        verify_tls: bool,
+    ) {
+        m.open_edit_form(
+            name,
+            url,
+            token_env,
+            auth_scheme,
+            verify_tls,
+            None,
+            None,
+            true,
+            BackendPreference::Rest,
+            BackendPreference::Rest,
+        );
     }
 
     #[test]
@@ -1186,7 +1347,7 @@ mod tests {
     fn token_action_models_set_clear_and_keep() {
         // Edit form: token blank, no clear intent ⇒ Keep.
         let mut m = ConfigModal::default();
-        m.open_edit_form("work", "https://w", None, AuthScheme::Auto, true);
+        open_edit(&mut m, "work", "https://w", None, AuthScheme::Auto, true);
         assert_eq!(m.form().unwrap().token_action(), TokenAction::Keep);
         // Ctrl+X toggles the clear intent ⇒ Clear.
         m.handle_key(ctrl('x'), &[], "");
@@ -1240,9 +1401,119 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_e_toggles_exclude_and_ctrl_b_ctrl_r_cycle_the_api_backends() {
+        let mut m = ConfigModal::default();
+        m.handle_key(key(KeyCode::Char('a')), &[], "");
+        // Defaults: exclude on, both backends REST.
+        assert!(m.form().unwrap().exclude_config_context);
+        assert_eq!(m.form().unwrap().api_vrf, BackendPreference::Rest);
+        assert_eq!(m.form().unwrap().api_route_target, BackendPreference::Rest);
+        // Ctrl+E flips exclude off (and back).
+        m.handle_key(ctrl('e'), &[], "");
+        assert!(!m.form().unwrap().exclude_config_context);
+        m.handle_key(ctrl('e'), &[], "");
+        assert!(m.form().unwrap().exclude_config_context);
+        // Ctrl+B cycles vrf rest → graphql → rest.
+        m.handle_key(ctrl('b'), &[], "");
+        assert_eq!(m.form().unwrap().api_vrf, BackendPreference::Graphql);
+        m.handle_key(ctrl('b'), &[], "");
+        assert_eq!(m.form().unwrap().api_vrf, BackendPreference::Rest);
+        // Ctrl+R cycles route_target independently.
+        m.handle_key(ctrl('r'), &[], "");
+        assert_eq!(
+            m.form().unwrap().api_route_target,
+            BackendPreference::Graphql
+        );
+        assert_eq!(
+            m.form().unwrap().api_vrf,
+            BackendPreference::Rest,
+            "vrf untouched"
+        );
+    }
+
+    #[test]
+    fn the_new_controls_invalidate_a_prior_test_result() {
+        // Each non-text control must clear a stale OK (mirrors auth/tls).
+        for k in [ctrl('e'), ctrl('b'), ctrl('r')] {
+            let mut m = ConfigModal::default();
+            m.handle_key(key(KeyCode::Char('a')), &[], "");
+            if let Some(f) = m.form_mut() {
+                f.test = TestState::Ok("4.2.0".to_string());
+            }
+            m.handle_key(k, &[], "");
+            assert_eq!(m.form().unwrap().test, TestState::Idle);
+        }
+    }
+
+    #[test]
+    fn form_validate_rejects_non_numeric_timeout_and_page_size() {
+        // A non-numeric timeout_secs blocks save with a clear message.
+        let mut m = ConfigModal::default();
+        m.handle_key(key(KeyCode::Char('a')), &[], "");
+        type_into(&mut m, "lab");
+        m.handle_key(key(KeyCode::Tab), &[], ""); // → url
+        type_into(&mut m, "https://nb.lab");
+        // Tab to timeout_secs (NAME→URL→TOKEN_ENV→TOKEN→TIMEOUT_SECS).
+        for _ in field::URL..field::TIMEOUT_SECS {
+            m.handle_key(key(KeyCode::Tab), &[], "");
+        }
+        type_into(&mut m, "soon");
+        let out = m.handle_key(key(KeyCode::Enter), &[], "");
+        assert_eq!(out, ModalOutcome::None, "non-numeric timeout blocks save");
+        assert!(
+            m.form()
+                .unwrap()
+                .message
+                .as_deref()
+                .unwrap()
+                .contains("timeout_secs")
+        );
+
+        // A non-numeric page_size is likewise rejected.
+        let mut m = ConfigModal::default();
+        m.handle_key(key(KeyCode::Char('a')), &[], "");
+        type_into(&mut m, "lab");
+        m.handle_key(key(KeyCode::Tab), &[], "");
+        type_into(&mut m, "https://nb.lab");
+        for _ in field::URL..field::PAGE_SIZE {
+            m.handle_key(key(KeyCode::Tab), &[], "");
+        }
+        type_into(&mut m, "lots");
+        let out = m.handle_key(key(KeyCode::Enter), &[], "");
+        assert_eq!(out, ModalOutcome::None, "non-numeric page_size blocks save");
+        assert!(
+            m.form()
+                .unwrap()
+                .message
+                .as_deref()
+                .unwrap()
+                .contains("page_size")
+        );
+    }
+
+    #[test]
+    fn form_numeric_fields_parse_and_empty_is_none() {
+        let mut m = ConfigModal::default();
+        m.handle_key(key(KeyCode::Char('a')), &[], "");
+        // Empty fields read back as None (use the built-in default).
+        assert_eq!(m.form().unwrap().timeout_secs(), None);
+        assert_eq!(m.form().unwrap().page_size(), None);
+        // Type valid digits into each.
+        for _ in field::NAME..field::TIMEOUT_SECS {
+            m.handle_key(key(KeyCode::Tab), &[], "");
+        }
+        type_into(&mut m, "30");
+        m.handle_key(key(KeyCode::Tab), &[], ""); // → page_size
+        type_into(&mut m, "250");
+        assert_eq!(m.form().unwrap().timeout_secs(), Some(30));
+        assert_eq!(m.form().unwrap().page_size(), Some(250));
+    }
+
+    #[test]
     fn editing_form_keeps_token_blank_and_records_original_name() {
         let mut m = ConfigModal::default();
-        m.open_edit_form(
+        open_edit(
+            &mut m,
             "work",
             "https://w",
             Some("W_TOKEN"),
@@ -1258,6 +1529,35 @@ mod tests {
         assert_eq!(f.editing.as_deref(), Some("work"));
         // The token field starts empty — the stored secret is never read back.
         assert!(f.token().is_none());
+    }
+
+    #[test]
+    fn editing_form_prefills_the_new_profile_knobs() {
+        // The new knobs (timeout/page_size/exclude/api backends) prefill from the
+        // ProfileConfig the app passes in.
+        let mut m = ConfigModal::default();
+        m.open_edit_form(
+            "work",
+            "https://w",
+            None,
+            AuthScheme::Auto,
+            true,
+            Some(30),
+            Some(250),
+            false,
+            BackendPreference::Graphql,
+            BackendPreference::Rest,
+        );
+        let f = m.form().unwrap();
+        assert_eq!(f.timeout_secs(), Some(30));
+        assert_eq!(f.page_size(), Some(250));
+        assert!(!f.exclude_config_context, "prefilled from the config value");
+        assert_eq!(f.api_vrf, BackendPreference::Graphql);
+        assert_eq!(f.api_route_target, BackendPreference::Rest);
+        // The numeric fields render their seeded values back as digits.
+        let lines = f.inputs.rendered_lines();
+        assert_eq!(lines[field::TIMEOUT_SECS].1, "30");
+        assert_eq!(lines[field::PAGE_SIZE].1, "250");
     }
 
     #[test]
@@ -1300,12 +1600,12 @@ mod tests {
         );
         // Editing 'work' and saving under its own name is allowed.
         let mut m2 = ConfigModal::default();
-        m2.open_edit_form("work", "https://w", None, AuthScheme::Auto, true);
+        open_edit(&mut m2, "work", "https://w", None, AuthScheme::Auto, true);
         let out = m2.handle_key(key(KeyCode::Enter), &names, "work");
         assert_eq!(out, ModalOutcome::Save { use_it: false });
         // …but renaming 'work' to the *other* existing name 'lab' is rejected.
         let mut m3 = ConfigModal::default();
-        m3.open_edit_form("work", "https://w", None, AuthScheme::Auto, true);
+        open_edit(&mut m3, "work", "https://w", None, AuthScheme::Auto, true);
         // Clear the name field and retype 'lab'.
         m3.handle_key(ctrl('u'), &names, "work");
         type_into(&mut m3, "lab");

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -10,7 +10,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::widgets::TableState;
 
 use crate::cache::{Cache, Freshness};
-use crate::config::ProfileConfig;
+use crate::config::{ApiConfig, BackendPreference, ProfileConfig};
 use crate::domain::detail::{DetailRow, DetailView, ObjectLink};
 use crate::netbox::auth::AuthScheme;
 use crate::netbox::client::NetBoxClient;
@@ -345,6 +345,21 @@ pub struct RecentItem {
 pub struct ProfileEntry {
     pub name: String,
     pub config: ProfileConfig,
+}
+
+/// Build the live [`ApiConfig`] for a profile from the editor's per-surface
+/// backend choices. REST is the implicit default, so a REST-everywhere profile
+/// gets `None` (no `[api]` table) — mirroring what `set_profile_api_backend`
+/// writes to disk. Only a GraphQL surface is recorded; `search` is never set here
+/// (search always falls back to REST, so the editor doesn't surface it).
+fn build_api_config(vrf: BackendPreference, route_target: BackendPreference) -> Option<ApiConfig> {
+    let some_if_graphql = |p: BackendPreference| (p == BackendPreference::Graphql).then_some(p);
+    let api = ApiConfig {
+        search: None,
+        vrf: some_if_graphql(vrf),
+        route_target: some_if_graphql(route_target),
+    };
+    (api != ApiConfig::default()).then_some(api)
 }
 
 /// Most-recent-first cap for the recents list.
@@ -2062,6 +2077,11 @@ impl App {
         let token_env = form.token_env();
         let auth_scheme = form.auth_scheme;
         let verify_tls = form.verify_tls;
+        let timeout_secs = form.timeout_secs();
+        let page_size = form.page_size();
+        let exclude_config_context = form.exclude_config_context;
+        let api_vrf = form.api_vrf;
+        let api_route_target = form.api_route_target;
         let token_action = form.token_action();
         let original = form.editing.clone();
 
@@ -2086,6 +2106,11 @@ impl App {
             token_env.as_deref(),
             auth_scheme,
             verify_tls,
+            timeout_secs,
+            page_size,
+            exclude_config_context,
+            api_vrf,
+            api_route_target,
         ) {
             self.set_status(format!("save failed: {e:#}"), Severity::Error);
             return Vec::new();
@@ -2104,22 +2129,21 @@ impl App {
         );
 
         // Build the live profile entry from the form + reflect it into `profiles`.
-        let mut config = ProfileConfig {
+        // The form now owns timeout/page_size/exclude/api too, so these come
+        // straight off it (mirroring what persist_profile wrote to disk): an empty
+        // numeric field is `None` (default), and a REST backend leaves `api` clean.
+        let api = build_api_config(api_vrf, api_route_target);
+        let config = ProfileConfig {
             url: url.clone(),
             token_env: token_env.clone(),
             auth_scheme: Some(auth_scheme),
             verify_tls: Some(verify_tls),
+            timeout_secs,
+            page_size,
+            exclude_config_context: Some(exclude_config_context),
+            api,
             ..Default::default()
         };
-        // Carry over any non-editor fields (timeout/page_size/…) when editing.
-        if let Some(orig) = &original
-            && let Some(existing) = self.profiles.iter().find(|p| &p.name == orig)
-        {
-            config.timeout_secs = existing.config.timeout_secs;
-            config.page_size = existing.config.page_size;
-            config.exclude_config_context = existing.config.exclude_config_context;
-            config.api.clone_from(&existing.config.api);
-        }
         self.upsert_live_profile(original.as_deref(), &name, config);
 
         // Return to the list, selecting the saved profile.
@@ -2170,6 +2194,7 @@ impl App {
     /// removed (H1) so a phantom profile can't return on the next launch; if the
     /// renamed profile was the active one, `active_profile` is repointed to the new
     /// name so the file stays self-consistent.
+    #[allow(clippy::too_many_arguments)]
     fn persist_profile(
         path: &std::path::Path,
         original: Option<&str>,
@@ -2178,7 +2203,13 @@ impl App {
         token_env: Option<&str>,
         auth_scheme: AuthScheme,
         verify_tls: bool,
+        timeout_secs: Option<u64>,
+        page_size: Option<usize>,
+        exclude_config_context: bool,
+        api_vrf: BackendPreference,
+        api_route_target: BackendPreference,
     ) -> anyhow::Result<()> {
+        use crate::config::ApiSurface;
         let mut doc = crate::config::load_doc_or_new(path)?;
         // Rename: drop the old section and repoint active_profile if it named it.
         if let Some(orig) = original
@@ -2197,6 +2228,24 @@ impl App {
         crate::config::set_profile_token_env(&mut doc, name, token_env)?;
         crate::config::set_profile_auth_scheme(&mut doc, name, Some(auth_scheme))?;
         crate::config::set_profile_verify_tls(&mut doc, name, Some(verify_tls))?;
+        // Empty numeric fields clear the key (built-in default); a positive value
+        // writes it. `exclude_config_context` is written explicitly (like
+        // verify_tls), so the form value is authoritative. REST backends drop the
+        // `[api]` key (and an empty `[api]` table) to keep REST profiles clean.
+        crate::config::set_profile_timeout_secs(&mut doc, name, timeout_secs)?;
+        crate::config::set_profile_page_size(&mut doc, name, page_size)?;
+        crate::config::set_profile_exclude_config_context(
+            &mut doc,
+            name,
+            Some(exclude_config_context),
+        )?;
+        crate::config::set_profile_api_backend(&mut doc, name, ApiSurface::Vrf, api_vrf)?;
+        crate::config::set_profile_api_backend(
+            &mut doc,
+            name,
+            ApiSurface::RouteTarget,
+            api_route_target,
+        )?;
         // First profile in a fresh file becomes active.
         if doc.get("active_profile").is_none() {
             crate::config::set_active_profile(&mut doc, name);
@@ -2318,8 +2367,27 @@ impl App {
         let token_env = entry.config.token_env.clone();
         let auth_scheme = entry.config.auth_scheme.unwrap_or(AuthScheme::Auto);
         let verify_tls = entry.config.verify_tls.unwrap_or(true);
+        let timeout_secs = entry.config.timeout_secs;
+        let page_size = entry.config.page_size;
+        // Absent key ⇒ exclude (matches NetBox client's `unwrap_or(true)` default).
+        let exclude_config_context = entry.config.exclude_config_context.unwrap_or(true);
+        let api_vrf = entry.config.api_preference(crate::config::ApiSurface::Vrf);
+        let api_route_target = entry
+            .config
+            .api_preference(crate::config::ApiSurface::RouteTarget);
         if let Some(Modal::Config(modal)) = &mut self.modal {
-            modal.open_edit_form(name, &url, token_env.as_deref(), auth_scheme, verify_tls);
+            modal.open_edit_form(
+                name,
+                &url,
+                token_env.as_deref(),
+                auth_scheme,
+                verify_tls,
+                timeout_secs,
+                page_size,
+                exclude_config_context,
+                api_vrf,
+                api_route_target,
+            );
         }
     }
 
@@ -7342,6 +7410,110 @@ mod tests {
         let live = a.profiles.iter().find(|p| p.name == "beta").unwrap();
         assert_eq!(live.config.auth_scheme, Some(AuthScheme::Bearer));
         assert_eq!(live.config.verify_tls, Some(false));
+    }
+
+    #[test]
+    fn save_writes_the_new_profile_knobs_and_defaults_stay_clean() {
+        use crate::config::{ApiSurface, BackendPreference};
+        let (mut a, _dir, path) = app_with_config(&["alpha"]);
+        a.handle_event(press(KeyCode::Char('S'))); // open modal
+        a.handle_event(press(KeyCode::Char('a'))); // add form
+        type_form(&mut a, "lab"); // name
+        a.handle_event(press(KeyCode::Tab));
+        type_form(&mut a, "https://nb.lab"); // url
+        // Tab to timeout_secs (url→token_env→token→timeout_secs) and type a value.
+        for _ in 0..3 {
+            a.handle_event(press(KeyCode::Tab));
+        }
+        type_form(&mut a, "30"); // timeout_secs
+        a.handle_event(press(KeyCode::Tab));
+        type_form(&mut a, "250"); // page_size
+        // exclude defaults on → flip it OFF with Ctrl+E; route vrf through graphql.
+        a.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('e'),
+            KeyModifiers::CONTROL,
+        )));
+        a.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('b'),
+            KeyModifiers::CONTROL,
+        )));
+        a.handle_event(press(KeyCode::Enter)); // save
+
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            text.contains("[profiles.lab.api]"),
+            "api table written: {text}"
+        );
+        assert!(text.contains("vrf = \"graphql\""), "{text}");
+        // route_target stayed REST → no key for it.
+        assert!(
+            !text.contains("route_target"),
+            "REST surface stays clean: {text}"
+        );
+
+        let cfg = crate::config::load(&path).unwrap();
+        let lab = &cfg.profiles["lab"];
+        assert_eq!(lab.timeout_secs, Some(30));
+        assert_eq!(lab.page_size, Some(250));
+        assert_eq!(lab.exclude_config_context, Some(false));
+        assert_eq!(
+            lab.api_preference(ApiSurface::Vrf),
+            BackendPreference::Graphql
+        );
+        assert_eq!(
+            lab.api_preference(ApiSurface::RouteTarget),
+            BackendPreference::Rest
+        );
+
+        // Now edit it back to defaults: clear the numeric fields, flip exclude on,
+        // cycle vrf back to REST — the keys should drop and the [api] table vanish.
+        a.handle_event(press(KeyCode::Char('e'))); // edit the (selected) saved profile
+        // Tab to timeout_secs and clear it (Ctrl+U), same for page_size.
+        for _ in 0..4 {
+            a.handle_event(press(KeyCode::Tab));
+        }
+        a.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        ))); // clear timeout_secs
+        a.handle_event(press(KeyCode::Tab));
+        a.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        ))); // clear page_size
+        a.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('e'),
+            KeyModifiers::CONTROL,
+        ))); // exclude back on (default)
+        a.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('b'),
+            KeyModifiers::CONTROL,
+        ))); // vrf back to REST
+        a.handle_event(press(KeyCode::Enter)); // save
+
+        let text2 = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !text2.contains("timeout_secs"),
+            "cleared timeout drops the key: {text2}"
+        );
+        assert!(
+            !text2.contains("page_size"),
+            "cleared page_size drops the key: {text2}"
+        );
+        assert!(
+            !text2.contains("[profiles.lab.api]"),
+            "REST-everywhere drops the api table: {text2}"
+        );
+        // exclude is written explicitly (like verify_tls), so it's present as true.
+        let cfg2 = crate::config::load(&path).unwrap();
+        let lab2 = &cfg2.profiles["lab"];
+        assert_eq!(lab2.timeout_secs, None);
+        assert_eq!(lab2.page_size, None);
+        assert_eq!(lab2.exclude_config_context, Some(true));
+        assert_eq!(
+            lab2.api_preference(ApiSurface::Vrf),
+            BackendPreference::Rest
+        );
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1438,8 +1438,8 @@ fn render_config(
     // Size to content, capped to the screen — the ttl/xfr modal idiom
     // (`base_height.min(area.height - 4)`), so the modal floats as a centered box
     // instead of filling the screen like a page. `CONTENT_H` covers the tallest
-    // section (the profile add/edit form); on a standard 80x24 it's unchanged.
-    const CONTENT_H: u16 = 20;
+    // section (the profile add/edit form: 6 text rows + 5 control rows + test/help).
+    const CONTENT_H: u16 = 22;
     let popup = centered_popup(area, 60, CONTENT_H.min(area.height.saturating_sub(4)));
     frame.render_widget(Clear, popup);
 
@@ -1647,12 +1647,16 @@ fn render_config_profiles(
             frame.render_widget(Paragraph::new(lines), area);
         }
         ProfilesMode::Form(form) => {
-            // Layout: the 4 form rows up top, then the auth/tls controls, the test
-            // state, the help line, and an optional message.
+            // Layout: the 6 form rows up top (name/url/token_env/token + the two
+            // numeric fields), then the non-text controls (auth/tls/exclude + the
+            // two API backends), the test state, the help line, and a message.
             let rows = Layout::vertical([
-                Constraint::Length(4), // the FormInput rows
+                Constraint::Length(6), // the FormInput rows
                 Constraint::Length(1), // auth_scheme
                 Constraint::Length(1), // verify_tls
+                Constraint::Length(1), // exclude_config_context
+                Constraint::Length(1), // api vrf
+                Constraint::Length(1), // api route_target
                 Constraint::Length(1), // blank
                 Constraint::Length(1), // test state
                 Constraint::Length(1), // message
@@ -1671,7 +1675,7 @@ fn render_config_profiles(
             };
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("auth_scheme  ", Style::default().fg(theme.header)),
+                    Span::styled("auth_scheme   ", Style::default().fg(theme.header)),
                     Span::styled(scheme, Style::default().fg(theme.accent)),
                     Span::styled("  (Ctrl+S cycles)", Style::default().fg(theme.text_dim)),
                 ])),
@@ -1679,7 +1683,7 @@ fn render_config_profiles(
             );
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
-                    Span::styled("verify_tls   ", Style::default().fg(theme.header)),
+                    Span::styled("verify_tls    ", Style::default().fg(theme.header)),
                     Span::styled(
                         if form.verify_tls { "on" } else { "off" },
                         Style::default().fg(theme.accent),
@@ -1687,6 +1691,40 @@ fn render_config_profiles(
                     Span::styled("  (Ctrl+L toggles)", Style::default().fg(theme.text_dim)),
                 ])),
                 rows[2],
+            );
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("config_ctx    ", Style::default().fg(theme.header)),
+                    Span::styled(
+                        if form.exclude_config_context {
+                            "excluded"
+                        } else {
+                            "included"
+                        },
+                        Style::default().fg(theme.accent),
+                    ),
+                    Span::styled("  (Ctrl+E toggles)", Style::default().fg(theme.text_dim)),
+                ])),
+                rows[3],
+            );
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("api vrf       ", Style::default().fg(theme.header)),
+                    Span::styled(form.api_vrf.as_str(), Style::default().fg(theme.accent)),
+                    Span::styled("  (Ctrl+B cycles)", Style::default().fg(theme.text_dim)),
+                ])),
+                rows[4],
+            );
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("api rtgt      ", Style::default().fg(theme.header)),
+                    Span::styled(
+                        form.api_route_target.as_str(),
+                        Style::default().fg(theme.accent),
+                    ),
+                    Span::styled("  (Ctrl+R cycles)", Style::default().fg(theme.text_dim)),
+                ])),
+                rows[5],
             );
 
             let (test_text, test_style) = match &form.test {
@@ -1701,12 +1739,12 @@ fn render_config_profiles(
                 ),
                 TestState::Failed(e) => (format!("✗ {e}"), Style::default().fg(theme.error)),
             };
-            frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[4]);
+            frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[7]);
 
             if let Some(msg) = &form.message {
                 frame.render_widget(
                     Paragraph::new(Span::styled(msg.clone(), Style::default().fg(theme.error))),
-                    rows[5],
+                    rows[8],
                 );
             }
 
@@ -1719,7 +1757,7 @@ fn render_config_profiles(
             };
             frame.render_widget(
                 Paragraph::new(Span::styled(help, Style::default().fg(theme.text_dim))),
-                rows[6],
+                rows[9],
             );
         }
         ProfilesMode::ConfirmDelete { name, .. } => {


### PR DESCRIPTION
Second of the two config items (contract tests landed in #36). Closes the "deepen the Config modal" roadmap item.

## What
The Config modal's **profile editor** now sets the knobs that used to require hand-editing `config.toml`:
- **API backends** — `[profiles.<name>.api]` `vrf` / `route_target` = `rest`|`graphql`, cycled with **Ctrl+B** / **Ctrl+R**
- **timeout_secs** + **page_size** — numeric text fields
- **exclude_config_context** — **Ctrl+E** toggle

Each row shows its current value + the control hint, matching the existing auth/tls controls.

## Kept clean / kept safe
- New format-preserving toml_edit setters (`set_profile_timeout_secs` / `page_size` / `exclude_config_context` / `api_backend`). **REST/default values are dropped from the file** — the `[api]` table is removed when it becomes empty — so default profiles carry no noise.
- Live in-memory profile + on-disk TOML stay consistent (`build_api_config` mirrors the disk writer).
- **Token path untouched** — still never written to `config.toml` (verified by scan + the existing token tests).

## Deliberately NOT surfaced (no-op toggles)
Matching the module's existing exclusion of `confirm_writes`: the `search` backend (always falls back to REST) and `confirm_writes` (writes deferred). Surfacing either would be a dead toggle.

## Tests / gate
New tests in config.rs (setter round-trip + clear-to-default removes keys/empty `[api]`), config_modal.rs (controls cycle/toggle, edit prefills, numeric validation), and state.rs (full save round-trip: `vrf=graphql` + `timeout=30` + exclude → correct TOML; clearing back to defaults removes the keys + `[api]`). 

Gate green (re-verified locally): fmt, both clippy passes, `cargo test --all-features` (765 lib) + `--no-default-features`.

Implemented via a focused agent, reviewed + gate-verified before merge.