### PR TITLE
chore(release): add scripts/smoke.sh — the full pre-tag gate in one shot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,14 @@ cargo build
 cargo test --all-features
 ```
 
+Before tagging a release, run the full pre-tag gate in one shot — it adds the
+`--no-default-features` clippy/test legs, `cargo audit`, a build smoke, and
+man-page / completion generation on top of the above:
+
+```bash
+scripts/smoke.sh
+```
+
 ### Pre-commit hooks
 
 `.pre-commit-config.yaml` runs `cargo fmt` and `cargo clippy` on commit and

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,9 +114,10 @@ reviewable PRs that lock contracts and reduce future change cost.
   documented changes, marking the prefix-`utilization` absence and `/api/status` auth as observed-not-noted).
 - ☐ **CLI contract harness** — a thin reusable harness for command-level tests that records
   `(args, stdout, stderr, exit_code)` expectations while preserving the stdout-data-only invariant.
-- ☐ **Release smoke checklist automation** — one local command/script that runs the release-critical
-  gate (`fmt`, diff check, both clippies, both test modes, audit, package/build smoke, man/completion
-  generation) before tags move.
+- ☑ **Release smoke checklist automation** — `scripts/smoke.sh` runs the release-critical gate in one
+  shot (`fmt`, both clippies, both test modes, `cargo audit`, build smoke, man-page + completion
+  generation) before tags move. Referenced from `CONTRIBUTING.md`. (Cross-compiled musl/darwin/windows
+  builds stay the release workflow's matrix, not the local smoke.)
 - ☐ **Observability contracts** — pin `nbox status`, MCP status, and selected debug/audit fields so
   users and agents can tell backend, version, capability, and failure mode without scraping prose.
 - ◐ **Config migration/compat tests** — token-source precedence (`select_env_token`), the onboarding

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Release smoke: run the full pre-tag gate locally, in one shot, so a tag never
+# moves on a tree that would fail CI or the release build. Mirrors the CI `check`
+# + `audit` jobs — format, both clippy modes (pedantic), both test modes, and
+# `cargo audit` — then adds a build smoke and man-page / shell-completion
+# generation. The cross-compiled release matrix (musl/darwin/windows) is the
+# release workflow's job, not this script's.
+#
+# Usage:  scripts/smoke.sh    (run from anywhere; it cd's to the repo root)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }
+
+step "Format check"
+cargo fmt --all -- --check
+
+step "Clippy — all features (pedantic gate)"
+cargo clippy --all-targets --all-features -- -D warnings
+
+step "Clippy — no default features"
+cargo clippy --all-targets --no-default-features -- -D warnings
+
+step "Tests — all features"
+cargo test --all-features
+
+step "Tests — no default features"
+cargo test --no-default-features
+
+step "Security audit"
+if ! command -v cargo-audit >/dev/null 2>&1; then
+    echo "cargo-audit not installed — run: cargo install cargo-audit --locked" >&2
+    exit 1
+fi
+cargo audit
+
+step "Build smoke — all features + no default features"
+cargo build --all-features
+cargo build --no-default-features
+
+step "Man pages + shell completions generate"
+smoke_dir="$(mktemp -d)"
+trap 'rm -rf "$smoke_dir"' EXIT
+cargo run --quiet --all-features -- man "$smoke_dir/man" >/dev/null
+for sh in bash zsh fish powershell elvish; do
+    cargo run --quiet --all-features -- completions "$sh" >/dev/null
+done
+
+printf '\n\033[1;32m✓ smoke passed — gate is green; safe to tag.\033[0m\n'


### PR DESCRIPTION
Tier 1 #2. A single local command that runs the **release-critical gate** before a tag moves:

`fmt` → clippy (all-features, pedantic) → clippy (no-default-features) → test (all-features) → test (no-default-features) → `cargo audit` → build smoke (both feature modes) → man-page + shell-completion generation.

Mirrors the CI `check` + `audit` jobs and adds the artifact-generation smoke, so it catches the "gate passed locally… oh wait I forgot audit" class of mistake **before** the tag moves. Cross-compiled musl/darwin/windows stays the release workflow's matrix.

Ran it end-to-end on this tree — green (`✓ smoke passed`). Referenced from CONTRIBUTING.md; roadmap item marked done.