### PR TITLE
feat(tui): api backends in the Settings Connection category

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,13 +75,12 @@ Polish the read experience. No writes here.
   dropped when empty). Deliberately NOT surfaced (no-op toggles, like the long-excluded `confirm_writes`):
   the `search` backend (always falls back to REST) and `confirm_writes` (writes deferred).
 - ☑ **Settings-section connection parity (hot-apply).** The Config modal's **Settings** section now has a
-  **Connection** category exposing the active profile's `page_size`, `timeout_secs`, and
-  `exclude_config_context`, seeded from the live profile. Saving a change persists it to that profile
-  (format-preserving) and **reconnects** through the existing switch path so it hot-applies — the client
-  bakes these at construction. (The profile editor remains the place to manage *any* profile; Settings is
-  the quick-tweak surface for the *active* one.) **Deferred:** the per-surface `api` backends
-  (`vrf`/`route_target`) as Settings cycles — already editable in the profile editor (`Ctrl+B`/`Ctrl+R`),
-  so this is low marginal value; revisit if asked.
+  **Connection** category exposing the active profile's `page_size`, `timeout_secs`,
+  `exclude_config_context`, and the per-surface `[api]` `vrf`/`route_target` backends (`rest`/`graphql`
+  cycles), seeded from the live profile. Saving a change persists it to that profile (format-preserving)
+  and **reconnects** through the existing switch path so it hot-applies — the client bakes these at
+  construction. (The profile editor remains the place to manage *any* profile; Settings is the quick-tweak
+  surface for the *active* one.) The api backends were folded in after the initial parity pass.
 - ☑ **Release `0.2.0`** — banked the large read surface accumulated since `0.1.1` (MCP HTTP/OAuth, the new
   read commands, MCP resources, the in-app config layer, three hardening rounds).
 - ☑ **Release `0.4.0`** — per-surface API backends (breaking), REST-canonical search (GraphQL search

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -489,6 +489,10 @@ pub enum SettingId {
     TimeoutSecs,
     /// Active profile `exclude_config_context` — a toggle; reconnects.
     ExcludeConfigContext,
+    /// Active profile `[api] vrf` backend — a rest/graphql cycle; reconnects.
+    ApiVrf,
+    /// Active profile `[api] route_target` backend — a rest/graphql cycle; reconnects.
+    ApiRouteTarget,
 }
 
 impl SettingId {
@@ -505,6 +509,8 @@ impl SettingId {
             SettingId::PageSize => "page_size",
             SettingId::TimeoutSecs => "timeout_secs",
             SettingId::ExcludeConfigContext => "exclude_config_context",
+            SettingId::ApiVrf => "api vrf",
+            SettingId::ApiRouteTarget => "api route_target",
         }
     }
 }
@@ -524,6 +530,8 @@ pub const SETTINGS_CATEGORIES: &[(&str, &[SettingId])] = &[
             SettingId::PageSize,
             SettingId::TimeoutSecs,
             SettingId::ExcludeConfigContext,
+            SettingId::ApiVrf,
+            SettingId::ApiRouteTarget,
         ],
     ),
     ("Cache", &[SettingId::CacheEnabled, SettingId::CacheTtl]),
@@ -575,6 +583,10 @@ pub struct SettingsPane {
     pub timeout: TextInput,
     /// Active profile `exclude_config_context` toggle. Reconnects.
     pub exclude_config_context: bool,
+    /// Active profile `[api] vrf` backend (rest/graphql cycle). Reconnects.
+    pub api_vrf: BackendPreference,
+    /// Active profile `[api] route_target` backend (rest/graphql cycle). Reconnects.
+    pub api_route_target: BackendPreference,
     /// A transient info / validation line shown under the form.
     pub message: Option<String>,
 }
@@ -587,6 +599,8 @@ pub struct ConnectionSeed {
     pub page_size: Option<usize>,
     pub timeout_secs: Option<u64>,
     pub exclude_config_context: bool,
+    pub api_vrf: BackendPreference,
+    pub api_route_target: BackendPreference,
 }
 
 impl SettingsPane {
@@ -643,6 +657,8 @@ impl SettingsPane {
             page_size,
             timeout,
             exclude_config_context: connection.exclude_config_context,
+            api_vrf: connection.api_vrf,
+            api_route_target: connection.api_route_target,
             message: None,
         }
     }
@@ -741,11 +757,40 @@ impl SettingsPane {
         self.message = None;
     }
 
-    /// The `TextInput` backing a field, if it has one (theme and the cache toggle
-    /// are non-text controls).
+    /// The working `[api] vrf` backend.
+    pub fn api_vrf(&self) -> BackendPreference {
+        self.api_vrf
+    }
+
+    /// The working `[api] route_target` backend.
+    pub fn api_route_target(&self) -> BackendPreference {
+        self.api_route_target
+    }
+
+    /// Cycle an api backend between `rest` and `graphql` (Left/Right/Space on its
+    /// row). Two values, so any cycle key flips it.
+    fn cycle_api(&mut self, id: SettingId) {
+        let flip = |p: BackendPreference| match p {
+            BackendPreference::Rest => BackendPreference::Graphql,
+            BackendPreference::Graphql => BackendPreference::Rest,
+        };
+        match id {
+            SettingId::ApiVrf => self.api_vrf = flip(self.api_vrf),
+            SettingId::ApiRouteTarget => self.api_route_target = flip(self.api_route_target),
+            _ => {}
+        }
+        self.message = None;
+    }
+
+    /// The `TextInput` backing a field, if it has one (theme, the toggles, and the
+    /// api cycles are non-text controls).
     pub fn input_mut(&mut self, id: SettingId) -> Option<&mut TextInput> {
         match id {
-            SettingId::Theme | SettingId::CacheEnabled | SettingId::ExcludeConfigContext => None,
+            SettingId::Theme
+            | SettingId::CacheEnabled
+            | SettingId::ExcludeConfigContext
+            | SettingId::ApiVrf
+            | SettingId::ApiRouteTarget => None,
             SettingId::RefreshSecs => Some(&mut self.refresh),
             SettingId::OpenBrowserCommand => Some(&mut self.browser),
             SettingId::LogLevel => Some(&mut self.log_level),
@@ -1008,6 +1053,19 @@ impl ConfigModal {
                 // connection knob, so the save (not this keypress) reconnects.
                 if s.focused_field() == Some(SettingId::ExcludeConfigContext) && is_cycle_key {
                     s.toggle_exclude_config_context();
+                    return ModalOutcome::None;
+                }
+                // The api backends cycle rest/graphql with the same keys; also a
+                // connection knob, applied on save (not live, unlike the theme cycle).
+                if is_cycle_key
+                    && matches!(
+                        s.focused_field(),
+                        Some(SettingId::ApiVrf | SettingId::ApiRouteTarget)
+                    )
+                {
+                    if let Some(id) = s.focused_field() {
+                        s.cycle_api(id);
+                    }
                     return ModalOutcome::None;
                 }
                 match key.code {
@@ -1876,13 +1934,17 @@ mod tests {
                 page_size: Some(100),
                 timeout_secs: Some(45),
                 exclude_config_context: false,
+                api_vrf: BackendPreference::Graphql,
+                api_route_target: BackendPreference::Rest,
             },
         );
         assert_eq!(m.settings.page_size(), Some(100));
         assert_eq!(m.settings.timeout_secs(), Some(45));
         assert!(!m.settings.exclude_config_context());
+        assert_eq!(m.settings.api_vrf(), BackendPreference::Graphql);
+        assert_eq!(m.settings.api_route_target(), BackendPreference::Rest);
 
-        // The category exists with the three connection knobs in order.
+        // The category exists with the five connection knobs in order.
         let conn = SETTINGS_CATEGORIES
             .iter()
             .find(|(name, _)| *name == "Connection")
@@ -1892,7 +1954,9 @@ mod tests {
             &[
                 SettingId::PageSize,
                 SettingId::TimeoutSecs,
-                SettingId::ExcludeConfigContext
+                SettingId::ExcludeConfigContext,
+                SettingId::ApiVrf,
+                SettingId::ApiRouteTarget,
             ]
         );
     }
@@ -1911,6 +1975,7 @@ mod tests {
                 page_size: None,
                 timeout_secs: None,
                 exclude_config_context: true,
+                ..ConnectionSeed::default()
             },
         );
         enter_connection_fields(&mut m);
@@ -1939,6 +2004,50 @@ mod tests {
         assert_eq!(out, ModalOutcome::None);
         assert!(m.settings.message.is_some(), "shows a validation message");
         assert_eq!(m.settings.page_size(), None);
+    }
+
+    #[test]
+    fn settings_connection_api_backends_cycle_rest_graphql() {
+        let mut m = ConfigModal::new(
+            "default",
+            None,
+            "",
+            "",
+            "",
+            true,
+            30,
+            ConnectionSeed::default(), // both api backends seed to rest
+        );
+        enter_connection_fields(&mut m);
+        // Fields: page_size, timeout_secs, exclude, api vrf (4th), api route_target.
+        m.handle_key(key(KeyCode::Down), &[], ""); // → timeout_secs
+        m.handle_key(key(KeyCode::Down), &[], ""); // → exclude_config_context
+        m.handle_key(key(KeyCode::Down), &[], ""); // → api vrf
+        assert_eq!(m.settings.focused_field(), Some(SettingId::ApiVrf));
+        assert_eq!(m.settings.api_vrf(), BackendPreference::Rest);
+        m.handle_key(key(KeyCode::Char(' ')), &[], "");
+        assert_eq!(
+            m.settings.api_vrf(),
+            BackendPreference::Graphql,
+            "Space cycles rest→graphql"
+        );
+        m.handle_key(key(KeyCode::Left), &[], "");
+        assert_eq!(
+            m.settings.api_vrf(),
+            BackendPreference::Rest,
+            "Left flips back"
+        );
+
+        // route_target cycles independently of vrf.
+        m.handle_key(key(KeyCode::Down), &[], ""); // → api route_target
+        assert_eq!(m.settings.focused_field(), Some(SettingId::ApiRouteTarget));
+        m.handle_key(key(KeyCode::Right), &[], "");
+        assert_eq!(m.settings.api_route_target(), BackendPreference::Graphql);
+        assert_eq!(
+            m.settings.api_vrf(),
+            BackendPreference::Rest,
+            "vrf is untouched by route_target's cycle"
+        );
     }
 
     #[test]

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1788,6 +1788,10 @@ impl App {
                         page_size: p.config.page_size,
                         timeout_secs: p.config.timeout_secs,
                         exclude_config_context: p.config.exclude_config_context.unwrap_or(true),
+                        api_vrf: p.config.api_preference(crate::config::ApiSurface::Vrf),
+                        api_route_target: p
+                            .config
+                            .api_preference(crate::config::ApiSurface::RouteTarget),
                     });
             self.modal = Some(Modal::Config(Box::new(ConfigModal::new(
                 self.theme.name(),
@@ -1969,6 +1973,8 @@ impl App {
         let new_page_size = modal.settings.page_size();
         let new_timeout = modal.settings.timeout_secs();
         let new_exclude = modal.settings.exclude_config_context();
+        let new_api_vrf = modal.settings.api_vrf();
+        let new_api_route_target = modal.settings.api_route_target();
 
         let refresh_changed = new_refresh != self.refresh_secs;
 
@@ -2025,7 +2031,13 @@ impl App {
         // bakes timeout/page_size/exclude at construction — so a change is persisted
         // to that profile and hot-applied by reconnecting through the existing
         // switch path. Unchanged ⇒ no reconnect, just the plain "saved" confirmation.
-        match self.apply_connection_settings(new_page_size, new_timeout, new_exclude) {
+        match self.apply_connection_settings(
+            new_page_size,
+            new_timeout,
+            new_exclude,
+            new_api_vrf,
+            new_api_route_target,
+        ) {
             Some(reconnect) => commands.extend(reconnect),
             None => self.set_status("settings saved", Severity::Success),
         }
@@ -2033,36 +2045,40 @@ impl App {
     }
 
     /// Persist a change to the active profile's connection knobs (`page_size`,
-    /// `timeout_secs`, `exclude_config_context`) and reconnect so it takes effect
-    /// live. Returns `None` when nothing changed (the caller shows the plain "saved"
-    /// status); `Some(commands)` when a change was attempted — the reconnect
-    /// commands, or empty if the persist failed (this method sets the error status).
-    /// The profile's identity/auth/api fields are carried through unchanged.
+    /// `timeout_secs`, `exclude_config_context`, and the `[api]` `vrf`/`route_target`
+    /// backends) and reconnect so it takes effect live. Returns `None` when nothing
+    /// changed (the caller shows the plain "saved" status); `Some(commands)` when a
+    /// change was attempted — the reconnect commands, or empty if the persist failed
+    /// (this method sets the error status). The profile's identity/auth fields are
+    /// carried through unchanged.
     fn apply_connection_settings(
         &mut self,
         page_size: Option<usize>,
         timeout_secs: Option<u64>,
         exclude_config_context: bool,
+        api_vrf: BackendPreference,
+        api_route_target: BackendPreference,
     ) -> Option<Vec<AppCommand>> {
+        use crate::config::ApiSurface;
         let idx = self.profile_index;
         let entry = self.profiles.get(idx)?;
         let cfg = &entry.config;
         let changed = cfg.page_size != page_size
             || cfg.timeout_secs != timeout_secs
-            || cfg.exclude_config_context.unwrap_or(true) != exclude_config_context;
+            || cfg.exclude_config_context.unwrap_or(true) != exclude_config_context
+            || cfg.api_preference(ApiSurface::Vrf) != api_vrf
+            || cfg.api_preference(ApiSurface::RouteTarget) != api_route_target;
         if !changed {
             return None;
         }
 
-        // Snapshot the unchanged identity/auth/api fields for the format-preserving
+        // Snapshot the unchanged identity/auth fields for the format-preserving
         // write (no rename: original == name == the active profile).
         let name = entry.name.clone();
         let url = cfg.url.clone();
         let token_env = cfg.token_env.clone();
         let auth_scheme = cfg.auth_scheme.unwrap_or(AuthScheme::Auto);
         let verify_tls = cfg.verify_tls.unwrap_or(true);
-        let api_vrf = cfg.api_preference(crate::config::ApiSurface::Vrf);
-        let api_route_target = cfg.api_preference(crate::config::ApiSurface::RouteTarget);
 
         let Some(path) = self.config_path.clone() else {
             self.set_status(
@@ -2097,6 +2113,7 @@ impl App {
             entry.config.timeout_secs = timeout_secs;
             entry.config.page_size = page_size;
             entry.config.exclude_config_context = Some(exclude_config_context);
+            entry.config.api = build_api_config(api_vrf, api_route_target);
         }
         Some(self.switch_to_index(idx))
     }
@@ -8079,6 +8096,45 @@ mod tests {
             cmds.iter()
                 .any(|c| matches!(c, AppCommand::SwitchProfile { .. })),
             "a connection-knob change reconnects to hot-apply it"
+        );
+    }
+
+    #[test]
+    fn settings_save_api_backend_persists_to_profile_and_reconnects() {
+        use crate::config::{ApiSurface, BackendPreference};
+        let (mut a, _dir, path) = app_with_config(&["a"]);
+        open_settings(&mut a);
+        // Connection category; api vrf is the 4th field (page_size, timeout_secs,
+        // exclude_config_context, api vrf, api route_target).
+        a.handle_event(press(KeyCode::Down)); // → Behavior
+        a.handle_event(press(KeyCode::Down)); // → Connection
+        a.handle_event(press(KeyCode::Right)); // enter fields (page_size)
+        a.handle_event(press(KeyCode::Down)); // → timeout_secs
+        a.handle_event(press(KeyCode::Down)); // → exclude_config_context
+        a.handle_event(press(KeyCode::Down)); // → api vrf
+        a.handle_event(press(KeyCode::Char(' '))); // cycle rest → graphql
+        let cmds = a.handle_event(press(KeyCode::Enter)); // save
+
+        assert!(a.modal.is_none(), "save closes the modal");
+        // The [api] vrf backend persisted to the active profile and is reflected live.
+        let cfg = crate::config::load(&path).unwrap();
+        assert_eq!(
+            cfg.profiles
+                .get("a")
+                .unwrap()
+                .api_preference(ApiSurface::Vrf),
+            BackendPreference::Graphql
+        );
+        assert_eq!(
+            a.profiles[a.profile_index]
+                .config
+                .api_preference(ApiSurface::Vrf),
+            BackendPreference::Graphql
+        );
+        assert!(
+            cmds.iter()
+                .any(|c| matches!(c, AppCommand::SwitchProfile { .. })),
+            "an api-backend change reconnects to hot-apply it"
         );
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1599,6 +1599,19 @@ fn render_config_settings(frame: &mut Frame, area: Rect, modal: &mut ConfigModal
                 ])),
                 value_area,
             );
+        } else if id == SettingId::ApiVrf || id == SettingId::ApiRouteTarget {
+            let pref = if id == SettingId::ApiVrf {
+                s.api_vrf()
+            } else {
+                s.api_route_target()
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(pref.as_str(), Style::default().fg(theme.accent)),
+                    Span::styled("  (←/→/Space)", Style::default().fg(theme.text_dim)),
+                ])),
+                value_area,
+            );
         } else if let Some(input) = s.input_mut(id) {
             let pos = input.render_with_focus(frame, value_area, ' ', theme, focused);
             if focused {


### PR DESCRIPTION
Completes the settings-parity ask (the bit deferred from #54). The Settings → **Connection** category now also exposes the active profile's `[api]` `vrf` and `route_target` backends as **rest/graphql cycles** (Left/Right/Space), alongside `page_size` / `timeout_secs` / `exclude_config_context`.

## Reuses the established pattern end-to-end
- `ConnectionSeed` carries the two `BackendPreference` values, seeded from the active profile's `api_preference`.
- The cycle mirrors the theme/toggle widgets (two values → any cycle key flips).
- On save, `apply_connection_settings` now includes the api backends in change-detection, persists them via `persist_profile` (which already writes `[api]`), updates the live profile's `ApiConfig` (`build_api_config`), and **reconnects** to hot-apply. Unchanged ⇒ no reconnect.

## Tests
- `settings_connection_api_backends_cycle_rest_graphql` — the rest↔graphql cycle, independent per surface.
- `settings_save_api_backend_persists_to_profile_and_reconnects` — end-to-end save persists `[api] vrf=graphql` to the active profile + emits a reconnect.
- Extended the seeding/category test to assert the api fields and the full five-knob Connection category.

## Gate
fmt ✓ · clippy `--all-features` ✓ · clippy `--no-default-features` ✓ · tests ✓ (950 / 855).