### PR TITLE
feat(mcp): nbox_get accepts ip_address as an alias for ip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ stderr. Every tool is annotated read-only.
 | Tool | Purpose |
 | ---- | ------- |
 | `nbox_status` | Connection + active backend capabilities + NetBox/Django/Python versions (call first to confirm reachability and inspect `capabilities`). |
-| `nbox_search` | Search devices/sites/racks/IPs/prefixes/VLANs/circuits/aggregates/ASNs/IP ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets; `query` (required), `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag` (one scope filter at a time), `vrf` (id\|rd\|name; filters IP/prefix results only). Find a reference before `nbox_get`. |
+| `nbox_search` | Search devices/sites/racks/IPs/prefixes/VLANs/circuits/aggregates/ASNs/IP ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets; `query` (required), `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag` (one scope filter at a time), `vrf` (id\|rd\|name; filters IP/prefix results only). Find a reference before `nbox_get`; a result's `kind` (e.g. `ip_address`) feeds straight into `nbox_get`, which accepts it as an alias for `ip`. |
 | `nbox_get` | One object: `kind` (device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, cluster, vrf, route_target) + `ref`; `vrf`/`site`/`group` disambiguate (an ambiguous ref returns the candidates). |
 | `nbox_get_interface` | One interface on a device: config, addresses, cable-path trace. |
 | `nbox_next_ip` | Next available address(es) in a prefix (nothing reserved); `count`, `vrf`. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`nbox_get` (MCP) accepts `ip_address` as an alias for `ip`.** A `nbox_search`
+  result's `kind` is `ip_address` (the one kind whose spelling differs from
+  `nbox_get`'s `ip`; all others already match), so a search → get chain — and the
+  `nbox://ip_address/<ref>` resource URI — now works without translating the kind.
 - **Edit more profile knobs from the in-app Config modal.** The profile add/edit
   form now sets the settings that used to need hand-editing `config.toml`:
   `timeout_secs` and `page_size` (numeric fields; empty = default),

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -381,11 +381,11 @@ Consolidated future scope:
 - ☑ **(test) `live_browse_on_recent_clears_the_results` checks state, not the recents render.** _(done, PR #18)_ It asserts
   `browse_kind == None` + empty view but seeds no recents, so it doesn't prove the fallback paints. Seed a
   recent and assert `home_target()` falls back to it.
-- ☐ **MCP `nbox_search` hit `kind` is snake_case (`ip_address`), but `nbox_get`/CLI use `ip`.** Surfaced by
-  the MCP contract tests (PR #20) and pinned as-is. An agent chaining search → get must translate the kind
-  (`ip_address` → `ip`, etc.). Minor surface inconsistency — candidate small follow-up: align the
-  search-result `kind` with the `nbox_get` kind set for a frictionless chain, or document the mapping in
-  AGENTS.md / docs/MCP.md.
+- ☑ **MCP search → get kind chaining.** `nbox_search` returns `kind = "ip_address"` while `nbox_get`
+  canonically uses `ip` (the only divergence — every other kind already matches). Rather than change the
+  pinned search output, `GetKind` now accepts `ip_address` as a non-breaking alias for `ip` (serde alias on
+  the tool arg + `from_str` for `nbox://ip_address/…`), so an agent can chain search → get without
+  translating. Documented in `AGENTS.md` / `docs/MCP.md`.
 - Considered, not worth doing: `nav_section_index_for_slug` linear scan over 9 slugs (a `match` would be
   exhaustive, but the list is tiny); `status_in_banner` elevating only Warning/Error (deliberate — long
   Info/Success messages are transient and stay in the footer slot).

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -341,6 +341,10 @@ tools accept the full set. `ref` is the natural reference for that kind: a
 name/slug/ID for named objects, a CIDR for prefix and aggregate, an address for
 ip, a VID or name for vlan, the AS number for asn, a name/RD/ID for vrf, a name (e.g. 65000:100) or ID for route_target.
 
+`nbox_get` also accepts `ip_address` as an alias for `ip` — that's the `kind` a
+`nbox_search` result carries, so a search → get chain can pass the hit's `kind`
+through unchanged (it's the one kind whose spelling differs between the two).
+
 ## Resources
 
 The same objects are also exposed as MCP **resources**, for hosts that browse or

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -51,6 +51,12 @@ pub struct NboxMcp {
 #[serde(rename_all = "snake_case")]
 pub enum GetKind {
     Device,
+    /// IP address. Accepts both `ip` and `ip_address` — the latter is what
+    /// `nbox_search` returns as a result `kind`, so an agent can chain
+    /// search → get (and `nbox://ip_address/…`) without translating. (Search uses
+    /// `ObjectKind::IpAddress` = `"ip_address"`; every other kind already matches
+    /// between the two enums, so this is the only alias needed.)
+    #[serde(alias = "ip_address")]
     Ip,
     Prefix,
     Vlan,
@@ -116,9 +122,14 @@ impl GetKind {
         }
     }
 
-    /// Parse a URI kind slug back to a `GetKind`. Inverse of [`Self::as_str`].
+    /// Parse a URI kind slug back to a `GetKind`. Inverse of [`Self::as_str`],
+    /// plus the `ip_address` alias for `ip` (the form `nbox_search` emits), so
+    /// `nbox://ip_address/…` resolves like `nbox://ip/…`.
     fn from_str(s: &str) -> Option<GetKind> {
-        GetKind::ALL.into_iter().find(|k| k.as_str() == s)
+        GetKind::ALL
+            .into_iter()
+            .find(|k| k.as_str() == s)
+            .or_else(|| (s == "ip_address").then_some(GetKind::Ip))
     }
 }
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1460,6 +1460,27 @@ fn parse_resource_uri_round_trips_kind_and_ref() {
 }
 
 #[test]
+fn get_accepts_the_ip_address_alias_from_search() {
+    // nbox_search returns `kind = "ip_address"` (ObjectKind::IpAddress) while
+    // nbox_get canonically uses `ip`. The alias lets an agent chain search → get
+    // (and `nbox://ip_address/…`) without translating the kind. Every other kind
+    // already matches between the two enums, so `ip_address` is the only alias.
+    // Tool-arg path (serde Deserialize):
+    assert!(matches!(
+        serde_json::from_value::<GetKind>(serde_json::json!("ip_address")).unwrap(),
+        GetKind::Ip
+    ));
+    assert!(matches!(
+        serde_json::from_value::<GetKind>(serde_json::json!("ip")).unwrap(),
+        GetKind::Ip
+    ));
+    // Resource-URI path:
+    let (kind, reference) = parse_resource_uri("nbox://ip_address/10.0.0.1").expect("parse");
+    assert!(matches!(kind, GetKind::Ip));
+    assert_eq!(reference, "10.0.0.1");
+}
+
+#[test]
 fn parse_resource_uri_rejects_bad_scheme_kind_and_empty_ref() {
     for uri in ["file:///etc/passwd", "device/edge01", "nbox:/device/edge01"] {
         let err = parse_resource_uri(uri).expect_err("bad scheme");


### PR DESCRIPTION
Closes the MCP search→get kind asymmetry (review Tier 1 #1).

`nbox_search` returns `kind = "ip_address"`; `nbox_get` canonically uses `ip`. I diffed the two enums — **that's the only divergence** (route_target/ip_range/etc. already match). Rather than rename the pinned search output (a CLI `--json`/MCP contract break), `GetKind` now accepts `ip_address` as a **non-breaking alias** for `ip`:
- serde `#[serde(alias = "ip_address")]` on the tool-arg path
- `from_str` fallback for `nbox://ip_address/<ref>`

So an agent can chain search → get (and the resource URI) without translating the kind. Documented in AGENTS.md / docs/MCP.md; test covers both paths. Gate green (767 lib tests).