### PR TITLE
perf(search): resolve scope and VRF concurrently

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -434,10 +434,10 @@ Consolidated future scope:
 
 A batch of proposed perf wins, each verified against the code. Net: one quick win, one medium, one probe; the rest skip. The search path is **network-dominated** — CPU micro-opts there are noise.
 
-- ☐ **Concurrent scope+VRF resolution (quick win).** `search.rs` resolves `--scope` then `--vrf` as two
-  **independent sequential awaits** (`resolve_scope` ~`:329`, `resolve_vrf` ~`:337`) before the 17-way
-  fan-out. `tokio::try_join!` them — saves 1-4 RTTs on *filtered* searches, zero risk. (No filter ⇒ both
-  return `Ok(None)` with zero network calls, so the win only applies when a scope/vrf filter is set.) NOTE:
+- ☑ **Concurrent scope+VRF resolution (quick win).** `search.rs` resolved `--scope` then `--vrf` as two
+  **independent sequential awaits** before the 17-way fan-out; now `tokio::try_join!`ed — saves 1-4 RTTs on
+  *filtered* searches, zero risk, byte-identical results. (No filter ⇒ both return `Ok(None)` with zero
+  network calls, so the win only applies when a scope/vrf filter is set.) NOTE:
   the broader "fire the fan-out optimistically alongside resolution" idea is **unsound** — the fan-out's
   filters need the resolved ids (`site_id`/`vrf_id`/scope content-type), so it can't start blind; a
   cancellation token doesn't help when the input is the missing value.

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -326,15 +326,18 @@ impl NetBoxClient {
         // unknown ref is a hard not-found error (exit 4) so search fails loudly
         // rather than quietly returning nothing. Scope is an *exact* match: each
         // flag filters by its own scope only — no hierarchy/descendant semantics.
-        let scope = self.resolve_scope(f).await?;
-
         // Resolve the (optional) `--vrf` reference (id | rd | name) to a numeric
         // id once, up front. An unknown VRF is a hard not-found error (exit 4) so
         // search fails loudly rather than quietly returning nothing — matching the
         // scope-filter behavior. The resolved id is applied as `vrf_id=` on the
         // VRF-capable endpoints (IPs, prefixes); the rest skip the vrf filter.
         // `--vrf` is orthogonal to the scope filters: both may be active at once.
-        let vrf_id = self.resolve_vrf(f).await?;
+        //
+        // The scope and VRF resolvers are independent and each can make 1-4
+        // round-trips, so run them concurrently — a `--scope` + `--vrf` search would
+        // otherwise pay both serial tails before the fan-out even starts. (With
+        // neither filter set both return `Ok(None)` after zero network calls.)
+        let (scope, vrf_id) = tokio::try_join!(self.resolve_scope(f), self.resolve_vrf(f))?;
 
         let (
             devices,


### PR DESCRIPTION
The quick win from the perf evaluation. `search_rest` resolved `--scope` then `--vrf` as two **independent sequential awaits** before the 17-way fan-out, so a `--scope` + `--vrf` search paid both resolution tails (each up to 4 round-trips) serially. They share no data → `tokio::try_join!` them so the fan-out starts after one combined tail instead of two.

- **Byte-identical results** — the same resolved scope + `vrf_id` feed the same fan-out.
- The no-filter common case still makes **zero** resolution calls (both return `Ok(None)` early).
- All search tests pass unchanged.

(Context: the broader 'fire the fan-out optimistically alongside resolution' idea was evaluated and rejected — the fan-out's filters need the resolved ids, so it can't start blind. And connection pooling was rejected outright: it reverts the `pool_max_idle_per_host(0)` gunicorn fix. See ROADMAP § Performance candidates.)

## Gate
fmt ✓ · clippy `--all-features` ✓ · clippy `--no-default-features` ✓ · tests ✓ (950 / 855).