### PR TITLE
ci(deps): ignore rand minor/major so it stops blocking the Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,17 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+    # `rand` is held at 0.8: the test-only RSA keygen (`rsa` 0.9.x) needs a
+    # `rand_core` 0.6 RNG, and `rand` 0.9/0.10 moved to `rand_core` 0.9, so the
+    # bump doesn't compile. Ignore its minor/major updates (0.8.x patches still
+    # flow) so one held crate stops blocking every other safe bump in the group.
+    # Unpin when `rsa` ships on `rand_core` 0.9 (then take rand 0.9+ and switch
+    # `thread_rng()` → `rng()`).
+    ignore:
+      - dependency-name: "rand"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -396,10 +396,10 @@ Consolidated future scope:
   a `rand_core` 0.6 RNG; `rand` 0.9/0.10 moved to `rand_core` 0.9, so the bump doesn't compile. Pinned on
   purpose (`Cargo.toml` comment). **Unblock when `rsa` ships on `rand_core` 0.9**, then take the bump and
   switch `thread_rng()` → `rng()`. Dependabot PR #15 (group bump incl. `rand` 0.10) is parked on this.
-- ☐ **Ungroup Dependabot cargo updates.** `dependabot.yml` groups all crates (`patterns: ["*"]`), so one
-  incompatible bump (e.g. `rand`) blocks safe ones in the same PR. `ratatui` 0.30.1→0.30.2 (+ the family)
-  was taken manually to unblock it from `rand` in #15; the root cause stands — split the group (or `ignore`
-  `rand`) so safe updates flow independently without hand-bumps.
+- ☑ **Ungroup Dependabot cargo updates.** `dependabot.yml` now `ignore`s `rand`'s minor/major bumps (0.8.x
+  patches still flow), so the held `rand` (⊥ `rsa` 0.9's `rand_core` 0.6) no longer blocks every other safe
+  crate in the grouped PR — no more manual hand-bumps like the `ratatui` 0.30.2 one. Unpin the ignore when
+  `rsa` ships on `rand_core` 0.9 (then take rand 0.9+ and switch `thread_rng()` → `rng()`).
 - ☑ **GitHub Actions on Node 24.** Bumped `actions/cache@v5`, `actions/upload-artifact@v7`, and the
   `docker/*` actions (Dependabot #4–8, 2026-06-20) to clear the Node-20 deprecation warnings in `release.yml`.
 


### PR DESCRIPTION
Root-cause fix for the manual ratatui bump (#32).

`dependabot.yml` groups all cargo crates, so the held `rand` (0.8 — `rsa` 0.9's test-only keygen needs `rand_core` 0.6; `rand` 0.9/0.10 moved to `rand_core` 0.9 and don't compile) blocked every safe bump in the grouped PR. Now `ignore` `rand`'s minor/major updates (0.8.x patches still flow), so the rest of the group updates independently — no more hand-bumps.

Unpin the ignore when `rsa` ships on `rand_core` 0.9. Roadmap item marked done. YAML validated.