### PR TITLE
refactor: bundle profile-edit-form args; share the 429-retry policy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -410,10 +410,12 @@ Consolidated future scope:
   pinned search output, `GetKind` now accepts `ip_address` as a non-breaking alias for `ip` (serde alias on
   the tool arg + `from_str` for `nbox://ip_address/…`), so an agent can chain search → get without
   translating. Documented in `AGENTS.md` / `docs/MCP.md`.
-- ☐ **De-dup the 429-retry loop** (`netbox/client.rs` `send()` vs `graphql()`). `parse_retry_after` +
-  `backoff` are already shared; the `if 429 && attempt < MAX_RETRIES { sleep; retry }` wrapper is copy-pasted
-  across the GET and POST paths. A retry combinator taking a `FnMut() -> impl Future<Output = Response>`
-  would fold them together — marginal, deferred (the GET-params vs POST-body difference makes it fiddly).
+- ☑ **De-dup the 429-retry loop** (`netbox/client.rs` `send()` vs `graphql()`). The copy-pasted
+  `if 429 && attempt < MAX_RETRIES { sleep; retry }` wrapper is now a shared `retry_on_rate_limit(&res,
+  attempt, what)` helper (owns `MAX_RETRIES`, honors `Retry-After`/`backoff`, tags the warn line by `what`);
+  both loops just `if retry_on_rate_limit(..).await { attempt += 1; continue }`. Sidestepped the
+  GET-params-vs-POST-body fiddliness by passing the already-sent `&Response` instead of a request closure.
+  Locked end-to-end by a wiremock test (429 + `Retry-After: 0` → retried → 200).
 - Considered, not worth doing: `nav_section_index_for_slug` linear scan over 9 slugs (a `match` would be
   exhaustive, but the list is tiny); `status_in_banner` elevating only Warning/Error (deliberate — long
   Info/Success messages are transient and stay in the footer slot); the error-body `truncate()` allocating

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -161,7 +161,6 @@ impl NetBoxClient {
     /// Issue an authenticated GET, returning the raw response. Retries on HTTP
     /// 429 (rate limited), honoring `Retry-After` when present, up to a small cap.
     async fn send(&self, path: &str, params: &[(&str, String)]) -> Result<reqwest::Response> {
-        const MAX_RETRIES: u32 = 3;
         let url = self.url_for(path)?;
 
         match self.masked_authorization() {
@@ -181,15 +180,7 @@ impl NetBoxClient {
             }
 
             let res = req.send().await.context("sending request to NetBox")?;
-            if res.status() == reqwest::StatusCode::TOO_MANY_REQUESTS && attempt < MAX_RETRIES {
-                let wait = parse_retry_after(
-                    res.headers()
-                        .get(reqwest::header::RETRY_AFTER)
-                        .and_then(|v| v.to_str().ok()),
-                )
-                .unwrap_or_else(|| backoff(attempt));
-                tracing::warn!("NetBox rate limited (429); retrying in {wait:?}");
-                tokio::time::sleep(wait).await;
+            if retry_on_rate_limit(&res, attempt, "NetBox").await {
                 attempt += 1;
                 continue;
             }
@@ -257,7 +248,6 @@ impl NetBoxClient {
         T: DeserializeOwned,
         V: Serialize,
     {
-        const MAX_RETRIES: u32 = 3;
         let url = self.url_for("/graphql/")?;
         let body = json!({
             "query": query,
@@ -285,15 +275,7 @@ impl NetBoxClient {
                 .send()
                 .await
                 .context("sending GraphQL request to NetBox")?;
-            if res.status() == reqwest::StatusCode::TOO_MANY_REQUESTS && attempt < MAX_RETRIES {
-                let wait = parse_retry_after(
-                    res.headers()
-                        .get(reqwest::header::RETRY_AFTER)
-                        .and_then(|v| v.to_str().ok()),
-                )
-                .unwrap_or_else(|| backoff(attempt));
-                tracing::warn!("NetBox GraphQL rate limited (429); retrying in {wait:?}");
-                tokio::time::sleep(wait).await;
+            if retry_on_rate_limit(&res, attempt, "NetBox GraphQL").await {
                 attempt += 1;
                 continue;
             }
@@ -389,6 +371,28 @@ fn backoff(attempt: u32) -> Duration {
     Duration::from_millis(500u64 << attempt.min(6))
 }
 
+/// The shared HTTP-429 retry policy for REST and GraphQL. When `res` is a 429 and
+/// `attempt` is below the cap, sleep for the server's `Retry-After` (or
+/// exponential `backoff`) and return `true` so the caller retries; otherwise
+/// return `false`. `what` tags the warn line so REST and GraphQL stay
+/// distinguishable in logs. Centralizing this keeps the two request loops from
+/// drifting apart on the rate-limit policy.
+async fn retry_on_rate_limit(res: &reqwest::Response, attempt: u32, what: &str) -> bool {
+    const MAX_RETRIES: u32 = 3;
+    if res.status() != reqwest::StatusCode::TOO_MANY_REQUESTS || attempt >= MAX_RETRIES {
+        return false;
+    }
+    let wait = parse_retry_after(
+        res.headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok()),
+    )
+    .unwrap_or_else(|| backoff(attempt));
+    tracing::warn!("{what} rate limited (429); retrying in {wait:?}");
+    tokio::time::sleep(wait).await;
+    true
+}
+
 /// Map a non-success HTTP status to a typed [`NboxError`] so exit codes are
 /// consistent no matter which path hit the error: 401→auth, 403→perms, 404→not
 /// found, everything else→generic API error. (Note: `get_optional` intercepts
@@ -465,6 +469,50 @@ mod tests {
     fn truncate_is_char_safe() {
         assert_eq!(truncate("hello", 10), "hello");
         assert_eq!(truncate("hello", 3), "hel…");
+    }
+
+    #[tokio::test]
+    async fn get_retries_a_429_then_succeeds() {
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // The eventual success (default priority — the fallback).
+        Mock::given(method("GET"))
+            .and(path("/api/x/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .mount(&server)
+            .await;
+        // Higher priority, good for exactly one response: a 429 carrying
+        // `Retry-After: 0` so the shared retry policy fires immediately (no test
+        // sleep). Once exhausted it stops matching and the 200 above serves.
+        Mock::given(method("GET"))
+            .and(path("/api/x/"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+
+        let client = NetBoxClient::new(
+            &ProfileConfig {
+                url: server.uri(),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        // `send` (via `get`) transparently retries the 429 and returns the 200.
+        let body: serde_json::Value = client.get("/api/x/", &[]).await.expect("retry then 200");
+        assert_eq!(body["ok"], json!(true));
+        // The retry really happened: the server saw two GETs for the same path.
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            2,
+            "a 429 is retried once, then the request succeeds"
+        );
     }
 
     #[test]

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -130,6 +130,24 @@ pub struct ProfileForm {
     pub clear_token: bool,
 }
 
+/// The persisted profile fields an edit form is prefilled from, bundled so the
+/// form constructors take one value instead of ten positional args. The app owns
+/// the [`ProfileConfig`](crate::config::ProfileConfig) and builds this from it;
+/// the form copies what it needs into its own inputs, so the borrows only need to
+/// live for the call.
+pub struct ProfileFormData<'a> {
+    pub name: &'a str,
+    pub url: &'a str,
+    pub token_env: Option<&'a str>,
+    pub auth_scheme: AuthScheme,
+    pub verify_tls: bool,
+    pub timeout_secs: Option<u64>,
+    pub page_size: Option<usize>,
+    pub exclude_config_context: bool,
+    pub api_vrf: BackendPreference,
+    pub api_route_target: BackendPreference,
+}
+
 impl ProfileForm {
     /// A blank add form (focus on `name`).
     pub fn add() -> Self {
@@ -173,19 +191,19 @@ impl ProfileForm {
     /// An edit form prefilled from an existing profile's metadata. The token
     /// field starts empty — the stored secret is never read back into the UI;
     /// leaving it blank keeps the existing keyring entry untouched.
-    #[allow(clippy::too_many_arguments)]
-    pub fn edit(
-        name: &str,
-        url: &str,
-        token_env: Option<&str>,
-        auth_scheme: AuthScheme,
-        verify_tls: bool,
-        timeout_secs: Option<u64>,
-        page_size: Option<usize>,
-        exclude_config_context: bool,
-        api_vrf: BackendPreference,
-        api_route_target: BackendPreference,
-    ) -> Self {
+    pub fn edit(data: ProfileFormData<'_>) -> Self {
+        let ProfileFormData {
+            name,
+            url,
+            token_env,
+            auth_scheme,
+            verify_tls,
+            timeout_secs,
+            page_size,
+            exclude_config_context,
+            api_vrf,
+            api_route_target,
+        } = data;
         let mut form = Self::add();
         form.inputs.input_mut(field::NAME).unwrap().set_value(name);
         form.inputs.input_mut(field::URL).unwrap().set_value(url);
@@ -1109,32 +1127,8 @@ impl ConfigModal {
 
     /// Open the edit form for `name`, prefilled from its metadata. Called by the
     /// app (which owns the [`ProfileConfig`]) in response to the edit request.
-    #[allow(clippy::too_many_arguments)]
-    pub fn open_edit_form(
-        &mut self,
-        name: &str,
-        url: &str,
-        token_env: Option<&str>,
-        auth_scheme: AuthScheme,
-        verify_tls: bool,
-        timeout_secs: Option<u64>,
-        page_size: Option<usize>,
-        exclude_config_context: bool,
-        api_vrf: BackendPreference,
-        api_route_target: BackendPreference,
-    ) {
-        self.profiles.mode = ProfilesMode::Form(ProfileForm::edit(
-            name,
-            url,
-            token_env,
-            auth_scheme,
-            verify_tls,
-            timeout_secs,
-            page_size,
-            exclude_config_context,
-            api_vrf,
-            api_route_target,
-        ));
+    pub fn open_edit_form(&mut self, data: ProfileFormData<'_>) {
+        self.profiles.mode = ProfilesMode::Form(ProfileForm::edit(data));
     }
 
     /// Return to the list view (after a save/delete settles), selecting `idx`.
@@ -1188,18 +1182,18 @@ mod tests {
         auth_scheme: AuthScheme,
         verify_tls: bool,
     ) {
-        m.open_edit_form(
+        m.open_edit_form(ProfileFormData {
             name,
             url,
             token_env,
             auth_scheme,
             verify_tls,
-            None,
-            None,
-            true,
-            BackendPreference::Rest,
-            BackendPreference::Rest,
-        );
+            timeout_secs: None,
+            page_size: None,
+            exclude_config_context: true,
+            api_vrf: BackendPreference::Rest,
+            api_route_target: BackendPreference::Rest,
+        });
     }
 
     #[test]
@@ -1536,18 +1530,18 @@ mod tests {
         // The new knobs (timeout/page_size/exclude/api backends) prefill from the
         // ProfileConfig the app passes in.
         let mut m = ConfigModal::default();
-        m.open_edit_form(
-            "work",
-            "https://w",
-            None,
-            AuthScheme::Auto,
-            true,
-            Some(30),
-            Some(250),
-            false,
-            BackendPreference::Graphql,
-            BackendPreference::Rest,
-        );
+        m.open_edit_form(ProfileFormData {
+            name: "work",
+            url: "https://w",
+            token_env: None,
+            auth_scheme: AuthScheme::Auto,
+            verify_tls: true,
+            timeout_secs: Some(30),
+            page_size: Some(250),
+            exclude_config_context: false,
+            api_vrf: BackendPreference::Graphql,
+            api_route_target: BackendPreference::Rest,
+        });
         let f = m.form().unwrap();
         assert_eq!(f.timeout_secs(), Some(30));
         assert_eq!(f.page_size(), Some(250));

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -18,7 +18,9 @@ use crate::netbox::dashboard::DashboardData;
 use crate::netbox::prefix_tree::{self, PrefixNode, PrefixTreeData};
 use crate::netbox::search::{ObjectKind, SearchFilters, SearchOutcome, SearchResult};
 use crate::tui::cheese::{Spinner, TextInput};
-use crate::tui::config_modal::{ConfigModal, ModalOutcome, ProfilesMode, TestState};
+use crate::tui::config_modal::{
+    ConfigModal, ModalOutcome, ProfileFormData, ProfilesMode, TestState,
+};
 use crate::tui::filter_modal::{FilterModal, FilterOutcome};
 use crate::tui::palette::{self, PaletteCommand};
 use crate::tui::theme::{Severity, Theme};
@@ -2376,10 +2378,10 @@ impl App {
             .config
             .api_preference(crate::config::ApiSurface::RouteTarget);
         if let Some(Modal::Config(modal)) = &mut self.modal {
-            modal.open_edit_form(
+            modal.open_edit_form(ProfileFormData {
                 name,
-                &url,
-                token_env.as_deref(),
+                url: &url,
+                token_env: token_env.as_deref(),
                 auth_scheme,
                 verify_tls,
                 timeout_secs,
@@ -2387,7 +2389,7 @@ impl App {
                 exclude_config_context,
                 api_vrf,
                 api_route_target,
-            );
+            });
         }
     }
 


### PR DESCRIPTION
Two code-health nits from the external review / ROADMAP, bundled per request. **No behavior change.**

## 1. `ProfileFormData` — shrink `open_edit_form`

`open_edit_form` (11 args) and `ProfileForm::edit` (10 args) each sat behind `#[allow(clippy::too_many_arguments)]`. Bundle the prefilled profile fields into a borrowed `ProfileFormData<'a>` struct threaded through both — both allows dropped. The app builds it from the live `ProfileConfig`; the form copies what it needs, so the borrows only live for the call.

## 2. `retry_on_rate_limit` — share the 429 policy

`send()` (GET) and `graphql()` (POST) hand-rolled the same `if 429 && attempt < MAX_RETRIES { Retry-After/backoff; sleep; retry }` block. Factored into one shared helper that owns `MAX_RETRIES` and tags the warn line by caller. Each loop is now `if retry_on_rate_limit(&res, attempt, what).await { attempt += 1; continue }`. The ROADMAP previously deferred this over the GET-params-vs-POST-body closure fiddliness — sidestepped by passing the already-sent `&Response` rather than a request closure.

New **wiremock** test locks the loop end-to-end: a 429 with `Retry-After: 0` (instant) is retried, then the 200 serves; asserts the server saw two requests.

## Gate

fmt ✓ · clippy `--all-features` ✓ · clippy `--no-default-features` ✓ · tests ✓ (938 / 843, incl. new `get_retries_a_429_then_succeeds` + the existing `editing_form_prefills_the_new_profile_knobs`).