### PR TITLE
fix(tui): onboarding persists the timeout_secs/page_size it shows

### DIFF
--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -198,6 +198,30 @@ pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     crate::config::set_profile_token_env(&mut doc, &name, token_env.as_deref())?;
     crate::config::set_profile_auth_scheme(&mut doc, &name, Some(auth_scheme))?;
     crate::config::set_profile_verify_tls(&mut doc, &name, Some(verify_tls))?;
+    // The wizard renders the shared add-form, so its numeric fields (timeout_secs /
+    // page_size) accept input — persist them too, the same way the editor does, so a
+    // value typed during onboarding isn't silently dropped. The Ctrl-toggled knobs
+    // (exclude / api) aren't reachable in the wizard, so they write their defaults
+    // (exclude = the runtime default; REST ⇒ no `[api]` table).
+    crate::config::set_profile_timeout_secs(&mut doc, &name, form.timeout_secs())?;
+    crate::config::set_profile_page_size(&mut doc, &name, form.page_size())?;
+    crate::config::set_profile_exclude_config_context(
+        &mut doc,
+        &name,
+        Some(form.exclude_config_context),
+    )?;
+    crate::config::set_profile_api_backend(
+        &mut doc,
+        &name,
+        crate::config::ApiSurface::Vrf,
+        form.api_vrf,
+    )?;
+    crate::config::set_profile_api_backend(
+        &mut doc,
+        &name,
+        crate::config::ApiSurface::RouteTarget,
+        form.api_route_target,
+    )?;
     crate::config::set_active_profile(&mut doc, &name);
     crate::config::write_doc(path, &doc)?;
 
@@ -550,6 +574,34 @@ mod tests {
         assert!(!text.contains("token ="), "raw token never written to TOML");
         // A freshly written config is no longer first-run.
         assert!(!crate::config::needs_onboarding(&path, None));
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn persist_writes_typed_timeout_and_page_size() {
+        // Regression: the wizard renders the shared add-form, so the timeout_secs /
+        // page_size fields are visible + editable — a value typed there must persist,
+        // not be silently dropped (it was, before the persist() setters were added).
+        let path = temp_config("tuning");
+        let _ = std::fs::remove_file(&path);
+        let mut w = OnboardingWizard::new();
+        for (idx, val) in [
+            (field::URL, "https://nb.example"),
+            (field::TIMEOUT_SECS, "30"),
+            (field::PAGE_SIZE, "250"),
+        ] {
+            w.form
+                .form_input_mut()
+                .input_mut(idx)
+                .unwrap()
+                .set_value(val);
+        }
+        persist(&w.form, &path).unwrap();
+
+        let cfg: Config = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let prof = &cfg.profiles["default"];
+        assert_eq!(prof.timeout_secs, Some(30), "typed timeout persisted");
+        assert_eq!(prof.page_size, Some(250), "typed page_size persisted");
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 


### PR DESCRIPTION
Follow-up to #37, from external review (the data-loss bug it flagged).

## The bug
#37 added `timeout_secs`/`page_size` as **shared `ProfileForm`** text fields. The first-run wizard reuses `ProfileForm::add()` and renders the **whole** `FormInput`, so it now shows and accepts input for those fields — but `onboarding::persist()` only wrote `token_env`/`auth_scheme`/`verify_tls`. A value typed into `timeout_secs`/`page_size` during onboarding was **silently dropped**.

## Fix
`persist()` now writes the new fields the same way the editor's `persist_profile` does:
- `timeout_secs` / `page_size` from the form (so typed values persist),
- `exclude_config_context` = the runtime default (the wizard doesn't route `Ctrl+E`),
- api backends default to REST ⇒ no `[api]` table (the wizard doesn't route `Ctrl+B`/`Ctrl+R`).

The `exclude`/`api` Ctrl-controls aren't reachable in the wizard (its key handler only routes `Ctrl+S`/`Ctrl+L`/`Ctrl+T`), so they correctly write defaults — only the visible text fields were the loss.

## Test
New `persist_writes_typed_timeout_and_page_size` regression test (types into the timeout/page_size fields, asserts they land in the on-disk profile). Gate green: fmt, both clippy passes, `cargo test --all-features` (766 lib).

(Review's Issues 2 & 3 — the `#[allow(too_many_arguments)]` on `open_edit_form` and `Ctrl+R` being a readline-ish key — are accurate and minor; left as-is. A `ProfileFormData` struct to shrink the arg list is a reasonable later cleanup.)