### PR TITLE
chore(deps): ignore dtolnay/rust-toolchain bumps (deliberate MSRV floor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # `dtolnay/rust-toolchain` is pinned to the project MSRV (1.88) on purpose to
+    # keep a low support floor: building CI on a newer toolchain would stop
+    # catching code that needs features beyond 1.88, silently eroding the floor.
+    # Ignore all version bumps for it — raise the pin by hand when the MSRV is
+    # intentionally raised (the version is a deliberate policy choice, not a dep).
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
Pins the Rust toolchain to the project MSRV (1.88) as a deliberate low-support-floor policy. Building CI on a newer toolchain would stop catching code that requires features beyond 1.88, silently eroding the floor. Ignore all version bumps for `dtolnay/rust-toolchain` so Dependabot stops re-proposing them (the closed #41 was a 1.88→1.100 bump); the pin is raised by hand when the MSRV is intentionally raised.

Follows the same pattern as the `rand` ignore (#39). No build impact — config only.