### PR TITLE
fix TUI onboarding token handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ server for AI agents.
 ## Quick Start
 
 First run? Just launch the TUI — with no config it opens a first-run wizard that
-captures a profile (url + token), test-connects, and drops you into the app:
+captures a profile (URL plus a keyring-backed or env-backed token source),
+test-connects, and drops you into the app:
 
 ```bash
 nbox                              # first run: guided onboarding, then the TUI
@@ -354,7 +355,7 @@ in-app: list them (active marked), and add / edit / select / delete without
 hand-editing `config.toml`. The add/edit form covers `name`, `url`, `token_env`,
 `auth_scheme`, and `verify_tls`, plus an optional masked token field. When a
 keyring is available, a typed token is stored there (never in `config.toml`);
-otherwise nbox saves the profile metadata and tells you to use `token_env` or
+otherwise pasted-token saves are blocked and nbox tells you to use `token_env` or
 `NBOX_TOKEN`. `Ctrl+T` test-connects before you commit; `Enter` saves, `Ctrl+G`
 saves and switches to it. Unlike the quick `P` cycle, selecting or adding-and-using
 a profile here **persists** `active_profile` to your config. Deleting the active
@@ -392,9 +393,9 @@ TUI renders without color and marks the selection with a `>` cursor.
 ## Configuration
 
 First-time setup needs no hand-edited TOML: launch `nbox` with no config and the
-TUI runs a first-run wizard that captures a profile (url, token or `token_env`,
-`auth_scheme`, `verify_tls`), test-connects, writes it, and continues into the
-app. The same wizard appears when a config exists but has no resolvable active
+TUI runs a first-run wizard that captures a profile (url, `token_env`/`NBOX_TOKEN`,
+or a pasted token when keyring storage is available), test-connects, writes it,
+and continues into the app. The same wizard appears when a config exists but has no resolvable active
 profile. You can still configure by hand — the file lives at:
 
 | OS | Path |

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ server for AI agents.
 ## Quick Start
 
 First run? Just launch the TUI — with no config it opens a first-run wizard that
-captures a profile (URL plus a keyring-backed or env-backed token source),
-test-connects, and drops you into the app:
+captures a profile, test-connects it, and drops you into the app. The wizard can
+store the token in a persistent OS keyring when this build has one; otherwise it
+keeps you on the portable path and asks for `token_env`/`NBOX_TOKEN` instead.
 
 ```bash
 nbox                              # first run: guided onboarding, then the TUI
@@ -33,7 +34,7 @@ Prefer the shell? Configure a profile by hand:
 ```bash
 nbox profile add work https://netbox.example.com --token-env NETBOX_TOKEN
 nbox profile use work
-export NETBOX_TOKEN=...           # or store the token: nbox config token set
+export NETBOX_TOKEN=...           # portable; desktop keyring builds can use `nbox config token set`
 
 # Look things up from the shell
 nbox search edge01
@@ -206,6 +207,12 @@ all on by default. There are no feature-variant builds to choose between.
 | `keyring` | Yes | OS-keyring token storage (`nbox config token`) |
 | `updates` | Yes | GitHub update notifications |
 | `keyring-secret-service` | No | Linux D-Bus (Secret Service) keyring backend — for desktop packagers |
+
+`keyring` means macOS Keychain / Windows Credential Manager support is compiled
+in. Default Linux and musl builds intentionally do **not** link the D-Bus Secret
+Service backend; on those builds pasted-token saves are blocked and env vars are
+the supported token path. Build with `--features keyring-secret-service` only when
+you want a Linux desktop keyring build.
 
 ```bash
 # Lean stdio-only build (drops all of the above):
@@ -393,10 +400,9 @@ TUI renders without color and marks the selection with a `>` cursor.
 ## Configuration
 
 First-time setup needs no hand-edited TOML: launch `nbox` with no config and the
-TUI runs a first-run wizard that captures a profile (url, `token_env`/`NBOX_TOKEN`,
-or a pasted token when keyring storage is available), test-connects, writes it,
-and continues into the app. The same wizard appears when a config exists but has no resolvable active
-profile. You can still configure by hand — the file lives at:
+TUI runs a first-run wizard that captures a profile, test-connects, writes it, and
+continues into the app. The same wizard appears when a config exists but has no
+resolvable active profile. You can still configure by hand — the file lives at:
 
 | OS | Path |
 |----|------|
@@ -436,10 +442,22 @@ vrf = "graphql"               # rest | graphql
 route_target = "graphql"      # rest | graphql
 ```
 
-Tokens are **never written to config**. nbox resolves them in order: the profile's
-`token_env` variable (if set & present), then `NBOX_TOKEN`, then the OS keyring
-entry for the profile (`nbox config token set` — input hidden, never echoed). Env
-always overrides the keyring. `nbox config token status` shows the active source
+Tokens are **never written to config**. The config stores only profile metadata
+and, optionally, the *name* of an env var (`token_env`), not its value.
+
+Token sources are resolved in this order:
+
+1. the env var named by the profile's `token_env` (if set & present)
+2. `NBOX_TOKEN`
+3. the OS keyring entry for the profile (`nbox config token set`)
+4. none
+
+Use env vars for CI, SSH, Docker, static Linux/musl builds, and anything
+headless. Use the OS keyring for interactive desktop onboarding when the binary
+has a persistent backend: macOS Keychain, Windows Credential Manager, or a Linux
+build with `keyring-secret-service`. Default Linux/musl release binaries have no
+D-Bus keyring backend, so pasted-token saves are refused rather than accepted into
+a non-persistent mock store. `nbox config token status` shows the active source
 (never the token). See [docs/CONFIG.md](docs/CONFIG.md) for the full reference.
 
 ## MCP Server

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -98,9 +98,12 @@ dependency.)
 The TUI onboarding wizard and Config modal follow the same rule. If a pasted
 token cannot be stored in a persistent keyring, the save is blocked and the form
 stays open with guidance to use `token_env`/`NBOX_TOKEN`; nbox does not create a
-profile that pretends a token was saved. If a runtime keyring operation fails
-(for example a locked keychain), profile metadata and keyring changes are rolled
-back together as far as the platform allows.
+profile that pretends a newly pasted token was saved. Explicit token set/clear
+actions fail closed if the runtime keyring operation fails (for example a locked
+keychain), with profile metadata and keyring changes rolled back together as far
+as the platform allows. A profile rename with "keep stored token" is best-effort:
+if the old token cannot be read or copied, the rename still saves and nbox warns
+you to re-enter the token or set `token_env`.
 
 `auth_scheme = "auto"` detects NetBox 4.5+ v2 tokens (`nbt_…` → `Authorization:
 Bearer`) versus legacy v1 tokens (`Authorization: Token`). Force one with

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -48,21 +48,34 @@ mishandle a newer schema.
 
 ## Tokens
 
-Tokens are **never written to config**. nbox resolves them in order:
+Tokens are **never written to config**. The TOML stores profile metadata and,
+optionally, the *name* of an env var (`token_env`), never the token value.
+
+Resolution order:
 
 1. the env var named by the profile's `token_env` (if set & present)
 2. `NBOX_TOKEN`
 3. the OS keyring entry for the profile (`nbox config token set`)
 4. none — nbox reports a clear "no token" error
 
-Env always overrides the keyring: CI/SSH/break-glass paths set an env var, while
-the keyring is for interactive human onboarding. Inspect the active source with
-`nbox config token status` (it prints the source — `token_env`/`NBOX_TOKEN`/
-`keyring`/`none` — never the token).
+Who stores what:
+
+| Source | Where the token lives | What nbox writes to `config.toml` | Best for |
+|--------|------------------------|-----------------------------------|----------|
+| `token_env` | Your shell, systemd unit, CI secret, MCP host env, etc. | The env var name only, e.g. `token_env = "NETBOX_TOKEN"` | CI, SSH, Docker, agents, static Linux/musl |
+| `NBOX_TOKEN` | Your process environment | Nothing | One-off overrides and break-glass runs |
+| OS keyring | macOS Keychain, Windows Credential Manager, or Linux Secret Service when built in | Nothing | Interactive desktop use |
+
+Env always overrides the keyring. This is intentional: CI/SSH/Docker can inject a
+known token without editing config, and a temporary `NBOX_TOKEN` can override a
+desktop keyring entry. Inspect the active source with `nbox config token status`
+(it prints the source — `token_env`/`NBOX_TOKEN`/`keyring`/`none` — never the
+token).
 
 ### OS keyring
 
-Store the token in your OS keyring instead of an env var:
+Store the token in your OS keyring instead of an env var, when this build has a
+real persistent keyring backend:
 
 ```bash
 nbox config token set      # prompts, input hidden (or reads a piped line)
@@ -81,6 +94,13 @@ the Secret Service (D-Bus) backend is **off by default** — build with
 reports the keyring as unavailable and you should use `NBOX_TOKEN` or a
 `token_env` instead. (This keeps static/musl builds free of a D-Bus link
 dependency.)
+
+The TUI onboarding wizard and Config modal follow the same rule. If a pasted
+token cannot be stored in a persistent keyring, the save is blocked and the form
+stays open with guidance to use `token_env`/`NBOX_TOKEN`; nbox does not create a
+profile that pretends a token was saved. If a runtime keyring operation fails
+(for example a locked keychain), profile metadata and keyring changes are rolled
+back together as far as the platform allows.
 
 `auth_scheme = "auto"` detects NetBox 4.5+ v2 tokens (`nbt_…` → `Authorization:
 Bearer`) versus legacy v1 tokens (`Authorization: Token`). Force one with

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -233,8 +233,10 @@ nbox serve --http 0.0.0.0:8080 \
 ### `keyring not available on this system` (Linux)
 
 The default static binary ships no D-Bus (Secret Service) backend, so
-`nbox config token` can't reach a keyring. Use an env var instead, or install a
-build with the Linux backend compiled in:
+`nbox config token` and the TUI pasted-token field cannot persist a token there.
+This is deliberate: without the backend, keyring v3 would fall back to an
+in-process mock store that disappears when nbox exits. Use an env var instead, or
+install a build with the Linux backend compiled in:
 
 ```bash
 export NBOX_TOKEN=...                              # or set the profile's token_env

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -64,42 +64,49 @@ pub const fn keyring_available() -> bool {
     }
 }
 
-/// Read the token for `account` from the OS keyring, or `None` when absent /
-/// unavailable. Never panics; a missing entry, an unusable keystore, or the
-/// feature being off all yield `None` so token resolution simply falls through.
-#[must_use]
-pub fn keyring_get(account: &str) -> Option<String> {
+/// Read the token for `account` from the OS keyring.
+///
+/// A missing entry, unavailable persistent keystore, or feature-off build returns
+/// `Ok(None)`. A real backend failure (locked keychain, D-Bus failure, etc.)
+/// returns an error so transactional callers can avoid committing metadata that
+/// depends on a secret move they could not verify.
+pub fn keyring_get_checked(account: &str) -> anyhow::Result<Option<String>> {
     #[cfg(feature = "keyring")]
     {
         if !keyring_available() {
-            return None;
+            return Ok(None);
         }
-        let entry = match keyring::Entry::new(SERVICE, account) {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::debug!("keyring open failed: {e}");
-                return None;
-            }
-        };
+        let entry = keyring::Entry::new(SERVICE, account)
+            .map_err(|e| anyhow::anyhow!("keyring open failed: {e}"))?;
         match entry.get_password() {
             // An empty stored value is treated as "no token" — an empty string
             // would otherwise flow through `resolve_token` and produce a confusing
             // 401 instead of a clean "no token from any source".
-            Ok(token) => (!token.is_empty()).then_some(token),
+            Ok(token) => Ok((!token.is_empty()).then_some(token)),
             // A missing entry is the normal "no token here" case (silent). A real
-            // backend failure (locked keystore, D-Bus error) is logged at debug so
-            // it's diagnosable, but still returns None so the UI falls through (L5).
-            Err(keyring::Error::NoEntry) => None,
-            Err(e) => {
-                tracing::debug!("keyring read failed: {e}");
-                None
-            }
+            // backend failure is returned so save/rename paths can fail closed.
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(anyhow::anyhow!("keyring read failed: {e}")),
         }
     }
     #[cfg(not(feature = "keyring"))]
     {
         let _ = account;
-        None
+        Ok(None)
+    }
+}
+
+/// Read the token for `account` from the OS keyring, or `None` when absent /
+/// unavailable. Never panics; a missing entry, an unusable keystore, or the
+/// feature being off all yield `None` so token resolution simply falls through.
+#[must_use]
+pub fn keyring_get(account: &str) -> Option<String> {
+    match keyring_get_checked(account) {
+        Ok(token) => token,
+        Err(e) => {
+            tracing::debug!("{e:#}");
+            None
+        }
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -8,7 +8,7 @@ use crate::cache::{Cache, CacheKey};
 use crate::domain::detail::{load_detail, load_detail_by_ref};
 use crate::netbox::client::NetBoxClient;
 use crate::netbox::search::SearchRequest;
-use crate::tui::events::{spawn_preview_ticks, spawn_terminal_events, spawn_ticks};
+use crate::tui::events::{AbortOnDrop, spawn_preview_ticks, spawn_terminal_events, spawn_ticks};
 use crate::tui::state::{App, AppCommand, AppEvent};
 use crate::tui::ui;
 
@@ -61,7 +61,7 @@ async fn event_loop(
     refresh_secs: Option<u64>,
 ) -> Result<()> {
     let (tx, mut rx) = mpsc::channel::<AppEvent>(64);
-    spawn_terminal_events(tx.clone());
+    let _terminal_events = AbortOnDrop::new(spawn_terminal_events(tx.clone()));
     // The preview debounce is always on (independent of the optional auto-refresh).
     spawn_preview_ticks(tx.clone());
     // The auto-refresh ticker, kept as a handle so the Settings section can re-arm

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -5,13 +5,38 @@ use std::time::Duration;
 use crossterm::event::{Event, EventStream, KeyEventKind};
 use futures::StreamExt;
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 
 use crate::tui::state::AppEvent;
 
+/// Abort a spawned task when this guard leaves scope.
+///
+/// Terminal event readers block inside crossterm until input arrives. Relying on
+/// a dropped receiver to stop them means the task can survive a UI phase handoff
+/// and steal the next keypress before it notices the send failed.
+#[must_use]
+pub struct AbortOnDrop<T> {
+    handle: JoinHandle<T>,
+}
+
+impl<T> AbortOnDrop<T> {
+    pub fn new(handle: JoinHandle<T>) -> Self {
+        Self { handle }
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
 /// Spawn a task that reads terminal events and forwards them as [`AppEvent`]s.
-/// Exits when the receiver is dropped.
-pub fn spawn_terminal_events(tx: Sender<AppEvent>) {
+/// Exits when the receiver is dropped after an event is read. The returned handle
+/// should be aborted when the owning UI phase ends, so a pending read cannot leak
+/// across handoffs.
+pub fn spawn_terminal_events(tx: Sender<AppEvent>) -> JoinHandle<()> {
     tokio::spawn(async move {
         let mut stream = EventStream::new();
         while let Some(Ok(event)) = stream.next().await {
@@ -25,7 +50,7 @@ pub fn spawn_terminal_events(tx: Sender<AppEvent>) {
                 break;
             }
         }
-    });
+    })
 }
 
 /// Spawn a task that emits [`AppEvent::Tick`] every `secs` seconds. Exits when

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -17,6 +17,7 @@ pub mod filter_modal;
 pub mod fuzzy;
 pub mod onboarding;
 pub mod palette;
+pub mod profile_token;
 pub mod state;
 pub mod term;
 pub mod theme;

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -35,8 +35,9 @@ use tokio::sync::mpsc;
 
 use crate::netbox::auth::AuthScheme;
 use crate::netbox::client::NetBoxClient;
-use crate::tui::config_modal::{ProfileForm, TestState, field};
+use crate::tui::config_modal::{ProfileForm, TestState, TokenAction, field};
 use crate::tui::events::{AbortOnDrop, spawn_terminal_events};
+use crate::tui::profile_token::PreparedTokenChange;
 use crate::tui::state::{AppEvent, ConnectRequest};
 use crate::tui::theme::Theme;
 
@@ -190,18 +191,18 @@ pub struct PersistOutcome {
     pub needs_env_guidance: bool,
 }
 
-/// Persist the wizard's profile: write the metadata (format-preserving) via the
-/// same setters the editor uses, then store a typed token in the OS keyring when
-/// one was given and the keyring is available. The interactive wizard validates
-/// that case before calling this, so a pasted token is not silently accepted on
-/// builds with no persistent keyring. Returns a [`PersistOutcome`]
-/// describing what happened so the driver can guide the user when no token landed
-/// anywhere. The token is NEVER written to TOML.
+/// Persist the wizard's profile: prepare a typed-token keyring write first, then
+/// write the metadata (format-preserving) via the same setters the editor uses.
+/// If the metadata write fails, the keyring change is rolled back. The
+/// interactive wizard validates the no-keyring case before calling this, and any
+/// runtime keyring write failure keeps the user in the wizard instead of creating
+/// a profile without the pasted token. Returns a [`PersistOutcome`] describing
+/// what happened so the driver can guide the user when no token source was given.
+/// The token is NEVER written to TOML.
 ///
 /// Pure but for the file/keyring writes (mirroring the editor's profile save plus
-/// keyring set on the render thread). The keyring being unavailable is **not** an
-/// error at this layer — the metadata still saves and `token_env` is persisted
-/// when given. The UI guard decides whether to keep the user in the wizard.
+/// keyring set on the render thread). Metadata-only and `token_env`-backed
+/// profiles save without touching the keyring.
 pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     let name = form.name();
     let url = form.url();
@@ -242,18 +243,17 @@ pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
         form.api_route_target,
     )?;
     crate::config::set_active_profile(&mut doc, &name);
-    crate::config::write_doc(path, &doc)?;
 
-    // A typed token goes to the OS keyring (never TOML). Keyring-unavailable is
-    // not fatal at this low-level writer — the interactive wizard blocks this
-    // path before saving, while direct tests/uses report env guidance below.
-    let mut stored_in_keyring = false;
-    if let Some(token) = &token {
-        let account = crate::secret::account_key(&path.display().to_string(), &name);
-        if crate::secret::keyring_set(&account, token).is_ok() {
-            stored_in_keyring = true;
-        }
+    let token_action = token
+        .as_ref()
+        .map_or(TokenAction::Keep, |token| TokenAction::Set(token.clone()));
+    let token_change = PreparedTokenChange::prepare(path, None, &name, &token_action)?;
+    if let Err(e) = crate::config::write_doc(path, &doc) {
+        token_change.rollback();
+        return Err(e);
     }
+    let stored_in_keyring = token_change.stored_token();
+    let _ = token_change.commit();
 
     // If nothing authenticatable landed — no keyring entry and no token_env — the
     // user must export NBOX_TOKEN or set a token_env to connect.

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -3,7 +3,7 @@
 //! When the TUI launches with no usable config (no file, no profiles, or no
 //! resolvable active profile — see [`crate::config::needs_onboarding`]) we run a
 //! short guided wizard instead of dying with "run `nbox config init`". It
-//! captures one profile (name, url, token/token_env, auth_scheme, verify_tls),
+//! captures one profile (name, url, token source, auth_scheme, verify_tls),
 //! reusing Phase B's [`ProfileForm`]/`FormInput` add-form and its
 //! test-connect/`verify_compatible` path verbatim — no re-implemented
 //! form/validation/probe. On success it writes the profile via the same config
@@ -13,9 +13,9 @@
 //! keyring, and returns the chosen profile name so `run_tui` continues into the
 //! normal `App` with that profile active.
 //!
-//! Keyring-unavailable path: the wizard still completes. The metadata is saved
-//! and `token_env` is persisted when given; we surface env-var guidance rather
-//! than hard-failing because the keychain is missing.
+//! Keyring-unavailable path: a pasted token cannot be stored, so save is blocked
+//! with guidance to use `token_env`/`NBOX_TOKEN` instead. Metadata-only profiles
+//! can still be saved intentionally.
 //!
 //! The state + key handling here are PURE (no terminal, no network): [`handle_key`]
 //! is a state transition returning a [`WizardAction`] the driver acts on, and
@@ -36,7 +36,7 @@ use tokio::sync::mpsc;
 use crate::netbox::auth::AuthScheme;
 use crate::netbox::client::NetBoxClient;
 use crate::tui::config_modal::{ProfileForm, TestState, field};
-use crate::tui::events::spawn_terminal_events;
+use crate::tui::events::{AbortOnDrop, spawn_terminal_events};
 use crate::tui::state::{AppEvent, ConnectRequest};
 use crate::tui::theme::Theme;
 
@@ -116,7 +116,7 @@ impl OnboardingWizard {
                     WizardAction::None
                 }
             },
-            KeyCode::Enter => match self.form.validate() {
+            KeyCode::Enter => match validate_for_onboarding_save(&self.form) {
                 Ok(()) => WizardAction::Save,
                 Err(e) => {
                     self.form.message = Some(e);
@@ -160,6 +160,22 @@ impl OnboardingWizard {
     }
 }
 
+/// Onboarding-specific save validation.
+///
+/// The shared profile form only checks syntax. First-run onboarding also has to
+/// prevent a misleading "saved" path when the user pasted a token but this build
+/// has no persistent keyring backend to store it.
+fn validate_for_onboarding_save(form: &ProfileForm) -> Result<(), String> {
+    form.validate()?;
+    if form.token().is_some() && !crate::secret::keyring_available() {
+        return Err(
+            "this build can't store pasted tokens; clear token and use token_env or NBOX_TOKEN"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// What [`persist`] did, so the driver can show the right status / steer the user.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PersistOutcome {
@@ -176,13 +192,16 @@ pub struct PersistOutcome {
 
 /// Persist the wizard's profile: write the metadata (format-preserving) via the
 /// same setters the editor uses, then store a typed token in the OS keyring when
-/// one was given and the keyring is available. Returns a [`PersistOutcome`]
+/// one was given and the keyring is available. The interactive wizard validates
+/// that case before calling this, so a pasted token is not silently accepted on
+/// builds with no persistent keyring. Returns a [`PersistOutcome`]
 /// describing what happened so the driver can guide the user when no token landed
 /// anywhere. The token is NEVER written to TOML.
 ///
 /// Pure but for the file/keyring writes (mirroring the editor's profile save plus
 /// keyring set on the render thread). The keyring being unavailable is **not** an
-/// error — the metadata still saves and `token_env` is persisted when given.
+/// error at this layer — the metadata still saves and `token_env` is persisted
+/// when given. The UI guard decides whether to keep the user in the wizard.
 pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     let name = form.name();
     let url = form.url();
@@ -226,7 +245,8 @@ pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     crate::config::write_doc(path, &doc)?;
 
     // A typed token goes to the OS keyring (never TOML). Keyring-unavailable is
-    // not fatal — the metadata is already saved; we fall back to env guidance.
+    // not fatal at this low-level writer — the interactive wizard blocks this
+    // path before saving, while direct tests/uses report env guidance below.
     let mut stored_in_keyring = false;
     if let Some(token) = &token {
         let account = crate::secret::account_key(&path.display().to_string(), &name);
@@ -262,7 +282,7 @@ pub async fn run(
     theme: &Theme,
 ) -> Result<Option<PersistOutcome>> {
     let (tx, mut rx) = mpsc::channel::<AppEvent>(64);
-    spawn_terminal_events(tx.clone());
+    let _terminal_events = AbortOnDrop::new(spawn_terminal_events(tx.clone()));
 
     let mut wizard = OnboardingWizard::new();
     // Latest-test-wins guard: each test bumps `test_seq`; a `ConnectTested` with
@@ -511,6 +531,29 @@ mod tests {
         // Type a valid url ⇒ Enter saves.
         type_into(&mut w, "https://nb.example");
         assert_eq!(w.handle_key(key(KeyCode::Enter)), WizardAction::Save);
+    }
+
+    #[test]
+    fn enter_blocks_pasted_token_when_keyring_is_unavailable() {
+        if crate::secret::keyring_available() {
+            return;
+        }
+        let mut w = OnboardingWizard::new();
+        type_into(&mut w, "https://nb.example");
+        for _ in field::URL..field::TOKEN {
+            w.handle_key(key(KeyCode::Tab));
+        }
+        type_into(&mut w, "nbt_secret");
+
+        assert_eq!(w.handle_key(key(KeyCode::Enter)), WizardAction::None);
+        assert!(
+            w.form
+                .message
+                .as_deref()
+                .is_some_and(|m| m.contains("can't store pasted tokens")),
+            "message: {:?}",
+            w.form.message
+        );
     }
 
     #[test]

--- a/src/tui/profile_token.rs
+++ b/src/tui/profile_token.rs
@@ -38,6 +38,7 @@ impl SecretOps for RealSecretOps {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TokenNotice {
     Cleared,
+    MigrationSkipped,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +50,7 @@ struct SecretSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PreparedKind {
     None,
+    Notice(TokenNotice),
     Set {
         new_key: String,
         old_key: Option<String>,
@@ -103,7 +105,7 @@ impl PreparedTokenChange {
         match action {
             TokenAction::Set(token) => Self::prepare_set(ops, new_key, old_key, token),
             TokenAction::Clear => Self::prepare_clear(ops, new_key, old_key),
-            TokenAction::Keep => Self::prepare_keep(ops, new_key, old_key),
+            TokenAction::Keep => Ok(Self::prepare_keep(ops, new_key, old_key)),
         }
     }
 
@@ -171,27 +173,35 @@ impl PreparedTokenChange {
         })
     }
 
-    fn prepare_keep<O: SecretOps>(
-        ops: &O,
-        new_key: String,
-        old_key: Option<String>,
-    ) -> Result<Self> {
+    fn prepare_keep<O: SecretOps>(ops: &O, new_key: String, old_key: Option<String>) -> Self {
         let Some(old_key) = old_key else {
-            return Ok(Self {
+            return Self {
                 kind: PreparedKind::None,
-            });
+            };
         };
-        let Some(existing) = ops
-            .get(&old_key)
-            .map_err(|e| anyhow::anyhow!("could not read stored token before rename ({e:#})"))?
-        else {
-            return Ok(Self {
-                kind: PreparedKind::None,
-            });
+        let existing = match ops.get(&old_key) {
+            Ok(Some(existing)) => existing,
+            Ok(None) => {
+                return Self {
+                    kind: PreparedKind::None,
+                };
+            }
+            Err(e) => {
+                tracing::debug!("could not read stored token before rename: {e:#}");
+                return Self {
+                    kind: PreparedKind::Notice(TokenNotice::MigrationSkipped),
+                };
+            }
         };
-        let previous_new = ops.get(&new_key).map_err(|e| {
-            anyhow::anyhow!("could not read destination stored token before rename ({e:#})")
-        })?;
+        let previous_new = match ops.get(&new_key) {
+            Ok(value) => value,
+            Err(e) => {
+                tracing::debug!("could not read destination stored token before rename: {e:#}");
+                return Self {
+                    kind: PreparedKind::Notice(TokenNotice::MigrationSkipped),
+                };
+            }
+        };
         if let Err(e) = ops.set(&new_key, &existing) {
             restore_snapshot(
                 ops,
@@ -200,17 +210,18 @@ impl PreparedTokenChange {
                     value: previous_new.clone(),
                 },
             );
-            anyhow::bail!(
-                "stored token was NOT migrated to the new name ({e:#}); re-enter it or set a token_env"
-            );
+            tracing::debug!("stored token was not migrated to the new profile name: {e:#}");
+            return Self {
+                kind: PreparedKind::Notice(TokenNotice::MigrationSkipped),
+            };
         }
-        Ok(Self {
+        Self {
             kind: PreparedKind::RenameKeep {
                 new_key,
                 old_key,
                 previous_new,
             },
-        })
+        }
     }
 
     pub(crate) fn stored_token(&self) -> bool {
@@ -224,6 +235,7 @@ impl PreparedTokenChange {
     fn commit_with_ops<O: SecretOps>(self, ops: &O) -> Option<TokenNotice> {
         match self.kind {
             PreparedKind::None => None,
+            PreparedKind::Notice(notice) => Some(notice),
             PreparedKind::Set { old_key, .. } => {
                 if let Some(old_key) = old_key
                     && let Err(e) = ops.delete(&old_key)
@@ -248,7 +260,7 @@ impl PreparedTokenChange {
 
     fn rollback_with_ops<O: SecretOps>(&self, ops: &O) {
         match &self.kind {
-            PreparedKind::None => {}
+            PreparedKind::None | PreparedKind::Notice(_) => {}
             PreparedKind::Set {
                 new_key,
                 previous_new,
@@ -298,6 +310,7 @@ mod tests {
     #[derive(Default)]
     struct FakeSecretOps {
         entries: RefCell<HashMap<String, String>>,
+        fail_get: RefCell<HashSet<String>>,
         fail_set: RefCell<HashSet<String>>,
         fail_delete: RefCell<HashSet<String>>,
     }
@@ -320,6 +333,9 @@ mod tests {
 
     impl SecretOps for FakeSecretOps {
         fn get(&self, account: &str) -> Result<Option<String>> {
+            if self.fail_get.borrow().contains(account) {
+                anyhow::bail!("injected get failure");
+            }
             Ok(self.entries.borrow().get(account).cloned())
         }
 
@@ -446,6 +462,30 @@ mod tests {
             ops.get_entry(path, "new").as_deref(),
             Some("existing-new-token")
         );
+    }
+
+    #[test]
+    fn rename_keep_get_failure_is_best_effort_warning() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+        ops.fail_get
+            .borrow_mut()
+            .insert(FakeSecretOps::key(path, "old"));
+
+        let prepared = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            Some("old"),
+            "new",
+            &TokenAction::Keep,
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared.commit_with_ops(&ops),
+            Some(TokenNotice::MigrationSkipped)
+        );
+        assert_eq!(ops.get_entry(path, "new"), None);
     }
 
     #[test]

--- a/src/tui/profile_token.rs
+++ b/src/tui/profile_token.rs
@@ -1,0 +1,472 @@
+//! Transactional keyring changes for profile saves.
+//!
+//! Profile metadata and profile tokens live in different stores (`config.toml`
+//! and the OS keyring). A save that changes both has to prepare the keyring
+//! mutation before writing the file, then roll it back if the file write fails.
+//! That avoids the two bad half-states: a profile that says it saved but has no
+//! token, or a token orphaned under a profile that never landed in the config.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::tui::config_modal::TokenAction;
+
+/// Abstracts the keyring for focused transaction tests.
+pub(crate) trait SecretOps {
+    fn get(&self, account: &str) -> Result<Option<String>>;
+    fn set(&self, account: &str, token: &str) -> Result<()>;
+    fn delete(&self, account: &str) -> Result<()>;
+}
+
+pub(crate) struct RealSecretOps;
+
+impl SecretOps for RealSecretOps {
+    fn get(&self, account: &str) -> Result<Option<String>> {
+        crate::secret::keyring_get_checked(account)
+    }
+
+    fn set(&self, account: &str, token: &str) -> Result<()> {
+        crate::secret::keyring_set(account, token)
+    }
+
+    fn delete(&self, account: &str) -> Result<()> {
+        crate::secret::keyring_delete(account)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TokenNotice {
+    Cleared,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SecretSnapshot {
+    key: String,
+    value: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PreparedKind {
+    None,
+    Set {
+        new_key: String,
+        old_key: Option<String>,
+        previous_new: Option<String>,
+    },
+    Clear {
+        snapshots: Vec<SecretSnapshot>,
+    },
+    RenameKeep {
+        new_key: String,
+        old_key: String,
+        previous_new: Option<String>,
+    },
+}
+
+/// A keyring mutation that has already been applied far enough for the config
+/// write to proceed. Call `commit` after the TOML write succeeds, or `rollback`
+/// after it fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedTokenChange {
+    kind: PreparedKind,
+}
+
+impl PreparedTokenChange {
+    pub(crate) fn prepare(
+        path: &Path,
+        original: Option<&str>,
+        name: &str,
+        action: &TokenAction,
+    ) -> Result<Self> {
+        Self::prepare_with_ops(
+            &RealSecretOps,
+            &path.display().to_string(),
+            original,
+            name,
+            action,
+        )
+    }
+
+    fn prepare_with_ops<O: SecretOps>(
+        ops: &O,
+        path: &str,
+        original: Option<&str>,
+        name: &str,
+        action: &TokenAction,
+    ) -> Result<Self> {
+        let new_key = crate::secret::account_key(path, name);
+        let old_key = original
+            .filter(|orig| *orig != name)
+            .map(|orig| crate::secret::account_key(path, orig));
+
+        match action {
+            TokenAction::Set(token) => Self::prepare_set(ops, new_key, old_key, token),
+            TokenAction::Clear => Self::prepare_clear(ops, new_key, old_key),
+            TokenAction::Keep => Self::prepare_keep(ops, new_key, old_key),
+        }
+    }
+
+    fn prepare_set<O: SecretOps>(
+        ops: &O,
+        new_key: String,
+        old_key: Option<String>,
+        token: &str,
+    ) -> Result<Self> {
+        let previous_new = ops
+            .get(&new_key)
+            .map_err(|e| anyhow::anyhow!("could not read existing stored token ({e:#})"))?;
+        if let Err(e) = ops.set(&new_key, token) {
+            restore_snapshot(
+                ops,
+                &SecretSnapshot {
+                    key: new_key.clone(),
+                    value: previous_new.clone(),
+                },
+            );
+            anyhow::bail!(
+                "pasted token was NOT stored ({e:#}); clear it and use token_env/NBOX_TOKEN or enable keyring storage"
+            );
+        }
+        Ok(Self {
+            kind: PreparedKind::Set {
+                new_key,
+                old_key,
+                previous_new,
+            },
+        })
+    }
+
+    fn prepare_clear<O: SecretOps>(
+        ops: &O,
+        new_key: String,
+        old_key: Option<String>,
+    ) -> Result<Self> {
+        let mut snapshots = Vec::with_capacity(if old_key.is_some() { 2 } else { 1 });
+        let mut keys = vec![new_key];
+        if let Some(old) = old_key
+            && !keys.iter().any(|key| key == &old)
+        {
+            keys.push(old);
+        }
+
+        for key in keys {
+            let snapshot = SecretSnapshot {
+                value: ops.get(&key).map_err(|e| {
+                    anyhow::anyhow!("could not read stored token before clear ({e:#})")
+                })?,
+                key,
+            };
+            if let Err(e) = ops.delete(&snapshot.key) {
+                rollback_snapshots(ops, &snapshots);
+                anyhow::bail!(
+                    "stored token was NOT cleared ({e:#}); try again or clear it outside nbox"
+                );
+            }
+            snapshots.push(snapshot);
+        }
+
+        Ok(Self {
+            kind: PreparedKind::Clear { snapshots },
+        })
+    }
+
+    fn prepare_keep<O: SecretOps>(
+        ops: &O,
+        new_key: String,
+        old_key: Option<String>,
+    ) -> Result<Self> {
+        let Some(old_key) = old_key else {
+            return Ok(Self {
+                kind: PreparedKind::None,
+            });
+        };
+        let Some(existing) = ops
+            .get(&old_key)
+            .map_err(|e| anyhow::anyhow!("could not read stored token before rename ({e:#})"))?
+        else {
+            return Ok(Self {
+                kind: PreparedKind::None,
+            });
+        };
+        let previous_new = ops.get(&new_key).map_err(|e| {
+            anyhow::anyhow!("could not read destination stored token before rename ({e:#})")
+        })?;
+        if let Err(e) = ops.set(&new_key, &existing) {
+            restore_snapshot(
+                ops,
+                &SecretSnapshot {
+                    key: new_key.clone(),
+                    value: previous_new.clone(),
+                },
+            );
+            anyhow::bail!(
+                "stored token was NOT migrated to the new name ({e:#}); re-enter it or set a token_env"
+            );
+        }
+        Ok(Self {
+            kind: PreparedKind::RenameKeep {
+                new_key,
+                old_key,
+                previous_new,
+            },
+        })
+    }
+
+    pub(crate) fn stored_token(&self) -> bool {
+        matches!(self.kind, PreparedKind::Set { .. })
+    }
+
+    pub(crate) fn commit(self) -> Option<TokenNotice> {
+        self.commit_with_ops(&RealSecretOps)
+    }
+
+    fn commit_with_ops<O: SecretOps>(self, ops: &O) -> Option<TokenNotice> {
+        match self.kind {
+            PreparedKind::None => None,
+            PreparedKind::Set { old_key, .. } => {
+                if let Some(old_key) = old_key
+                    && let Err(e) = ops.delete(&old_key)
+                {
+                    tracing::debug!("failed to delete old keyring entry after profile save: {e:#}");
+                }
+                None
+            }
+            PreparedKind::RenameKeep { old_key, .. } => {
+                if let Err(e) = ops.delete(&old_key) {
+                    tracing::debug!("failed to delete old keyring entry after profile save: {e:#}");
+                }
+                None
+            }
+            PreparedKind::Clear { .. } => Some(TokenNotice::Cleared),
+        }
+    }
+
+    pub(crate) fn rollback(&self) {
+        self.rollback_with_ops(&RealSecretOps);
+    }
+
+    fn rollback_with_ops<O: SecretOps>(&self, ops: &O) {
+        match &self.kind {
+            PreparedKind::None => {}
+            PreparedKind::Set {
+                new_key,
+                previous_new,
+                ..
+            }
+            | PreparedKind::RenameKeep {
+                new_key,
+                previous_new,
+                ..
+            } => {
+                restore_snapshot(
+                    ops,
+                    &SecretSnapshot {
+                        key: new_key.clone(),
+                        value: previous_new.clone(),
+                    },
+                );
+            }
+            PreparedKind::Clear { snapshots } => rollback_snapshots(ops, snapshots),
+        }
+    }
+}
+
+fn rollback_snapshots<O: SecretOps>(ops: &O, snapshots: &[SecretSnapshot]) {
+    for snapshot in snapshots.iter().rev() {
+        restore_snapshot(ops, snapshot);
+    }
+}
+
+fn restore_snapshot<O: SecretOps>(ops: &O, snapshot: &SecretSnapshot) {
+    let result = match &snapshot.value {
+        Some(token) => ops.set(&snapshot.key, token),
+        None => ops.delete(&snapshot.key),
+    };
+    if let Err(e) = result {
+        tracing::debug!("failed to restore keyring entry during profile-save rollback: {e:#}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::{HashMap, HashSet};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeSecretOps {
+        entries: RefCell<HashMap<String, String>>,
+        fail_set: RefCell<HashSet<String>>,
+        fail_delete: RefCell<HashSet<String>>,
+    }
+
+    impl FakeSecretOps {
+        fn key(path: &str, name: &str) -> String {
+            crate::secret::account_key(path, name)
+        }
+
+        fn insert(&self, path: &str, name: &str, token: &str) {
+            self.entries
+                .borrow_mut()
+                .insert(Self::key(path, name), token.to_string());
+        }
+
+        fn get_entry(&self, path: &str, name: &str) -> Option<String> {
+            self.entries.borrow().get(&Self::key(path, name)).cloned()
+        }
+    }
+
+    impl SecretOps for FakeSecretOps {
+        fn get(&self, account: &str) -> Result<Option<String>> {
+            Ok(self.entries.borrow().get(account).cloned())
+        }
+
+        fn set(&self, account: &str, token: &str) -> Result<()> {
+            if self.fail_set.borrow().contains(account) {
+                anyhow::bail!("injected set failure");
+            }
+            self.entries
+                .borrow_mut()
+                .insert(account.to_string(), token.to_string());
+            Ok(())
+        }
+
+        fn delete(&self, account: &str) -> Result<()> {
+            if self.fail_delete.borrow().contains(account) {
+                anyhow::bail!("injected delete failure");
+            }
+            self.entries.borrow_mut().remove(account);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn set_restores_previous_secret_on_rollback() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+        ops.insert(path, "lab", "old-token");
+
+        let prepared = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            Some("lab"),
+            "lab",
+            &TokenAction::Set("new-token".to_string()),
+        )
+        .unwrap();
+        assert_eq!(ops.get_entry(path, "lab").as_deref(), Some("new-token"));
+
+        prepared.rollback_with_ops(&ops);
+        assert_eq!(ops.get_entry(path, "lab").as_deref(), Some("old-token"));
+    }
+
+    #[test]
+    fn set_deletes_new_secret_on_add_rollback() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+
+        let prepared = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            None,
+            "lab",
+            &TokenAction::Set("new-token".to_string()),
+        )
+        .unwrap();
+        assert_eq!(ops.get_entry(path, "lab").as_deref(), Some("new-token"));
+
+        prepared.rollback_with_ops(&ops);
+        assert_eq!(ops.get_entry(path, "lab"), None);
+    }
+
+    #[test]
+    fn clear_restores_deleted_secret_on_rollback() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+        ops.insert(path, "lab", "old-token");
+
+        let prepared = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            Some("lab"),
+            "lab",
+            &TokenAction::Clear,
+        )
+        .unwrap();
+        assert_eq!(ops.get_entry(path, "lab"), None);
+
+        prepared.rollback_with_ops(&ops);
+        assert_eq!(ops.get_entry(path, "lab").as_deref(), Some("old-token"));
+    }
+
+    #[test]
+    fn rename_keep_copies_then_commits_old_key_delete() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+        ops.insert(path, "old", "old-token");
+
+        let prepared = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            Some("old"),
+            "new",
+            &TokenAction::Keep,
+        )
+        .unwrap();
+        assert_eq!(ops.get_entry(path, "old").as_deref(), Some("old-token"));
+        assert_eq!(ops.get_entry(path, "new").as_deref(), Some("old-token"));
+
+        assert_eq!(prepared.commit_with_ops(&ops), None);
+        assert_eq!(ops.get_entry(path, "old"), None);
+        assert_eq!(ops.get_entry(path, "new").as_deref(), Some("old-token"));
+    }
+
+    #[test]
+    fn rename_keep_restores_destination_on_rollback() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+        ops.insert(path, "old", "old-token");
+        ops.insert(path, "new", "existing-new-token");
+
+        let prepared = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            Some("old"),
+            "new",
+            &TokenAction::Keep,
+        )
+        .unwrap();
+        assert_eq!(ops.get_entry(path, "new").as_deref(), Some("old-token"));
+
+        prepared.rollback_with_ops(&ops);
+        assert_eq!(ops.get_entry(path, "old").as_deref(), Some("old-token"));
+        assert_eq!(
+            ops.get_entry(path, "new").as_deref(),
+            Some("existing-new-token")
+        );
+    }
+
+    #[test]
+    fn prepare_set_failure_keeps_previous_secret() {
+        let ops = FakeSecretOps::default();
+        let path = "/tmp/nbox/config.toml";
+        ops.insert(path, "lab", "old-token");
+        ops.fail_set
+            .borrow_mut()
+            .insert(FakeSecretOps::key(path, "lab"));
+
+        let err = PreparedTokenChange::prepare_with_ops(
+            &ops,
+            path,
+            Some("lab"),
+            "lab",
+            &TokenAction::Set("new-token".to_string()),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("pasted token was NOT stored"));
+        assert_eq!(ops.get_entry(path, "lab").as_deref(), Some("old-token"));
+    }
+}

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -2391,8 +2391,12 @@ impl App {
     }
 
     fn token_notice_status(notice: Option<TokenNotice>) -> Option<(String, Severity)> {
-        notice.map(|TokenNotice::Cleared| {
-            ("saved — stored token cleared".to_string(), Severity::Info)
+        notice.map(|notice| match notice {
+            TokenNotice::Cleared => ("saved — stored token cleared".to_string(), Severity::Info),
+            TokenNotice::MigrationSkipped => (
+                "saved — could not migrate the stored token to the new name; re-enter it or set a token_env".to_string(),
+                Severity::Warning,
+            ),
         })
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -2209,6 +2209,12 @@ impl App {
             return Vec::new();
         };
 
+        if let Some(message) = Self::token_action_preflight_error(&token_action) {
+            self.set_form_error(message.clone());
+            self.set_status(message, Severity::Error);
+            return Vec::new();
+        }
+
         // Write the metadata to the config file (format-preserving). The token is
         // NEVER written here. On a rename the old TOML section is removed (H1).
         if let Err(e) = Self::persist_profile(
@@ -2233,15 +2239,18 @@ impl App {
 
         // Reconcile the OS-keyring token (H2/H3/H5): store a new value, clear on the
         // explicit clear intent, or migrate the existing entry across a rename. The
-        // token is never written to TOML; a keyring-unavailable store surfaces a
-        // clear warning so the user knows the token did NOT land anywhere.
-        let token_status = Self::apply_token_change(
-            &path,
-            original.as_deref(),
-            &name,
-            &token_action,
-            token_env.is_some(),
-        );
+        // token is never written to TOML; a failed explicit set/clear keeps the user
+        // in the form so the UI can't imply a token landed when it did not.
+        let token_status =
+            match Self::apply_token_change(&path, original.as_deref(), &name, &token_action) {
+                Ok(status) => status,
+                Err(e) => {
+                    let message = format!("token save failed: {e:#}");
+                    self.set_form_error(message.clone());
+                    self.set_status(message, Severity::Error);
+                    return Vec::new();
+                }
+            };
 
         // Build the live profile entry from the form + reflect it into `profiles`.
         // The form now owns timeout/page_size/exclude/api too, so these come
@@ -2299,6 +2308,14 @@ impl App {
             None => self.set_status(format!("saved profile '{name}'"), Severity::Success),
         }
         Vec::new()
+    }
+
+    fn set_form_error(&mut self, message: String) {
+        if let Some(Modal::Config(modal)) = &mut self.modal
+            && let Some(form) = modal.form_mut()
+        {
+            form.message = Some(message);
+        }
     }
 
     /// Persist a profile's editor metadata to the config file (format-preserving).
@@ -2373,13 +2390,13 @@ impl App {
 
     /// Reconcile the OS-keyring token for a profile save (H2/H3/H5). Returns an
     /// optional `(message, severity)` to surface when something noteworthy happened
-    /// (a dropped token, a clear, a migration) — `None` on the quiet happy path.
+    /// (a clear or best-effort migration warning) — `None` on the quiet happy path.
     ///
     /// The token value never appears in the returned message or any log.
     ///
-    /// - [`TokenAction::Set`]: store the new token under the (new) key. If the
-    ///   keyring is unavailable, the token is NOT stored — warn the user clearly and
-    ///   point them at `token_env`/`NBOX_TOKEN`. On a rename, also delete the old key.
+    /// - [`TokenAction::Set`]: store the new token under the (new) key. If storage
+    ///   fails, return an error; on a rename, delete the old key only after the new
+    ///   token is safely stored.
     /// - [`TokenAction::Clear`]: delete the entry under the current (and, on rename,
     ///   the old) key.
     /// - [`TokenAction::Keep`]: leave the value; on a rename, migrate the existing
@@ -2389,8 +2406,7 @@ impl App {
         original: Option<&str>,
         name: &str,
         action: &crate::tui::config_modal::TokenAction,
-        has_token_env: bool,
-    ) -> Option<(String, Severity)> {
+    ) -> anyhow::Result<Option<(String, Severity)>> {
         use crate::tui::config_modal::TokenAction;
         let path_str = path.display().to_string();
         let new_key = crate::secret::account_key(&path_str, name);
@@ -2401,28 +2417,38 @@ impl App {
 
         match action {
             TokenAction::Set(token) => {
-                // Drop any old-key entry first (rename), then store under the new key.
-                if let Some(old) = &old_key {
-                    let _ = crate::secret::keyring_delete(old);
+                crate::secret::keyring_set(&new_key, token).map_err(|e| {
+                    anyhow::anyhow!(
+                        "pasted token was NOT stored ({e}); clear it and use token_env/NBOX_TOKEN or enable keyring storage"
+                    )
+                })?;
+                // If this was a rename, remove the old-key entry only after the new
+                // token is safely stored, so a write failure can't strand the profile
+                // without its previous secret.
+                if let Some(old) = &old_key
+                    && let Err(e) = crate::secret::keyring_delete(old)
+                {
+                    tracing::debug!("failed to delete old keyring entry after token set: {e:#}");
                 }
-                match crate::secret::keyring_set(&new_key, token) {
-                    Ok(()) => None,
-                    Err(_) => Some((
-                        if has_token_env {
-                            "saved — keyring unavailable, token NOT stored; the token_env will be used".to_string()
-                        } else {
-                            "saved, but the token was NOT stored: keyring unavailable — set a token_env or export NBOX_TOKEN".to_string()
-                        },
-                        Severity::Warning,
-                    )),
-                }
+                Ok(None)
             }
             TokenAction::Clear => {
-                let _ = crate::secret::keyring_delete(&new_key);
+                crate::secret::keyring_delete(&new_key).map_err(|e| {
+                    anyhow::anyhow!(
+                        "stored token was NOT cleared ({e}); try again or clear it outside nbox"
+                    )
+                })?;
                 if let Some(old) = &old_key {
-                    let _ = crate::secret::keyring_delete(old);
+                    crate::secret::keyring_delete(old).map_err(|e| {
+                        anyhow::anyhow!(
+                            "old stored token was NOT cleared after rename ({e}); try again or clear it outside nbox"
+                        )
+                    })?;
                 }
-                Some(("saved — stored token cleared".to_string(), Severity::Info))
+                Ok(Some((
+                    "saved — stored token cleared".to_string(),
+                    Severity::Info,
+                )))
             }
             TokenAction::Keep => {
                 // Migrate the existing entry across a rename so auth follows the name.
@@ -2432,14 +2458,31 @@ impl App {
                     let migrated = crate::secret::keyring_set(&new_key, &existing).is_ok();
                     let _ = crate::secret::keyring_delete(old);
                     if !migrated {
-                        return Some((
+                        return Ok(Some((
                             "saved — could not migrate the stored token to the new name; re-enter it or set a token_env".to_string(),
                             Severity::Warning,
-                        ));
+                        )));
                     }
                 }
-                None
+                Ok(None)
             }
+        }
+    }
+
+    fn token_action_preflight_error(
+        action: &crate::tui::config_modal::TokenAction,
+    ) -> Option<String> {
+        use crate::tui::config_modal::TokenAction;
+        match action {
+            TokenAction::Set(_) if !crate::secret::keyring_available() => Some(
+                "this build can't store pasted tokens; clear token and use token_env or NBOX_TOKEN"
+                    .to_string(),
+            ),
+            TokenAction::Clear if !crate::secret::keyring_available() => Some(
+                "this build has no keyring to clear; remove token_env/NBOX_TOKEN instead"
+                    .to_string(),
+            ),
+            _ => None,
         }
     }
 
@@ -7471,8 +7514,7 @@ mod tests {
         a.handle_event(press(KeyCode::Tab));
         type_form(&mut a, "https://nb.lab"); // url
         a.handle_event(press(KeyCode::Tab)); // → token_env
-        a.handle_event(press(KeyCode::Tab)); // → token (masked)
-        type_form(&mut a, "nbt_supersecret.value"); // token → keyring only
+        type_form(&mut a, "NETBOX_TOKEN"); // env-backed token source
         // Enter saves (no test required).
         let cmds = a.handle_event(press(KeyCode::Enter));
         assert!(cmds.is_empty(), "plain save does not switch");
@@ -7482,6 +7524,7 @@ mod tests {
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.contains("[profiles.lab]"));
         assert!(text.contains("https://nb.lab"));
+        assert!(text.contains("token_env = \"NETBOX_TOKEN\""));
         assert!(
             !text.contains("nbt_supersecret"),
             "the token must never be written to TOML"
@@ -7489,6 +7532,53 @@ mod tests {
         // Back on the list, the saved profile is selected.
         if let Some(Modal::Config(m)) = &a.modal {
             assert!(matches!(m.profiles.mode, ProfilesMode::List { .. }));
+        }
+    }
+
+    #[test]
+    fn add_profile_with_pasted_token_blocks_when_keyring_is_unavailable() {
+        if crate::secret::keyring_available() {
+            return;
+        }
+        let (mut a, _dir, path) = app_with_config(&["alpha"]);
+        a.handle_event(press(KeyCode::Char('S'))); // open modal
+        a.handle_event(press(KeyCode::Char('a'))); // add form
+        type_form(&mut a, "lab"); // name
+        a.handle_event(press(KeyCode::Tab));
+        type_form(&mut a, "https://nb.lab"); // url
+        a.handle_event(press(KeyCode::Tab)); // → token_env
+        a.handle_event(press(KeyCode::Tab)); // → token (masked)
+        type_form(&mut a, "nbt_supersecret.value");
+
+        let cmds = a.handle_event(press(KeyCode::Enter));
+
+        assert!(cmds.is_empty());
+        assert!(
+            a.profiles.iter().all(|p| p.name != "lab"),
+            "profile should not be added live when token storage is impossible"
+        );
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !text.contains("[profiles.lab]"),
+            "metadata should not be written when a pasted token cannot be stored: {text}"
+        );
+        assert_eq!(a.status_severity, Severity::Error);
+        assert!(
+            a.status.contains("can't store pasted tokens"),
+            "{}",
+            a.status
+        );
+        if let Some(Modal::Config(m)) = &a.modal {
+            let f = m.form().expect("form stays open");
+            assert!(
+                f.message
+                    .as_deref()
+                    .is_some_and(|m| m.contains("can't store pasted tokens")),
+                "form message: {:?}",
+                f.message
+            );
+        } else {
+            panic!("config modal should remain open");
         }
     }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -23,6 +23,7 @@ use crate::tui::config_modal::{
 };
 use crate::tui::filter_modal::{FilterModal, FilterOutcome};
 use crate::tui::palette::{self, PaletteCommand};
+use crate::tui::profile_token::{PreparedTokenChange, TokenNotice};
 use crate::tui::theme::{Severity, Theme};
 
 /// A floating overlay drawn on top of the live screen. Both are modal: while one
@@ -2215,6 +2216,19 @@ impl App {
             return Vec::new();
         }
 
+        // Prepare the keyring mutation before writing TOML. If the config write
+        // fails, roll this back so neither side is left in a half-saved state.
+        let token_change =
+            match PreparedTokenChange::prepare(&path, original.as_deref(), &name, &token_action) {
+                Ok(change) => change,
+                Err(e) => {
+                    let message = format!("token save failed: {e:#}");
+                    self.set_form_error(message.clone());
+                    self.set_status(message, Severity::Error);
+                    return Vec::new();
+                }
+            };
+
         // Write the metadata to the config file (format-preserving). The token is
         // NEVER written here. On a rename the old TOML section is removed (H1).
         if let Err(e) = Self::persist_profile(
@@ -2233,24 +2247,12 @@ impl App {
                 api_route_target,
             },
         ) {
+            token_change.rollback();
             self.set_status(format!("save failed: {e:#}"), Severity::Error);
             return Vec::new();
         }
 
-        // Reconcile the OS-keyring token (H2/H3/H5): store a new value, clear on the
-        // explicit clear intent, or migrate the existing entry across a rename. The
-        // token is never written to TOML; a failed explicit set/clear keeps the user
-        // in the form so the UI can't imply a token landed when it did not.
-        let token_status =
-            match Self::apply_token_change(&path, original.as_deref(), &name, &token_action) {
-                Ok(status) => status,
-                Err(e) => {
-                    let message = format!("token save failed: {e:#}");
-                    self.set_form_error(message.clone());
-                    self.set_status(message, Severity::Error);
-                    return Vec::new();
-                }
-            };
+        let token_status = Self::token_notice_status(token_change.commit());
 
         // Build the live profile entry from the form + reflect it into `profiles`.
         // The form now owns timeout/page_size/exclude/api too, so these come
@@ -2388,85 +2390,10 @@ impl App {
         Ok(())
     }
 
-    /// Reconcile the OS-keyring token for a profile save (H2/H3/H5). Returns an
-    /// optional `(message, severity)` to surface when something noteworthy happened
-    /// (a clear or best-effort migration warning) — `None` on the quiet happy path.
-    ///
-    /// The token value never appears in the returned message or any log.
-    ///
-    /// - [`TokenAction::Set`]: store the new token under the (new) key. If storage
-    ///   fails, return an error; on a rename, delete the old key only after the new
-    ///   token is safely stored.
-    /// - [`TokenAction::Clear`]: delete the entry under the current (and, on rename,
-    ///   the old) key.
-    /// - [`TokenAction::Keep`]: leave the value; on a rename, migrate the existing
-    ///   entry from the old key to the new one so a renamed profile keeps its auth.
-    fn apply_token_change(
-        path: &std::path::Path,
-        original: Option<&str>,
-        name: &str,
-        action: &crate::tui::config_modal::TokenAction,
-    ) -> anyhow::Result<Option<(String, Severity)>> {
-        use crate::tui::config_modal::TokenAction;
-        let path_str = path.display().to_string();
-        let new_key = crate::secret::account_key(&path_str, name);
-        // The old key when this is a rename (renamed away from `original`).
-        let old_key = original
-            .filter(|orig| *orig != name)
-            .map(|orig| crate::secret::account_key(&path_str, orig));
-
-        match action {
-            TokenAction::Set(token) => {
-                crate::secret::keyring_set(&new_key, token).map_err(|e| {
-                    anyhow::anyhow!(
-                        "pasted token was NOT stored ({e}); clear it and use token_env/NBOX_TOKEN or enable keyring storage"
-                    )
-                })?;
-                // If this was a rename, remove the old-key entry only after the new
-                // token is safely stored, so a write failure can't strand the profile
-                // without its previous secret.
-                if let Some(old) = &old_key
-                    && let Err(e) = crate::secret::keyring_delete(old)
-                {
-                    tracing::debug!("failed to delete old keyring entry after token set: {e:#}");
-                }
-                Ok(None)
-            }
-            TokenAction::Clear => {
-                crate::secret::keyring_delete(&new_key).map_err(|e| {
-                    anyhow::anyhow!(
-                        "stored token was NOT cleared ({e}); try again or clear it outside nbox"
-                    )
-                })?;
-                if let Some(old) = &old_key {
-                    crate::secret::keyring_delete(old).map_err(|e| {
-                        anyhow::anyhow!(
-                            "old stored token was NOT cleared after rename ({e}); try again or clear it outside nbox"
-                        )
-                    })?;
-                }
-                Ok(Some((
-                    "saved — stored token cleared".to_string(),
-                    Severity::Info,
-                )))
-            }
-            TokenAction::Keep => {
-                // Migrate the existing entry across a rename so auth follows the name.
-                if let Some(old) = &old_key
-                    && let Some(existing) = crate::secret::keyring_get(old)
-                {
-                    let migrated = crate::secret::keyring_set(&new_key, &existing).is_ok();
-                    let _ = crate::secret::keyring_delete(old);
-                    if !migrated {
-                        return Ok(Some((
-                            "saved — could not migrate the stored token to the new name; re-enter it or set a token_env".to_string(),
-                            Severity::Warning,
-                        )));
-                    }
-                }
-                Ok(None)
-            }
-        }
+    fn token_notice_status(notice: Option<TokenNotice>) -> Option<(String, Severity)> {
+        notice.map(|TokenNotice::Cleared| {
+            ("saved — stored token cleared".to_string(), Severity::Info)
+        })
     }
 
     fn token_action_preflight_error(


### PR DESCRIPTION
## Summary

- stop first-run onboarding from leaking its terminal EventStream reader into the main TUI handoff
- add an abort-on-drop guard for terminal reader tasks and use it in both onboarding and the main app loop
- fail closed when onboarding or the Config modal tries to save a pasted token on builds without persistent keyring storage
- make keyring/profile metadata saves transactional so runtime keyring failures do not leave half-saved profiles
- document token source precedence and persistent-keyring platform behavior

## Root Cause

Onboarding spawned a detached crossterm EventStream reader and then handed the same terminal to the main app, which spawned its own reader. The orphaned reader could consume the first post-handoff key event before noticing its receiver was gone. Separately, Linux/default builds have no persistent Secret Service keyring backend, so pasted tokens could appear accepted while not being stored.

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo clippy --no-default-features --all-targets -- -D warnings
- cargo build --all-features
- cargo build --no-default-features
- cargo test --all-features
- cargo test --no-default-features
