### PR TITLE
refactor: persist_profile takes ProfileFormData; pin journal author key

### DIFF
--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -2112,8 +2112,9 @@ mod contracts {
 
     /// `nbox_journal` → `JournalView`: a top-level `entries` array whose rows carry
     /// the flattened entry fields. `comments` is always present; `created`/`kind`/
-    /// `author` are skip-if-none (no `author` in this fixture), so the row key set
-    /// here is the common three.
+    /// `author` are skip-if-none. This fixture carries all four (the `created_by`
+    /// user resolves to the `author` label) so the FULL row key set is pinned —
+    /// catching a drop/rename of `author`, which a minimal fixture would miss.
     #[tokio::test]
     async fn journal_view_shape_is_pinned() {
         let mock = MockServer::start().await;
@@ -2129,7 +2130,9 @@ mod contracts {
                 "count": 1, "next": null, "previous": null,
                 "results": [{
                     "id": 5, "created": "2024-01-02",
-                    "kind": {"value": "info", "label": "Info"}, "comments": "rebooted"
+                    "kind": {"value": "info", "label": "Info"},
+                    "created_by": {"id": 1, "username": "neteng", "display": "neteng"},
+                    "comments": "rebooted"
                 }]
             })))
             .mount(&mock)
@@ -2146,7 +2149,10 @@ mod contracts {
         let value = serde_json::to_value(&view).expect("serialize view");
 
         assert_keys(&value, &["entries"]);
-        assert_keys(&value["entries"][0], &["created", "kind", "comments"]);
+        let entry = &value["entries"][0];
+        assert_keys(entry, &["created", "kind", "author", "comments"]);
+        // `author` is the resolved user label (display), not the raw user object.
+        assert_eq!(entry["author"], "neteng");
     }
 
     /// `nbox_list_tags` → `TagsView`: a top-level `tags` array of rows. `name`/

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -131,10 +131,12 @@ pub struct ProfileForm {
 }
 
 /// The persisted profile fields an edit form is prefilled from, bundled so the
-/// form constructors take one value instead of ten positional args. The app owns
-/// the [`ProfileConfig`](crate::config::ProfileConfig) and builds this from it;
-/// the form copies what it needs into its own inputs, so the borrows only need to
-/// live for the call.
+/// form constructors (and `persist_profile`) take one value instead of ten
+/// positional args. The app owns the [`ProfileConfig`](crate::config::ProfileConfig)
+/// and builds this from it; the form copies what it needs into its own inputs, so
+/// the borrows only need to live for the call. `Copy` (every field is) so callers
+/// can destructure it without moves.
+#[derive(Clone, Copy)]
 pub struct ProfileFormData<'a> {
     pub name: &'a str,
     pub url: &'a str,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -2074,16 +2074,18 @@ impl App {
         if let Err(e) = Self::persist_profile(
             &path,
             Some(&name),
-            &name,
-            &url,
-            token_env.as_deref(),
-            auth_scheme,
-            verify_tls,
-            timeout_secs,
-            page_size,
-            exclude_config_context,
-            api_vrf,
-            api_route_target,
+            &ProfileFormData {
+                name: &name,
+                url: &url,
+                token_env: token_env.as_deref(),
+                auth_scheme,
+                verify_tls,
+                timeout_secs,
+                page_size,
+                exclude_config_context,
+                api_vrf,
+                api_route_target,
+            },
         ) {
             self.set_status(format!("save failed: {e:#}"), Severity::Error);
             return Some(Vec::new());
@@ -2195,16 +2197,18 @@ impl App {
         if let Err(e) = Self::persist_profile(
             &path,
             original.as_deref(),
-            &name,
-            &url,
-            token_env.as_deref(),
-            auth_scheme,
-            verify_tls,
-            timeout_secs,
-            page_size,
-            exclude_config_context,
-            api_vrf,
-            api_route_target,
+            &ProfileFormData {
+                name: &name,
+                url: &url,
+                token_env: token_env.as_deref(),
+                auth_scheme,
+                verify_tls,
+                timeout_secs,
+                page_size,
+                exclude_config_context,
+                api_vrf,
+                api_route_target,
+            },
         ) {
             self.set_status(format!("save failed: {e:#}"), Severity::Error);
             return Vec::new();
@@ -2288,22 +2292,24 @@ impl App {
     /// removed (H1) so a phantom profile can't return on the next launch; if the
     /// renamed profile was the active one, `active_profile` is repointed to the new
     /// name so the file stays self-consistent.
-    #[allow(clippy::too_many_arguments)]
     fn persist_profile(
         path: &std::path::Path,
         original: Option<&str>,
-        name: &str,
-        url: &str,
-        token_env: Option<&str>,
-        auth_scheme: AuthScheme,
-        verify_tls: bool,
-        timeout_secs: Option<u64>,
-        page_size: Option<usize>,
-        exclude_config_context: bool,
-        api_vrf: BackendPreference,
-        api_route_target: BackendPreference,
+        data: &ProfileFormData<'_>,
     ) -> anyhow::Result<()> {
         use crate::config::ApiSurface;
+        let ProfileFormData {
+            name,
+            url,
+            token_env,
+            auth_scheme,
+            verify_tls,
+            timeout_secs,
+            page_size,
+            exclude_config_context,
+            api_vrf,
+            api_route_target,
+        } = *data;
         let mut doc = crate::config::load_doc_or_new(path)?;
         // Rename: drop the old section and repoint active_profile if it named it.
         if let Some(orig) = original


### PR DESCRIPTION
Two future-maintenance cleanups, **no behavior change**.

## 1. `persist_profile` positional-arg fragility
Collapsed the 12 positional args (mixed `&str`/`Option`/enum, and **two** call sites since the Settings connection knobs landed in #54 — transposition-prone) into `(path, original, &ProfileFormData)`. Reuses the struct from #51 (now `Copy`, so `persist_profile` destructures it without moves) and drops the `#[allow(clippy::too_many_arguments)]`.

## 2. Journal contract minimal key set
`journal_view_shape_is_pinned` only asserted `[created, kind, comments]` because the fixture omitted `created_by` — so a drop/rename of the skip-if-none `author` field slipped through. The fixture now carries `created_by` and pins the full `[created, kind, author, comments]` set plus the resolved `author` label.

## Gate
fmt ✓ · clippy `--all-features` ✓ · clippy `--no-default-features` ✓ · tests ✓ (948 / 853).