### PR TITLE
fix(config): make keyring token storage opt-in (frictionless paste-to-config)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,11 +118,11 @@ MCP prompts are later. See `docs/MCP.md`.
 ## Configuration
 
 - Config: `~/.config/nbox/config.toml` (`nbox config init` to create).
-- Token: never stored in the config. Resolved in order: the profile's `token_env`
-  variable (if set & present) → `NBOX_TOKEN` → the OS keyring entry for the profile
-  (`nbox config token set`) → none. Env always overrides the keyring. Inspect the
-  active source with `nbox config token status` (never prints the token). Select a
-  profile with `--profile <name>` or set the active one.
+- Token: resolved in order: the profile's `token_env` variable (if set & present)
+  → `NBOX_TOKEN` → the profile's config `token` → the OS keyring entry when
+  `token_store = "keyring"` → none. Env always overrides saved tokens. Inspect
+  the active source with `nbox config token status` (never prints the token).
+  Select a profile with `--profile <name>` or set the active one.
 - Backends: REST is canonical. GraphQL is an opt-in per-surface accelerator set
   under `[profiles.<name>.api]` (`vrf` = `rest`|`graphql`; missing = REST). nbox
   probes `/graphql/`, adapts to NetBox 4.2/4.3/4.5+ filter/pagination shapes, and

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ server for AI agents.
 ## Quick Start
 
 First run? Just launch the TUI — with no config it opens a first-run wizard that
-captures a profile, test-connects it, and drops you into the app. The wizard can
-store the token in a persistent OS keyring when this build has one; otherwise it
-keeps you on the portable path and asks for `token_env`/`NBOX_TOKEN` instead.
+captures a profile, test-connects it, and drops you into the app. Paste a token
+and nbox saves it in your user-only `config.toml`; use `Ctrl+K` in the wizard, or
+`nbox config token set`, only if you want OS-keyring storage instead.
 
 ```bash
 nbox                              # first run: guided onboarding, then the TUI
@@ -34,7 +34,7 @@ Prefer the shell? Configure a profile by hand:
 ```bash
 nbox profile add work https://netbox.example.com --token-env NETBOX_TOKEN
 nbox profile use work
-export NETBOX_TOKEN=...           # portable; desktop keyring builds can use `nbox config token set`
+export NETBOX_TOKEN=...           # env vars override config/keyring tokens
 
 # Look things up from the shell
 nbox search edge01
@@ -210,9 +210,10 @@ all on by default. There are no feature-variant builds to choose between.
 
 `keyring` means macOS Keychain / Windows Credential Manager support is compiled
 in. Default Linux and musl builds intentionally do **not** link the D-Bus Secret
-Service backend; on those builds pasted-token saves are blocked and env vars are
-the supported token path. Build with `--features keyring-secret-service` only when
-you want a Linux desktop keyring build.
+Service backend; on those builds `token_store = "keyring"` is unavailable, while
+normal config-token and env-var storage still work. Build with
+`--features keyring-secret-service` only when you want a Linux desktop keyring
+build.
 
 ```bash
 # Lean stdio-only build (drops all of the above):
@@ -360,13 +361,14 @@ for that).
 `S` (or `config` in the palette) opens the Config modal to manage profiles
 in-app: list them (active marked), and add / edit / select / delete without
 hand-editing `config.toml`. The add/edit form covers `name`, `url`, `token_env`,
-`auth_scheme`, and `verify_tls`, plus an optional masked token field. When a
-keyring is available, a typed token is stored there (never in `config.toml`);
-otherwise pasted-token saves are blocked and nbox tells you to use `token_env` or
-`NBOX_TOKEN`. `Ctrl+T` test-connects before you commit; `Enter` saves, `Ctrl+G`
-saves and switches to it. Unlike the quick `P` cycle, selecting or adding-and-using
-a profile here **persists** `active_profile` to your config. Deleting the active
-or last profile is blocked.
+`auth_scheme`, `verify_tls`, and `token_store`, plus an optional masked token
+field. A typed token is saved to `config.toml` by default (redacted by display
+commands; config files are written user-only on Unix). `Ctrl+K` switches
+`token_store` to `keyring` for explicit OS-keyring storage instead. `Ctrl+T`
+test-connects before you commit; `Enter` saves, `Ctrl+G` saves and switches to
+it. Unlike the quick `P` cycle, selecting or adding-and-using a profile here
+**persists** `active_profile` to your config. Deleting the active or last profile
+is blocked.
 
 `Tab` switches the Config modal to its **Settings** section, a two-pane editor —
 categories on the left, the selected category's fields on the right:
@@ -428,7 +430,9 @@ ttl_secs = 30              # reuse window in seconds (clamped to 5–300)
 
 [profiles.work]
 url = "https://netbox.example.com"
+# token = "nbt_..."              # default TUI paste path; redacted by config show
 token_env = "NETBOX_TOKEN"
+# token_store = "keyring"        # optional: opt into OS keyring instead of token
 auth_scheme = "auto"          # auto | bearer | token
 verify_tls = true
 timeout_secs = 15
@@ -442,23 +446,25 @@ vrf = "graphql"               # rest | graphql
 route_target = "graphql"      # rest | graphql
 ```
 
-Tokens are **never written to config**. The config stores only profile metadata
-and, optionally, the *name* of an env var (`token_env`), not its value.
+Tokens can be stored directly in the profile as `token = "..."` for the normal
+single-user desktop flow. Display commands redact it, and config files are
+written user-only on Unix. If you prefer external secret handling, store only the
+*name* of an env var (`token_env`) or opt into the OS keyring.
 
 Token sources are resolved in this order:
 
 1. the env var named by the profile's `token_env` (if set & present)
 2. `NBOX_TOKEN`
-3. the OS keyring entry for the profile (`nbox config token set`)
-4. none
+3. the profile's `token = "..."`
+4. the OS keyring entry for profiles with `token_store = "keyring"`
+5. none
 
-Use env vars for CI, SSH, Docker, static Linux/musl builds, and anything
-headless. Use the OS keyring for interactive desktop onboarding when the binary
-has a persistent backend: macOS Keychain, Windows Credential Manager, or a Linux
-build with `keyring-secret-service`. Default Linux/musl release binaries have no
-D-Bus keyring backend, so pasted-token saves are refused rather than accepted into
-a non-persistent mock store. `nbox config token status` shows the active source
-(never the token). See [docs/CONFIG.md](docs/CONFIG.md) for the full reference.
+Use env vars for CI, SSH, Docker, and anything headless. Use the OS keyring only
+when you explicitly want desktop secret-store integration: macOS Keychain,
+Windows Credential Manager, or a Linux build with `keyring-secret-service`.
+Default Linux/musl release binaries have no D-Bus keyring backend. `nbox config
+token status` shows the active source (never the token). See
+[docs/CONFIG.md](docs/CONFIG.md) for the full reference.
 
 ## MCP Server
 
@@ -543,12 +549,12 @@ raw escape-hatch tool come later.
 | Symptom | Fix |
 |---------|-----|
 | `no config at … — run nbox config init` | First run: just launch `nbox` for the guided wizard, or `nbox profile add …`. |
-| `error: authentication failed` (exit 3) | The token is missing/invalid. Check `nbox config token status` for the resolved source; export `NBOX_TOKEN` or point `token_env` at a set variable. |
+| `error: authentication failed` (exit 3) | The token is missing/invalid. Check `nbox config token status` for the resolved source; paste a token in the TUI, export `NBOX_TOKEN`, or point `token_env` at a set variable. |
 | `403` / permission denied (exit 3) | The token is valid but lacks object permissions, or your NetBox needs `LOGIN_REQUIRED`-aware tokens. Use a token with read access. |
 | TLS / certificate error | For a lab with a self-signed cert, set `verify_tls = false` on that profile (never in production). |
 | `operation timed out` on one search endpoint | Transient; nbox already disables stale keep-alive reuse. Retry, or raise `timeout_secs`. |
 | `ambiguous` (exit 5) | The reference matched several objects — disambiguate (`--vrf` for an IP/prefix, `--site`/`--group` for a VLAN). |
-| `keyring not available` (Linux) | The default static binary has no D-Bus backend. Use `token_env`/`NBOX_TOKEN`, or install a build with `keyring-secret-service`. |
+| `keyring not available` (Linux) | The default static binary has no D-Bus backend. Keep `token_store = "config"`, use `token_env`/`NBOX_TOKEN`, or install a build with `keyring-secret-service`. |
 | NetBox version error | nbox requires NetBox **4.2+**. Check `nbox status`. |
 
 Full list with copy-paste fixes: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -28,7 +28,9 @@ ttl_secs = 30              # reuse window in seconds (clamped to 5–300)
 
 [profiles.work]
 url = "https://netbox.example.com"
+# token = "nbt_..."              # default TUI paste path; redacted by config show
 token_env = "NETBOX_TOKEN"
+# token_store = "keyring"        # optional: opt into OS keyring instead of token
 auth_scheme = "auto"          # auto | bearer | token
 verify_tls = true
 timeout_secs = 15
@@ -48,15 +50,19 @@ mishandle a newer schema.
 
 ## Tokens
 
-Tokens are **never written to config**. The TOML stores profile metadata and,
-optionally, the *name* of an env var (`token_env`), never the token value.
+Tokens can be stored directly in the profile as `token = "..."` for the normal
+single-user desktop flow. `nbox config show`, JSON output, and `Debug` output
+redact that value, and config files are written user-only on Unix. If you prefer
+external secret handling, store only the *name* of an env var (`token_env`) or
+opt into the OS keyring with `token_store = "keyring"`.
 
 Resolution order:
 
 1. the env var named by the profile's `token_env` (if set & present)
 2. `NBOX_TOKEN`
-3. the OS keyring entry for the profile (`nbox config token set`)
-4. none — nbox reports a clear "no token" error
+3. the profile's `token = "..."`
+4. the OS keyring entry for profiles with `token_store = "keyring"`
+5. none — nbox reports a clear "no token" error
 
 Who stores what:
 
@@ -64,18 +70,19 @@ Who stores what:
 |--------|------------------------|-----------------------------------|----------|
 | `token_env` | Your shell, systemd unit, CI secret, MCP host env, etc. | The env var name only, e.g. `token_env = "NETBOX_TOKEN"` | CI, SSH, Docker, agents, static Linux/musl |
 | `NBOX_TOKEN` | Your process environment | Nothing | One-off overrides and break-glass runs |
-| OS keyring | macOS Keychain, Windows Credential Manager, or Linux Secret Service when built in | Nothing | Interactive desktop use |
+| `token` | `config.toml` | `token = "..."` | Normal single-user desktop/TUI use |
+| OS keyring | macOS Keychain, Windows Credential Manager, or Linux Secret Service when built in | `token_store = "keyring"` | Users who explicitly want OS secret-store prompts/integration |
 
-Env always overrides the keyring. This is intentional: CI/SSH/Docker can inject a
-known token without editing config, and a temporary `NBOX_TOKEN` can override a
-desktop keyring entry. Inspect the active source with `nbox config token status`
-(it prints the source — `token_env`/`NBOX_TOKEN`/`keyring`/`none` — never the
-token).
+Env always overrides config/keyring tokens. This is intentional: CI/SSH/Docker
+can inject a known token without editing config, and a temporary `NBOX_TOKEN` can
+override a saved desktop token. Inspect the active source with
+`nbox config token status` (it prints the source —
+`token_env`/`NBOX_TOKEN`/`config`/`keyring`/`none` — never the token).
 
 ### OS keyring
 
-Store the token in your OS keyring instead of an env var, when this build has a
-real persistent keyring backend:
+OS keyring is opt-in. Store the token there instead of `config.toml`, when this
+build has a real persistent keyring backend:
 
 ```bash
 nbox config token set      # prompts, input hidden (or reads a piped line)
@@ -86,24 +93,27 @@ nbox config token clear    # removes the stored token
 `set`/`clear` act on the active profile (or `--profile <name>`). The token is read
 without echo from a TTY prompt, or as a single line from stdin when piped
 (scripting) — there is no positional token argument, so it can't leak into shell
-history. The entry is keyed by config path + profile name (service `nbox`).
+history. `set` writes `token_store = "keyring"` and clears any plaintext profile
+`token`; `clear` removes the keyring entry and returns the profile to config-token
+mode. The entry is keyed by config path + profile name (service `nbox`).
 
 Backends: macOS Keychain and Windows Credential Manager are built in. On Linux
 the Secret Service (D-Bus) backend is **off by default** — build with
 `--features keyring-secret-service` to enable it; otherwise `nbox config token`
 reports the keyring as unavailable and you should use `NBOX_TOKEN` or a
-`token_env` instead. (This keeps static/musl builds free of a D-Bus link
-dependency.)
+config/token_env token instead. (This keeps static/musl builds free of a D-Bus
+link dependency.)
 
-The TUI onboarding wizard and Config modal follow the same rule. If a pasted
-token cannot be stored in a persistent keyring, the save is blocked and the form
-stays open with guidance to use `token_env`/`NBOX_TOKEN`; nbox does not create a
-profile that pretends a newly pasted token was saved. Explicit token set/clear
-actions fail closed if the runtime keyring operation fails (for example a locked
-keychain), with profile metadata and keyring changes rolled back together as far
-as the platform allows. A profile rename with "keep stored token" is best-effort:
-if the old token cannot be read or copied, the rename still saves and nbox warns
-you to re-enter the token or set `token_env`.
+The TUI onboarding wizard and Config modal default to `token_store = "config"`;
+`Ctrl+K` opts a profile into `keyring`. If a pasted token cannot be stored in a
+persistent keyring after that explicit opt-in, the save is blocked and the form
+stays open with guidance to switch back to config storage or use
+`token_env`/`NBOX_TOKEN`. Explicit keyring set/clear actions fail closed if the
+runtime keyring operation fails (for example a locked keychain), with profile
+metadata and keyring changes rolled back together as far as the platform allows.
+A profile rename with "keep stored token" is best-effort: if the old keyring
+token cannot be read or copied, the rename still saves and nbox warns you to
+re-enter the token or set `token_env`.
 
 `auth_scheme = "auto"` detects NetBox 4.5+ v2 tokens (`nbt_…` → `Authorization:
 Bearer`) versus legacy v1 tokens (`Authorization: Token`). Force one with

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -11,10 +11,10 @@ same JSON view models. Nothing is ever written.
 A configured profile, exactly as the CLI needs one: a NetBox `url` and a token.
 `nbox serve` resolves the token the same way every other command does, in
 precedence order: the env var named by the profile's `token_env`, then
-`NBOX_TOKEN`, then the profile's OS-keyring entry (`nbox config token set`). It
-honors the same global flags (`-p`/`--profile <name>`, `--config <path>`). See
-[docs/CONFIG.md](CONFIG.md) for profiles and token resolution. Confirm the CLI
-works first:
+`NBOX_TOKEN`, then the profile's `token`, then an OS-keyring entry only when the
+profile has `token_store = "keyring"`. It honors the same global flags
+(`-p`/`--profile <name>`, `--config <path>`). See [docs/CONFIG.md](CONFIG.md) for
+profiles and token resolution. Confirm the CLI works first:
 
 ```bash
 nbox status

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -10,10 +10,11 @@ launches the interactive TUI, which blocks on a terminal; `--no-tui` turns that
 into a usage error (exit 2) instead — so a misfired invocation in CI fails fast
 rather than hanging on a TTY that isn't there.
 
-The token never lives in a config file. Resolve it from the environment for
-scripts: export `NBOX_TOKEN` (or point a profile's `token_env` at a set
-variable). The full order is `token_env` → `NBOX_TOKEN` → OS keyring → none; env
-always wins. Requires NetBox 4.2+.
+For scripts and agents, prefer resolving the token from the environment: export
+`NBOX_TOKEN` (or point a profile's `token_env` at a set variable). Desktop users
+may also store `token = "..."` in the profile, and keyring is opt-in with
+`token_store = "keyring"`. The full order is `token_env` → `NBOX_TOKEN` →
+config `token` → opt-in keyring → none; env always wins. Requires NetBox 4.2+.
 
 ## Output formats
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -26,14 +26,15 @@ The token is missing, wrong, or expired — NetBox rejected it. First check whic
 source nbox resolved (it prints the source, never the token):
 
 ```bash
-nbox config token status                          # token_env | NBOX_TOKEN | keyring | none
+nbox config token status                          # token_env | NBOX_TOKEN | config | keyring | none
 ```
 
 If it says `none`, no token was found. Set one and retry:
 
 ```bash
 export NBOX_TOKEN=...                             # or point token_env at a set variable
-nbox config token set                             # or store it in the OS keyring (input hidden)
+nbox                                             # paste a token in the TUI, or use keyring below
+nbox config token set                             # optional OS-keyring storage (input hidden)
 ```
 
 If a token *is* resolving but still 401s, it's the wrong token for this instance —
@@ -52,12 +53,13 @@ nbox resolves the token in a fixed order; the first hit wins:
 
 1. the env var named by the profile's `token_env` (if set & present)
 2. `NBOX_TOKEN`
-3. the OS keyring entry for the profile (`nbox config token set`)
-4. none — a clear "no token" error
+3. the profile's `token = "..."`
+4. the OS keyring entry for profiles with `token_store = "keyring"`
+5. none — a clear "no token" error
 
-Env always overrides the keyring. If a stale `NBOX_TOKEN` is exported it shadows a
-correct keyring entry — `unset NBOX_TOKEN` (or fix the value), then re-check with
-`nbox config token status`.
+Env always overrides config/keyring tokens. If a stale `NBOX_TOKEN` is exported
+it shadows a correct saved token — `unset NBOX_TOKEN` (or fix the value), then
+re-check with `nbox config token status`.
 
 ### Wrong Authorization scheme (v1 vs v2 token)
 
@@ -233,13 +235,14 @@ nbox serve --http 0.0.0.0:8080 \
 ### `keyring not available on this system` (Linux)
 
 The default static binary ships no D-Bus (Secret Service) backend, so
-`nbox config token` and the TUI pasted-token field cannot persist a token there.
-This is deliberate: without the backend, keyring v3 would fall back to an
-in-process mock store that disappears when nbox exits. Use an env var instead, or
-install a build with the Linux backend compiled in:
+`nbox config token` and TUI profiles with `token_store = "keyring"` cannot persist
+a token there. This is deliberate: without the backend, keyring v3 would fall
+back to an in-process mock store that disappears when nbox exits. Keep
+`token_store = "config"`, use an env var, or install a build with the Linux
+backend compiled in:
 
 ```bash
-export NBOX_TOKEN=...                              # or set the profile's token_env
+export NBOX_TOKEN=...                              # or set token/token_env in the profile
 cargo install nbox --features keyring-secret-service   # build with the Linux keyring backend
 ```
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -2,8 +2,9 @@
 #
 # Real config lives at ~/.config/nbox/config.toml (Linux/macOS) or
 # %APPDATA%\nbox\config.toml (Windows) — create it with `nbox config init`.
-# Tokens are NOT stored here: point `token_env` at an environment variable, or
-# export NBOX_TOKEN to override per-invocation.
+# Tokens can be stored here as `token = "..."` for the normal desktop/TUI flow,
+# or kept outside the file with `token_env` / NBOX_TOKEN. Env vars override saved
+# config/keyring tokens.
 
 config_version = 1
 active_profile = "work"
@@ -26,7 +27,9 @@ ttl_secs = 30              # reuse window in seconds (clamped to 5–300)
 
 [profiles.work]
 url = "https://netbox.example.com"
+# token = "nbt_..."              # default TUI paste path; redacted by config show
 token_env = "NETBOX_TOKEN"   # nbox reads the token from this env var
+# token_store = "keyring"     # optional: opt into OS keyring instead of token
 auth_scheme = "auto"         # auto | bearer | token (auto-detects v2 nbt_ tokens)
 verify_tls = true
 timeout_secs = 15

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -503,8 +503,8 @@ pub enum ConfigCommand {
     },
 }
 
-/// `nbox config token` subcommands. The token is stored in the OS keyring, never
-/// in the config file; it is never echoed or printed.
+/// `nbox config token` subcommands. These manage the opt-in OS-keyring token
+/// path; token values are never echoed or printed.
 #[derive(Debug, Subcommand)]
 pub enum TokenCommand {
     /// Store the API token in the OS keyring for the active (or `--profile`)
@@ -514,8 +514,9 @@ pub enum TokenCommand {
     Set,
     /// Remove the stored keyring token for the active (or `--profile`) profile.
     Clear,
-    /// Report the resolved token *source* (token_env / NBOX_TOKEN / keyring /
-    /// none) for the active (or `--profile`) profile. Never prints the token.
+    /// Report the resolved token *source* (token_env / NBOX_TOKEN / config /
+    /// keyring / none) for the active (or `--profile`) profile. Never prints the
+    /// token.
     Status,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,8 @@ use crate::netbox::auth::AuthScheme;
 
 /// Starter config written by `nbox config init`.
 const INIT_TEMPLATE: &str = r#"# nbox configuration
-# Tokens are NOT stored here — point `token_env` at an environment variable,
-# or export NBOX_TOKEN to override.
+# Tokens can be stored in this user-only config file (`token = "..."`) or kept
+# outside it with `token_env` / NBOX_TOKEN. Env vars override config tokens.
 
 config_version = 1
 
@@ -226,6 +226,12 @@ pub struct ProfileConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_env: Option<String>,
 
+    #[serde(default, skip_serializing_if = "is_default_token_store")]
+    pub token_store: TokenStore,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<ConfigToken>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_scheme: Option<AuthScheme>,
 
@@ -249,6 +255,69 @@ pub struct ProfileConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_config_context: Option<bool>,
+}
+
+/// A NetBox API token stored in config.
+///
+/// This intentionally serializes as a normal TOML string, but `Debug` and
+/// `config show` redact it. The config file is written with user-only
+/// permissions on Unix.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ConfigToken(String);
+
+impl ConfigToken {
+    #[must_use]
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
+    }
+
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn redacted() -> Self {
+        Self("<redacted>".to_string())
+    }
+}
+
+impl std::fmt::Debug for ConfigToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("\"<redacted>\"")
+    }
+}
+
+/// Where a profile may persist an in-app pasted token.
+///
+/// The default is `config`: a pasted token is written to `config.toml` and
+/// redacted from display. `Keyring` is an explicit opt-in that stores pasted
+/// tokens in the OS keyring and enables the keyring as the lowest-precedence token
+/// source.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenStore {
+    #[default]
+    Config,
+    Keyring,
+}
+
+impl TokenStore {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Config => "config",
+            Self::Keyring => "keyring",
+        }
+    }
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde skip_serializing_if requires &T
+fn is_default_token_store(store: &TokenStore) -> bool {
+    *store == TokenStore::Config
 }
 
 /// Which NetBox read backend a profile should prefer.
@@ -465,6 +534,8 @@ pub enum TokenSource {
     TokenEnv(String),
     /// The `NBOX_TOKEN` environment variable.
     NboxToken,
+    /// The token value stored in the profile config file.
+    Config,
     /// The OS keyring entry for this profile.
     Keyring,
     /// No token from any source.
@@ -475,9 +546,8 @@ pub enum TokenSource {
 /// the keyring lookup.
 ///
 /// Precedence (highest first): the profile's `token_env` (if set & present), then
-/// `NBOX_TOKEN`, then the OS keyring entry for this profile, then `None`. Env
-/// always overrides the keyring — CI/SSH/break-glass paths set an env var; the
-/// keyring is for interactive human onboarding.
+/// `NBOX_TOKEN`, then the profile's config token, then the OS keyring entry for
+/// this profile only when `token_store = "keyring"`, then `None`.
 pub fn resolve_token(
     profile: &ProfileConfig,
     config_path: &Path,
@@ -490,6 +560,14 @@ pub fn resolve_token(
     let nbox = std::env::var("NBOX_TOKEN").ok();
     if let Some(t) = select_env_token(token_env, nbox) {
         return Some(t);
+    }
+    if let Some(token) = &profile.token
+        && !token.expose().is_empty()
+    {
+        return Some(token.expose().to_string());
+    }
+    if profile.token_store != TokenStore::Keyring {
+        return None;
     }
     let account = crate::secret::account_key(&config_path.display().to_string(), profile_name);
     crate::secret::keyring_get(&account)
@@ -510,16 +588,26 @@ pub fn resolve_token_source(
     if std::env::var("NBOX_TOKEN").is_ok_and(|t| !t.is_empty()) {
         return TokenSource::NboxToken;
     }
-    let account = crate::secret::account_key(&config_path.display().to_string(), profile_name);
-    if crate::secret::keyring_get(&account).is_some() {
-        return TokenSource::Keyring;
+    if profile
+        .token
+        .as_ref()
+        .is_some_and(|t| !t.expose().is_empty())
+    {
+        return TokenSource::Config;
+    }
+    if profile.token_store == TokenStore::Keyring {
+        let account = crate::secret::account_key(&config_path.display().to_string(), profile_name);
+        if crate::secret::keyring_get(&account).is_some() {
+            return TokenSource::Keyring;
+        }
     }
     TokenSource::None
 }
 
 /// Pure env-token precedence: the profile's `token_env` value wins over
-/// `NBOX_TOKEN`; empty values are skipped. Keyring (the next tier) is layered on
-/// in [`resolve_token`] after this returns `None`.
+/// `NBOX_TOKEN`; empty values are skipped. The keyring tier, when the profile
+/// explicitly opts into it, is layered on in [`resolve_token`] after this returns
+/// `None`.
 fn select_env_token(token_env: Option<String>, nbox_token: Option<String>) -> Option<String> {
     token_env
         .filter(|t| !t.is_empty())
@@ -571,6 +659,34 @@ pub fn set_profile_token_env(
         Some(env) => prof["token_env"] = value(env),
         None => {
             prof.remove("token_env");
+        }
+    }
+    Ok(())
+}
+
+/// Set (or clear) `profiles.<name>.token_store` in a format-preserving document.
+/// `Config` is the implicit default and removes the key; `Keyring` writes an
+/// explicit opt-in so token resolution may consult the OS keyring.
+pub fn set_profile_token_store(doc: &mut DocumentMut, name: &str, store: TokenStore) -> Result<()> {
+    let prof = profile_table_mut(doc, name)?;
+    match store {
+        TokenStore::Config => {
+            prof.remove("token_store");
+        }
+        TokenStore::Keyring => prof["token_store"] = value(store.as_str()),
+    }
+    Ok(())
+}
+
+/// Set (or clear) `profiles.<name>.token` in a format-preserving document.
+/// `None` (or an empty value) removes the key. Display paths must redact this
+/// field; `write_doc` makes the file user-only on Unix.
+pub fn set_profile_token(doc: &mut DocumentMut, name: &str, token: Option<&str>) -> Result<()> {
+    let prof = profile_table_mut(doc, name)?;
+    match token.filter(|t| !t.is_empty()) {
+        Some(token) => prof["token"] = value(token),
+        None => {
+            prof.remove("token");
         }
     }
     Ok(())
@@ -969,6 +1085,11 @@ pub fn write_doc(path: &Path, doc: &DocumentMut) -> Result<()> {
         fs::create_dir_all(parent)?;
     }
     fs::write(path, doc.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
     Ok(())
 }
 
@@ -1025,6 +1146,11 @@ pub(crate) fn redact_secrets(cfg: &mut Config) {
     if cfg.serve.http_token.is_some() {
         cfg.serve.http_token = Some("<redacted>".to_string());
     }
+    for profile in cfg.profiles.values_mut() {
+        if profile.token.is_some() {
+            profile.token = Some(ConfigToken::redacted());
+        }
+    }
 }
 
 /// Resolve the active (or `--profile`) profile name for a token command. The
@@ -1041,6 +1167,18 @@ fn token_profile_name(path: &Path, profile: Option<&str>) -> String {
         .unwrap_or_else(|| "default".to_string())
 }
 
+fn ensure_profile_exists(doc: &DocumentMut, name: &str) -> Result<()> {
+    let exists = doc
+        .get("profiles")
+        .and_then(Item::as_table)
+        .is_some_and(|profiles| profiles.contains_key(name));
+    if exists {
+        Ok(())
+    } else {
+        bail!("no profile named '{name}' — add the profile before storing a keyring token")
+    }
+}
+
 /// Handle `nbox config token {set,clear,status}`. The token value is never
 /// printed, echoed, or logged.
 fn run_config_token(
@@ -1054,6 +1192,8 @@ fn run_config_token(
     let account = crate::secret::account_key(&path.display().to_string(), &name);
     match cmd {
         TokenCommand::Set => {
+            let mut doc = load_doc_or_new(path)?;
+            ensure_profile_exists(&doc, &name)?;
             if !crate::secret::keyring_available() {
                 bail!(
                     "keyring not available on this system — set NBOX_TOKEN or a \
@@ -1067,6 +1207,12 @@ fn run_config_token(
                 bail!("no token entered");
             }
             crate::secret::keyring_set(&account, &token)?;
+            set_profile_token_store(&mut doc, &name, TokenStore::Keyring)?;
+            set_profile_token(&mut doc, &name, None)?;
+            if let Err(e) = write_doc(path, &doc) {
+                let _ = crate::secret::keyring_delete(&account);
+                return Err(e);
+            }
             eprintln!("stored token for profile '{name}' in the OS keyring");
             Ok(())
         }
@@ -1078,6 +1224,15 @@ fn run_config_token(
                 );
             }
             crate::secret::keyring_delete(&account)?;
+            if let Ok(mut doc) = load_doc_or_new(path)
+                && doc
+                    .get("profiles")
+                    .and_then(Item::as_table)
+                    .is_some_and(|profiles| profiles.contains_key(&name))
+            {
+                set_profile_token_store(&mut doc, &name, TokenStore::Config)?;
+                write_doc(path, &doc)?;
+            }
             eprintln!("cleared keyring token for profile '{name}'");
             Ok(())
         }
@@ -1093,6 +1248,7 @@ fn run_config_token(
             let label = match &source {
                 TokenSource::TokenEnv(var) => format!("token_env {var}"),
                 TokenSource::NboxToken => "NBOX_TOKEN".to_string(),
+                TokenSource::Config => "config".to_string(),
                 TokenSource::Keyring => "keyring".to_string(),
                 TokenSource::None => "none".to_string(),
             };
@@ -1101,9 +1257,11 @@ fn run_config_token(
                 "source": match &source {
                     TokenSource::TokenEnv(_) => "token_env",
                     TokenSource::NboxToken => "NBOX_TOKEN",
+                    TokenSource::Config => "config",
                     TokenSource::Keyring => "keyring",
                     TokenSource::None => "none",
                 },
+                "token_store": prof.token_store.as_str(),
                 "token_env": match &source {
                     TokenSource::TokenEnv(var) => Some(var.clone()),
                     _ => None,
@@ -1550,6 +1708,64 @@ search = "graphql"
     }
 
     #[test]
+    fn config_token_is_resolved_before_keyring() {
+        let profile = ProfileConfig {
+            url: "https://nb.example".into(),
+            token_env: Some("NBOX_TEST_DEFINITELY_UNSET_VAR_XYZ".into()),
+            token: Some(ConfigToken::new("config-secret")),
+            token_store: TokenStore::Keyring,
+            ..Default::default()
+        };
+        if std::env::var("NBOX_TOKEN").is_err() {
+            let path = Path::new("/nbox/test/config-token/config.toml");
+            assert_eq!(
+                resolve_token(&profile, path, "default").as_deref(),
+                Some("config-secret")
+            );
+            assert_eq!(
+                resolve_token_source(&profile, path, "default"),
+                TokenSource::Config
+            );
+        }
+    }
+
+    #[test]
+    fn keyring_is_ignored_without_explicit_opt_in() {
+        let profile = ProfileConfig {
+            url: "https://nb.example".into(),
+            token_env: Some("NBOX_TEST_DEFINITELY_UNSET_VAR_XYZ".into()),
+            ..Default::default()
+        };
+        if std::env::var("NBOX_TOKEN").is_err() {
+            let path = Path::new("/nbox/test/no-keyring-opt-in/config.toml");
+            assert_eq!(resolve_token(&profile, path, "default"), None);
+            assert_eq!(
+                resolve_token_source(&profile, path, "default"),
+                TokenSource::None
+            );
+        }
+    }
+
+    #[test]
+    fn config_token_debug_and_redaction_do_not_expose_secret() {
+        let mut cfg = Config::default();
+        cfg.profiles.insert(
+            "work".to_string(),
+            ProfileConfig {
+                url: "https://nb.example".to_string(),
+                token: Some(ConfigToken::new("nbt_supersecret.value")),
+                ..Default::default()
+            },
+        );
+
+        assert!(!format!("{cfg:?}").contains("nbt_supersecret"));
+        redact_secrets(&mut cfg);
+        let rendered = serde_json::to_string(&cfg).unwrap();
+        assert!(rendered.contains("<redacted>"));
+        assert!(!rendered.contains("nbt_supersecret"));
+    }
+
+    #[test]
     fn token_status_label_maps_each_source() {
         // The CLI's `status` label is a pure mapping over TokenSource; assert each
         // arm produces the documented, token-free label. (Mirrors the match in
@@ -1557,6 +1773,7 @@ search = "graphql"
         let label = |s: &TokenSource| match s {
             TokenSource::TokenEnv(var) => format!("token_env {var}"),
             TokenSource::NboxToken => "NBOX_TOKEN".to_string(),
+            TokenSource::Config => "config".to_string(),
             TokenSource::Keyring => "keyring".to_string(),
             TokenSource::None => "none".to_string(),
         };
@@ -1565,12 +1782,14 @@ search = "graphql"
             "token_env NETBOX_TOKEN"
         );
         assert_eq!(label(&TokenSource::NboxToken), "NBOX_TOKEN");
+        assert_eq!(label(&TokenSource::Config), "config");
         assert_eq!(label(&TokenSource::Keyring), "keyring");
         assert_eq!(label(&TokenSource::None), "none");
         // No label ever contains a token value — only the source / env-var name.
         for s in [
             TokenSource::TokenEnv("X".into()),
             TokenSource::NboxToken,
+            TokenSource::Config,
             TokenSource::Keyring,
             TokenSource::None,
         ] {
@@ -1601,7 +1820,10 @@ search = "graphql"
             return;
         }
 
-        let prof = ProfileConfig::default();
+        let prof = ProfileConfig {
+            token_store: TokenStore::Keyring,
+            ..Default::default()
+        };
         // With no env vars overriding, the source is the keyring entry we just set.
         if std::env::var("NBOX_TOKEN").is_err() {
             assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -760,8 +760,9 @@ async fn run_tui_onboarding(
         no_tui: ctx.no_tui,
     };
     let mut app = build_tui_app(&onboarded, path, &cfg).await?;
-    // When no token landed anywhere (no keyring entry, no token_env), steer the
-    // user toward an env var so the freshly-launched app's first requests succeed.
+    // When no token landed anywhere (no config token, keyring entry, or
+    // token_env), steer the user toward an env var so the freshly-launched app's
+    // first requests succeed.
     if outcome.needs_env_guidance {
         app.set_initial_status(
             "profile saved — set NBOX_TOKEN or a token_env to authenticate",

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -3,8 +3,9 @@
 //! A single modal with two sections (`Profiles` | `Settings`), `Tab` to switch.
 //! The Profiles section lists the configured profiles (active marked) with add /
 //! edit / select / delete actions, and an add/edit [`FormInput`] form whose token
-//! field is masked (never written to TOML; stored in the OS keyring on save). The
-//! form also carries the profile knobs that used to need hand-editing config.toml:
+//! field is masked (stored in config by default, or stored in the OS keyring only
+//! when `token_store = keyring`). The form also carries the profile knobs that
+//! used to need hand-editing config.toml:
 //! `timeout_secs` / `page_size` (numeric text fields), `exclude_config_context`
 //! (Ctrl+E), and the per-surface API backends `vrf` (Ctrl+B) / `route_target`
 //! (Ctrl+R), each rest ↔ graphql. The `search` backend and `confirm_writes` are
@@ -21,7 +22,7 @@
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::config::BackendPreference;
+use crate::config::{BackendPreference, TokenStore};
 use crate::netbox::auth::AuthScheme;
 use crate::tui::cheese::{FormInput, TextInput};
 use crate::tui::theme::Theme;
@@ -45,9 +46,10 @@ pub mod field {
     pub const PAGE_SIZE: usize = 5;
 }
 
-/// What the profile-save path should do with the OS-keyring token, derived from
-/// the edit form's token field + clear intent (see [`ProfileForm::token_action`]).
-/// The token value is never logged; only this intent crosses the pure/IO seam.
+/// What the profile-save path should do with the OS-keyring token when the
+/// profile explicitly opts into keyring storage, derived from the edit form's
+/// token field + clear intent (see [`ProfileForm::token_action`]). The token
+/// value is never logged; only this intent crosses the pure/IO seam.
 #[derive(Clone, PartialEq, Eq)]
 pub enum TokenAction {
     /// Store this freshly-typed token under the (possibly renamed) keyring key.
@@ -115,6 +117,9 @@ pub struct ProfileForm {
     pub api_vrf: BackendPreference,
     /// `[profiles.<name>.api].route_target` backend — cycled with `Ctrl+R`.
     pub api_route_target: BackendPreference,
+    /// Where pasted tokens are persisted. Defaults to config; keyring is an
+    /// explicit opt-in toggled with `Ctrl+K`.
+    pub token_store: TokenStore,
     /// `Some(original_name)` when editing an existing profile (so a rename can be
     /// detected and the old keyring entry migrated); `None` when adding.
     pub editing: Option<String>,
@@ -148,6 +153,8 @@ pub struct ProfileFormData<'a> {
     pub exclude_config_context: bool,
     pub api_vrf: BackendPreference,
     pub api_route_target: BackendPreference,
+    pub token_store: TokenStore,
+    pub config_token: Option<&'a str>,
 }
 
 impl ProfileForm {
@@ -165,7 +172,7 @@ impl ProfileForm {
             ),
             (
                 "token".to_string(),
-                TextInput::masked("paste a token to store in the keyring (optional)"),
+                TextInput::masked("paste token to save (optional)"),
             ),
             (
                 "timeout_secs".to_string(),
@@ -183,6 +190,7 @@ impl ProfileForm {
             exclude_config_context: true,
             api_vrf: BackendPreference::Rest,
             api_route_target: BackendPreference::Rest,
+            token_store: TokenStore::Config,
             editing: None,
             test: TestState::Idle,
             message: None,
@@ -192,7 +200,7 @@ impl ProfileForm {
 
     /// An edit form prefilled from an existing profile's metadata. The token
     /// field starts empty — the stored secret is never read back into the UI;
-    /// leaving it blank keeps the existing keyring entry untouched.
+    /// leaving it blank keeps the existing stored token untouched.
     pub fn edit(data: ProfileFormData<'_>) -> Self {
         let ProfileFormData {
             name,
@@ -205,6 +213,8 @@ impl ProfileForm {
             exclude_config_context,
             api_vrf,
             api_route_target,
+            token_store,
+            config_token: _,
         } = data;
         let mut form = Self::add();
         form.inputs.input_mut(field::NAME).unwrap().set_value(name);
@@ -232,6 +242,7 @@ impl ProfileForm {
         form.exclude_config_context = exclude_config_context;
         form.api_vrf = api_vrf;
         form.api_route_target = api_route_target;
+        form.token_store = token_store;
         form.editing = Some(name.to_string());
         form
     }
@@ -266,9 +277,9 @@ impl ProfileForm {
     }
 
     /// The token field's value, trimmed of surrounding whitespace, `None` when
-    /// empty. Used only to hand straight to the keyring; it is never rendered (the
-    /// field is masked) or logged. Trimming (L6) drops a trailing newline/space a
-    /// paste can leave behind, which would otherwise break auth.
+    /// empty. Used only to hand straight to persistence/client code; it is never
+    /// rendered (the field is masked) or logged. Trimming (L6) drops a trailing
+    /// newline/space a paste can leave behind, which would otherwise break auth.
     pub fn token(&self) -> Option<String> {
         let v = self
             .inputs
@@ -301,9 +312,9 @@ impl ProfileForm {
         t.parse::<usize>().ok().filter(|s| *s > 0)
     }
 
-    /// What the save path should do with the keyring token, from the form state:
-    /// a typed value ⇒ store it (overrides a pending clear); else the `Ctrl+X`
-    /// clear intent ⇒ delete the entry; else ⇒ keep whatever is stored. PURE.
+    /// What the save path should do with a typed token / clear intent. The app
+    /// save path only applies this to the OS keyring when the profile explicitly
+    /// uses `token_store = keyring`; config-token saves derive their own action.
     pub fn token_action(&self) -> TokenAction {
         match self.token() {
             Some(t) => TokenAction::Set(t),
@@ -368,6 +379,15 @@ impl ProfileForm {
     /// Advance the route-target API backend: rest → graphql → rest (`Ctrl+R`).
     pub fn cycle_api_route_target(&mut self) {
         self.api_route_target = cycle_backend(self.api_route_target);
+        self.invalidate_test();
+    }
+
+    /// Toggle token persistence between config and explicit keyring.
+    pub fn toggle_token_store(&mut self) {
+        self.token_store = match self.token_store {
+            TokenStore::Config => TokenStore::Keyring,
+            TokenStore::Keyring => TokenStore::Config,
+        };
         self.invalidate_test();
     }
 
@@ -1217,6 +1237,10 @@ impl ConfigModal {
                 form.cycle_api_route_target();
                 ModalOutcome::None
             }
+            KeyCode::Char('k') if ctrl => {
+                form.toggle_token_store();
+                ModalOutcome::None
+            }
             // Ctrl+T tests the connection; Enter saves; Ctrl+G saves + uses it.
             KeyCode::Char('t') if ctrl => match form.validate() {
                 Ok(()) => {
@@ -1245,8 +1269,8 @@ impl ConfigModal {
                     ModalOutcome::None
                 }
             },
-            // Ctrl+X toggles "clear the stored keyring token on save". Only
-            // meaningful while editing (a fresh add has no stored token to clear),
+            // Ctrl+X toggles "clear the stored token on save". Only meaningful
+            // while editing (a fresh add has no stored token to clear),
             // but harmless on add — token_action ignores Clear when a value is typed.
             KeyCode::Char('x') if ctrl => {
                 form.toggle_clear_token();
@@ -1362,6 +1386,8 @@ mod tests {
             exclude_config_context: true,
             api_vrf: BackendPreference::Rest,
             api_route_target: BackendPreference::Rest,
+            token_store: TokenStore::Config,
+            config_token: None,
         });
     }
 
@@ -1710,10 +1736,13 @@ mod tests {
             exclude_config_context: false,
             api_vrf: BackendPreference::Graphql,
             api_route_target: BackendPreference::Rest,
+            token_store: TokenStore::Keyring,
+            config_token: None,
         });
         let f = m.form().unwrap();
         assert_eq!(f.timeout_secs(), Some(30));
         assert_eq!(f.page_size(), Some(250));
+        assert_eq!(f.token_store, TokenStore::Keyring);
         assert!(!f.exclude_config_context, "prefilled from the config value");
         assert_eq!(f.api_vrf, BackendPreference::Graphql);
         assert_eq!(f.api_route_target, BackendPreference::Rest);

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -105,6 +105,10 @@ impl OnboardingWizard {
                 self.form.toggle_verify_tls();
                 WizardAction::None
             }
+            KeyCode::Char('k') if ctrl => {
+                self.form.toggle_token_store();
+                WizardAction::None
+            }
             // Ctrl+T tests the connection; Enter saves (and finishes).
             KeyCode::Char('t') if ctrl => match self.form.validate() {
                 Ok(()) => {
@@ -168,9 +172,12 @@ impl OnboardingWizard {
 /// has no persistent keyring backend to store it.
 fn validate_for_onboarding_save(form: &ProfileForm) -> Result<(), String> {
     form.validate()?;
-    if form.token().is_some() && !crate::secret::keyring_available() {
+    if form.token().is_some()
+        && form.token_store == crate::config::TokenStore::Keyring
+        && !crate::secret::keyring_available()
+    {
         return Err(
-            "this build can't store pasted tokens; clear token and use token_env or NBOX_TOKEN"
+            "this build can't store tokens in a keyring; switch token_store to config or use token_env"
                 .to_string(),
         );
     }
@@ -191,18 +198,17 @@ pub struct PersistOutcome {
     pub needs_env_guidance: bool,
 }
 
-/// Persist the wizard's profile: prepare a typed-token keyring write first, then
-/// write the metadata (format-preserving) via the same setters the editor uses.
-/// If the metadata write fails, the keyring change is rolled back. The
-/// interactive wizard validates the no-keyring case before calling this, and any
-/// runtime keyring write failure keeps the user in the wizard instead of creating
-/// a profile without the pasted token. Returns a [`PersistOutcome`] describing
-/// what happened so the driver can guide the user when no token source was given.
-/// The token is NEVER written to TOML.
-///
-/// Pure but for the file/keyring writes (mirroring the editor's profile save plus
-/// keyring set on the render thread). Metadata-only and `token_env`-backed
-/// profiles save without touching the keyring.
+/// Persist the wizard's profile. Pasted tokens are stored in config by default;
+/// if the user explicitly selected keyring, prepare that write first, then write
+/// metadata (format-preserving) via the same setters the editor uses. If the
+/// metadata write fails, the keyring change is rolled back. The interactive
+/// wizard validates the no-keyring case before calling this, and any runtime
+/// keyring write failure keeps the user in the wizard instead of creating a
+/// profile without the pasted token. Returns a [`PersistOutcome`] describing what
+/// happened so the driver can guide the user when no token source was given.
+/// Pure but for the file/keyring writes (mirroring the editor's profile save).
+/// Metadata-only, config-token, and `token_env`-backed profiles save without
+/// touching the keyring.
 pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     let name = form.name();
     let url = form.url();
@@ -210,6 +216,7 @@ pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     let auth_scheme = form.auth_scheme;
     let verify_tls = form.verify_tls;
     let token = form.token();
+    let token_store = form.token_store;
 
     // Write the metadata (format-preserving), the same way `ProfileCommand::Add`
     // and the editor do: upsert + the field setters + activate.
@@ -242,11 +249,21 @@ pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
         crate::config::ApiSurface::RouteTarget,
         form.api_route_target,
     )?;
+    crate::config::set_profile_token_store(&mut doc, &name, token_store)?;
+    if token_store == crate::config::TokenStore::Config {
+        crate::config::set_profile_token(&mut doc, &name, token.as_deref())?;
+    } else {
+        crate::config::set_profile_token(&mut doc, &name, None)?;
+    }
     crate::config::set_active_profile(&mut doc, &name);
 
-    let token_action = token
-        .as_ref()
-        .map_or(TokenAction::Keep, |token| TokenAction::Set(token.clone()));
+    let token_action = if token_store == crate::config::TokenStore::Keyring {
+        token
+            .as_ref()
+            .map_or(TokenAction::Keep, |token| TokenAction::Set(token.clone()))
+    } else {
+        TokenAction::Keep
+    };
     let token_change = PreparedTokenChange::prepare(path, None, &name, &token_action)?;
     if let Err(e) = crate::config::write_doc(path, &doc) {
         token_change.rollback();
@@ -254,10 +271,11 @@ pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
     }
     let stored_in_keyring = token_change.stored_token();
     let _ = token_change.commit();
+    let stored_in_config = token_store == crate::config::TokenStore::Config && token.is_some();
 
     // If nothing authenticatable landed — no keyring entry and no token_env — the
     // user must export NBOX_TOKEN or set a token_env to connect.
-    let needs_env_guidance = !stored_in_keyring && token_env.is_none();
+    let needs_env_guidance = !stored_in_keyring && !stored_in_config && token_env.is_none();
 
     Ok(PersistOutcome {
         name,
@@ -384,7 +402,7 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
     }
     // A roomy centered panel; clamp to the available area.
     let popup_w = 64.min(area.width);
-    let popup_h = 16.min(area.height);
+    let popup_h = 17.min(area.height);
     let popup_x = area.x + area.width.saturating_sub(popup_w) / 2;
     let popup_y = area.y + area.height.saturating_sub(popup_h) / 2;
     let popup = Rect::new(popup_x, popup_y, popup_w, popup_h);
@@ -407,6 +425,7 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
         Constraint::Length(4), // the FormInput rows
         Constraint::Length(1), // auth_scheme
         Constraint::Length(1), // verify_tls
+        Constraint::Length(1), // token_store
         Constraint::Length(1), // blank
         Constraint::Length(1), // test state
         Constraint::Length(1), // message
@@ -421,7 +440,7 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
                 Style::default().fg(theme.header),
             )),
             Line::from(Span::styled(
-                "Paste a token to store it in the OS keyring, or name a token_env.",
+                "Paste a token to save it, name a token_env, or Ctrl+K for Keychain.",
                 Style::default().fg(theme.text_dim),
             )),
         ]),
@@ -456,6 +475,20 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
         ])),
         rows[3],
     );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("token_store ", Style::default().fg(theme.header)),
+            Span::styled(
+                match wizard.form.token_store {
+                    crate::config::TokenStore::Config => "config",
+                    crate::config::TokenStore::Keyring => "keyring",
+                },
+                Style::default().fg(theme.accent),
+            ),
+            Span::styled("  (Ctrl+K toggles)", Style::default().fg(theme.text_dim)),
+        ])),
+        rows[4],
+    );
 
     let (test_text, test_style) = match &wizard.form.test {
         TestState::Idle => (String::new(), Style::default().fg(theme.text_dim)),
@@ -469,21 +502,21 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
         ),
         TestState::Failed(e) => (format!("✗ {e}"), Style::default().fg(theme.error)),
     };
-    frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[5]);
+    frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[6]);
 
     if let Some(msg) = &wizard.form.message {
         frame.render_widget(
             Paragraph::new(Span::styled(msg.clone(), Style::default().fg(theme.error))),
-            rows[6],
+            rows[7],
         );
     }
 
     frame.render_widget(
         Paragraph::new(Span::styled(
-            "Tab: field  Ctrl+T: test  Enter: save & continue  Esc: quit",
+            "Tab: field  Ctrl+T: test  Ctrl+K: token store  Enter: save & continue  Esc: quit",
             Style::default().fg(theme.text_dim),
         )),
-        rows[7],
+        rows[8],
     );
 }
 
@@ -534,12 +567,25 @@ mod tests {
     }
 
     #[test]
-    fn enter_blocks_pasted_token_when_keyring_is_unavailable() {
+    fn enter_saves_pasted_token_with_default_config_storage() {
+        let mut w = OnboardingWizard::new();
+        type_into(&mut w, "https://nb.example");
+        for _ in field::URL..field::TOKEN {
+            w.handle_key(key(KeyCode::Tab));
+        }
+        type_into(&mut w, "nbt_secret");
+
+        assert_eq!(w.handle_key(key(KeyCode::Enter)), WizardAction::Save);
+    }
+
+    #[test]
+    fn enter_blocks_keyring_token_when_keyring_is_unavailable() {
         if crate::secret::keyring_available() {
             return;
         }
         let mut w = OnboardingWizard::new();
         type_into(&mut w, "https://nb.example");
+        w.handle_key(ctrl('k')); // opt into keyring
         for _ in field::URL..field::TOKEN {
             w.handle_key(key(KeyCode::Tab));
         }
@@ -550,7 +596,7 @@ mod tests {
             w.form
                 .message
                 .as_deref()
-                .is_some_and(|m| m.contains("can't store pasted tokens")),
+                .is_some_and(|m| m.contains("can't store tokens in a keyring")),
             "message: {:?}",
             w.form.message
         );
@@ -613,10 +659,38 @@ mod tests {
         assert_eq!(cfg.active_profile.as_deref(), Some("default"));
         let prof = &cfg.profiles["default"];
         assert_eq!(prof.url, "https://nb.example");
-        // The token is NEVER in the file.
-        assert!(!text.contains("token ="), "raw token never written to TOML");
+        // No token was typed, so the file carries no token.
+        assert!(!text.contains("token ="), "no token should be invented");
         // A freshly written config is no longer first-run.
         assert!(!crate::config::needs_onboarding(&path, None));
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn persist_writes_pasted_token_to_config_by_default() {
+        let path = temp_config("token");
+        let _ = std::fs::remove_file(&path);
+        let mut w = OnboardingWizard::new();
+        type_into(&mut w, "https://nb.example");
+        for _ in field::URL..field::TOKEN {
+            w.handle_key(key(KeyCode::Tab));
+        }
+        type_into(&mut w, "nbt_secret.value");
+
+        let outcome = persist(&w.form, &path).unwrap();
+
+        assert!(!outcome.stored_in_keyring);
+        assert!(!outcome.needs_env_guidance);
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("token = \"nbt_secret.value\""), "{text}");
+        let cfg: Config = toml::from_str(&text).unwrap();
+        assert_eq!(
+            cfg.profiles["default"]
+                .token
+                .as_ref()
+                .map(crate::config::ConfigToken::expose),
+            Some("nbt_secret.value")
+        );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
 

--- a/src/tui/profile_token.rs
+++ b/src/tui/profile_token.rs
@@ -127,7 +127,7 @@ impl PreparedTokenChange {
                 },
             );
             anyhow::bail!(
-                "pasted token was NOT stored ({e:#}); clear it and use token_env/NBOX_TOKEN or enable keyring storage"
+                "pasted token was NOT stored ({e:#}); switch token_store to config or use token_env/NBOX_TOKEN"
             );
         }
         Ok(Self {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -10,7 +10,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::widgets::TableState;
 
 use crate::cache::{Cache, Freshness};
-use crate::config::{ApiConfig, BackendPreference, ProfileConfig};
+use crate::config::{ApiConfig, BackendPreference, ConfigToken, ProfileConfig, TokenStore};
 use crate::domain::detail::{DetailRow, DetailView, ObjectLink};
 use crate::netbox::auth::AuthScheme;
 use crate::netbox::client::NetBoxClient;
@@ -279,14 +279,15 @@ pub struct ConnectRequest {
     pub auth_scheme: AuthScheme,
     pub verify_tls: bool,
     /// The token to authenticate the probe with: the form's typed token, else the
-    /// resolved env token (token_env / `NBOX_TOKEN`). `None` here ⇒ try
-    /// [`keyring_account`](Self::keyring_account) in the spawned probe. If both are
-    /// absent the probe runs unauthenticated and likely 401s (surfaced as failure).
+    /// resolved env/config token (token_env / `NBOX_TOKEN` / profile `token`).
+    /// `None` here ⇒ try [`keyring_account`](Self::keyring_account) in the spawned
+    /// probe, but only for explicit keyring profiles. If both are absent the probe
+    /// runs unauthenticated and likely 401s (surfaced as failure).
     pub token: Option<String>,
     /// The OS-keyring account to read as the *last* token tier, resolved inside the
     /// spawned test-connect task — NOT on the render/event thread (M9). Only set
-    /// when editing an existing profile (a fresh add / onboarding has no keyring
-    /// entry yet). Ignored when `token` is already `Some`.
+    /// when editing an existing profile whose token_store is explicitly keyring.
+    /// Ignored when `token` is already `Some`.
     pub keyring_account: Option<String>,
 }
 
@@ -467,9 +468,8 @@ pub enum AppCommand {
         name: String,
         config: ProfileConfig,
         /// The active config file path, for keying the keyring token lookup during
-        /// reconnect (token resolution is `token_env` → `NBOX_TOKEN` → keyring).
-        /// `None` when the session has no backing file (token then comes from env
-        /// only).
+        /// reconnect when no config/env token exists. `None` when the session has
+        /// no backing file (token then comes from env/config only).
         config_path: Option<PathBuf>,
     },
     /// Test-connect a candidate profile from the Config modal: build a temporary
@@ -2102,6 +2102,8 @@ impl App {
                 exclude_config_context,
                 api_vrf,
                 api_route_target,
+                token_store: cfg.token_store,
+                config_token: cfg.token.as_ref().map(ConfigToken::expose),
             },
         ) {
             self.set_status(format!("save failed: {e:#}"), Severity::Error);
@@ -2122,8 +2124,8 @@ impl App {
     /// Build a [`ConnectRequest`] from the open form: the form's url/auth/tls plus
     /// the token to probe with. The probe token uses the SAME precedence as save /
     /// launch (M15) so the test reflects what a real connection would use:
-    ///   typed token → form `token_env` → `NBOX_TOKEN` → keyring (for the
-    ///   profile being edited).
+    ///   typed token → form `token_env` → `NBOX_TOKEN` → config token → keyring
+    ///   (only for explicit keyring profiles).
     /// Returns `None` if no form is open.
     fn form_connect_request(&self) -> Option<ConnectRequest> {
         let Some(Modal::Config(modal)) = &self.modal else {
@@ -2134,17 +2136,27 @@ impl App {
             .config_path
             .clone()
             .unwrap_or_else(|| PathBuf::from(""));
-        // The cheap (non-blocking) env tiers are resolved here: typed token wins,
-        // else the form's token_env, else NBOX_TOKEN. The keyring tier (potentially
-        // blocking) is deferred to the spawned probe via `keyring_account` (M9).
+        let editing_entry = form
+            .editing
+            .as_deref()
+            .and_then(|name| self.profiles.iter().find(|p| p.name == name));
+        // The cheap (non-blocking) tiers are resolved here: typed token wins, else
+        // the form's token_env, else NBOX_TOKEN, else the stored config token. The
+        // keyring tier (potentially blocking) is deferred to the spawned probe via
+        // `keyring_account` only when explicitly selected (M9).
         let token = form.token().or_else(|| {
             form.token_env()
                 .and_then(|name| std::env::var(&name).ok())
                 .filter(|t| !t.is_empty())
                 .or_else(|| std::env::var("NBOX_TOKEN").ok().filter(|t| !t.is_empty()))
+                .or_else(|| {
+                    editing_entry
+                        .and_then(|entry| entry.config.token.as_ref())
+                        .map(|token| token.expose().to_string())
+                })
         });
-        // Only an edit of an existing profile has a keyring entry to fall back to.
-        let keyring_account = if token.is_none() {
+        // Only an explicit keyring edit has a keyring entry to fall back to.
+        let keyring_account = if token.is_none() && form.token_store == TokenStore::Keyring {
             form.editing
                 .as_deref()
                 .map(|name| crate::secret::account_key(&path.display().to_string(), name))
@@ -2173,10 +2185,10 @@ impl App {
         }]
     }
 
-    /// Persist the open form's profile (config-file metadata + optional keyring
-    /// token), add/update it in the live `profiles`, and — when `use_it` — set it
-    /// active and ride the switch path to reconnect. Returns the switch command
-    /// when switching, else nothing.
+    /// Persist the open form's profile (metadata + optional config/keyring token),
+    /// add/update it in the live `profiles`, and — when `use_it` — set it active
+    /// and ride the switch path to reconnect. Returns the switch command when
+    /// switching, else nothing.
     fn modal_save(&mut self, use_it: bool) -> Vec<AppCommand> {
         // Snapshot the form fields (the borrow of `self.modal` must end before we
         // touch `self.profiles`/config).
@@ -2188,6 +2200,7 @@ impl App {
         };
         let name = form.name();
         let url = form.url();
+        let typed_token = form.token();
         let token_env = form.token_env();
         let auth_scheme = form.auth_scheme;
         let verify_tls = form.verify_tls;
@@ -2196,8 +2209,36 @@ impl App {
         let exclude_config_context = form.exclude_config_context;
         let api_vrf = form.api_vrf;
         let api_route_target = form.api_route_target;
-        let token_action = form.token_action();
+        let token_store = form.token_store;
+        let clear_token = form.clear_token;
         let original = form.editing.clone();
+        let existing_config_token = original.as_deref().and_then(|original| {
+            self.profiles
+                .iter()
+                .find(|p| p.name == original)
+                .and_then(|entry| entry.config.token.as_ref())
+                .map(|token| token.expose().to_string())
+        });
+        let config_token = if token_store == TokenStore::Config {
+            if clear_token {
+                None
+            } else {
+                typed_token.clone().or(existing_config_token.clone())
+            }
+        } else {
+            None
+        };
+        let token_action = if token_store == TokenStore::Keyring {
+            if clear_token {
+                crate::tui::config_modal::TokenAction::Clear
+            } else if let Some(token) = typed_token.clone().or(existing_config_token.clone()) {
+                crate::tui::config_modal::TokenAction::Set(token)
+            } else {
+                crate::tui::config_modal::TokenAction::Keep
+            }
+        } else {
+            crate::tui::config_modal::TokenAction::Keep
+        };
 
         // M7: a save with no backing config path can't persist anything; surface an
         // error rather than silently "succeeding" with an in-memory-only edit.
@@ -2229,8 +2270,8 @@ impl App {
                 }
             };
 
-        // Write the metadata to the config file (format-preserving). The token is
-        // NEVER written here. On a rename the old TOML section is removed (H1).
+        // Write the metadata + optional config token to the config file
+        // (format-preserving). On a rename the old TOML section is removed (H1).
         if let Err(e) = Self::persist_profile(
             &path,
             original.as_deref(),
@@ -2245,6 +2286,8 @@ impl App {
                 exclude_config_context,
                 api_vrf,
                 api_route_target,
+                token_store,
+                config_token: config_token.as_deref(),
             },
         ) {
             token_change.rollback();
@@ -2268,6 +2311,8 @@ impl App {
             page_size,
             exclude_config_context: Some(exclude_config_context),
             api,
+            token_store,
+            token: config_token.clone().map(ConfigToken::new),
             ..Default::default()
         };
         self.upsert_live_profile(original.as_deref(), &name, config);
@@ -2303,8 +2348,8 @@ impl App {
             }
             return commands;
         }
-        // H5: surface the token warning instead of an unconditional "saved", so a
-        // dropped token (keyring unavailable) is never masked by a success line.
+        // H5: surface a keyring warning instead of an unconditional "saved", so a
+        // failed keyring migration is never masked by a success line.
         match token_status {
             Some((msg, sev)) => self.set_status(msg, sev),
             None => self.set_status(format!("saved profile '{name}'"), Severity::Success),
@@ -2321,7 +2366,8 @@ impl App {
     }
 
     /// Persist a profile's editor metadata to the config file (format-preserving).
-    /// The token is never written here — it goes to the keyring separately.
+    /// A config-token is written here when selected; keyring tokens are prepared
+    /// separately before this write.
     ///
     /// `original` is the pre-edit name when editing (`None` on add). On a rename
     /// (`original` differs from `name`) the old `[profiles.<original>]` section is
@@ -2345,6 +2391,8 @@ impl App {
             exclude_config_context,
             api_vrf,
             api_route_target,
+            token_store,
+            config_token,
         } = *data;
         let mut doc = crate::config::load_doc_or_new(path)?;
         // Rename: drop the old section and repoint active_profile if it named it.
@@ -2382,6 +2430,8 @@ impl App {
             ApiSurface::RouteTarget,
             api_route_target,
         )?;
+        crate::config::set_profile_token_store(&mut doc, name, token_store)?;
+        crate::config::set_profile_token(&mut doc, name, config_token)?;
         // First profile in a fresh file becomes active.
         if doc.get("active_profile").is_none() {
             crate::config::set_active_profile(&mut doc, name);
@@ -2406,7 +2456,7 @@ impl App {
         use crate::tui::config_modal::TokenAction;
         match action {
             TokenAction::Set(_) if !crate::secret::keyring_available() => Some(
-                "this build can't store pasted tokens; clear token and use token_env or NBOX_TOKEN"
+                "this build can't store tokens in a keyring; switch token_store to config"
                     .to_string(),
             ),
             TokenAction::Clear if !crate::secret::keyring_available() => Some(
@@ -2466,6 +2516,8 @@ impl App {
         let api_route_target = entry
             .config
             .api_preference(crate::config::ApiSurface::RouteTarget);
+        let token_store = entry.config.token_store;
+        let config_token = entry.config.token.as_ref().map(ConfigToken::expose);
         if let Some(Modal::Config(modal)) = &mut self.modal {
             modal.open_edit_form(ProfileFormData {
                 name,
@@ -2478,6 +2530,8 @@ impl App {
                 exclude_config_context,
                 api_vrf,
                 api_route_target,
+                token_store,
+                config_token,
             });
         }
     }
@@ -3267,6 +3321,7 @@ impl App {
     /// guarantee it).
     fn switch_to_index(&mut self, idx: usize) -> Vec<AppCommand> {
         let entry = self.profiles[idx].clone();
+        let name = entry.name.clone();
         // Mint a fresh switch id and record it as both the awaited completion and
         // the high-water mark, so a slower, superseded switch — even one to this
         // same profile name — is dropped on arrival. `pending_profile` keeps the
@@ -3274,12 +3329,12 @@ impl App {
         self.switch_seq += 1;
         self.pending_switch = Some(self.switch_seq);
         self.switch_gen = self.switch_seq;
-        self.pending_profile = Some(entry.name.clone());
+        self.pending_profile = Some(name.clone());
         self.pending_switch_notice = None;
-        self.set_status(format!("switching to '{}'…", entry.name), Severity::Info);
+        self.set_status(format!("switching to '{name}'…"), Severity::Info);
         vec![AppCommand::SwitchProfile {
             id: self.switch_seq,
-            name: entry.name,
+            name: name.clone(),
             config: entry.config,
             config_path: self.config_path.clone(),
         }]
@@ -7437,7 +7492,7 @@ mod tests {
     }
 
     #[test]
-    fn add_profile_saves_metadata_to_config_and_live_list_without_token_in_toml() {
+    fn add_profile_saves_metadata_and_token_env_to_config() {
         let (mut a, _dir, path) = app_with_config(&["alpha"]);
         a.handle_event(press(KeyCode::Char('S'))); // open modal
         a.handle_event(press(KeyCode::Char('a'))); // add form
@@ -7451,14 +7506,14 @@ mod tests {
         assert!(cmds.is_empty(), "plain save does not switch");
         // The live list gained the profile.
         assert!(a.profiles.iter().any(|p| p.name == "lab"));
-        // The file has the metadata but NEVER the token.
+        // The file has the metadata and env-var name, not a token value.
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.contains("[profiles.lab]"));
         assert!(text.contains("https://nb.lab"));
         assert!(text.contains("token_env = \"NETBOX_TOKEN\""));
         assert!(
             !text.contains("nbt_supersecret"),
-            "the token must never be written to TOML"
+            "an env-backed profile should not invent a config token"
         );
         // Back on the list, the saved profile is selected.
         if let Some(Modal::Config(m)) = &a.modal {
@@ -7467,10 +7522,7 @@ mod tests {
     }
 
     #[test]
-    fn add_profile_with_pasted_token_blocks_when_keyring_is_unavailable() {
-        if crate::secret::keyring_available() {
-            return;
-        }
+    fn add_profile_with_pasted_token_saves_config_token_by_default() {
         let (mut a, _dir, path) = app_with_config(&["alpha"]);
         a.handle_event(press(KeyCode::Char('S'))); // open modal
         a.handle_event(press(KeyCode::Char('a'))); // add form
@@ -7484,32 +7536,28 @@ mod tests {
         let cmds = a.handle_event(press(KeyCode::Enter));
 
         assert!(cmds.is_empty());
-        assert!(
-            a.profiles.iter().all(|p| p.name != "lab"),
-            "profile should not be added live when token storage is impossible"
+        let lab = a
+            .profiles
+            .iter()
+            .find(|p| p.name == "lab")
+            .expect("profile should be added live");
+        assert_eq!(
+            lab.config.token.as_ref().map(ConfigToken::expose),
+            Some("nbt_supersecret.value")
         );
+        assert_eq!(lab.config.token_store, TokenStore::Config);
         let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("[profiles.lab]"));
+        assert!(text.contains("token = \"nbt_supersecret.value\""), "{text}");
         assert!(
-            !text.contains("[profiles.lab]"),
-            "metadata should not be written when a pasted token cannot be stored: {text}"
+            !text.contains("token_store"),
+            "config storage is the default and should not need a token_store key: {text}"
         );
-        assert_eq!(a.status_severity, Severity::Error);
-        assert!(
-            a.status.contains("can't store pasted tokens"),
-            "{}",
-            a.status
-        );
+        assert_eq!(a.status_severity, Severity::Success);
         if let Some(Modal::Config(m)) = &a.modal {
-            let f = m.form().expect("form stays open");
-            assert!(
-                f.message
-                    .as_deref()
-                    .is_some_and(|m| m.contains("can't store pasted tokens")),
-                "form message: {:?}",
-                f.message
-            );
+            assert!(matches!(m.profiles.mode, ProfilesMode::List { .. }));
         } else {
-            panic!("config modal should remain open");
+            panic!("config modal should remain open on the profile list");
         }
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1692,12 +1692,14 @@ fn render_config_profiles(
         }
         ProfilesMode::Form(form) => {
             // Layout: the 6 form rows up top (name/url/token_env/token + the two
-            // numeric fields), then the non-text controls (auth/tls/exclude + the
-            // two API backends), the test state, the help line, and a message.
+            // numeric fields), then the non-text controls (auth/tls/token store/
+            // exclude + the two API backends), the test state, the help line, and
+            // a message.
             let rows = Layout::vertical([
                 Constraint::Length(6), // the FormInput rows
                 Constraint::Length(1), // auth_scheme
                 Constraint::Length(1), // verify_tls
+                Constraint::Length(1), // token_store
                 Constraint::Length(1), // exclude_config_context
                 Constraint::Length(1), // api vrf
                 Constraint::Length(1), // api route_target
@@ -1738,6 +1740,20 @@ fn render_config_profiles(
             );
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
+                    Span::styled("token_store   ", Style::default().fg(theme.header)),
+                    Span::styled(
+                        match form.token_store {
+                            crate::config::TokenStore::Config => "config",
+                            crate::config::TokenStore::Keyring => "keyring",
+                        },
+                        Style::default().fg(theme.accent),
+                    ),
+                    Span::styled("  (Ctrl+K toggles)", Style::default().fg(theme.text_dim)),
+                ])),
+                rows[3],
+            );
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
                     Span::styled("config_ctx    ", Style::default().fg(theme.header)),
                     Span::styled(
                         if form.exclude_config_context {
@@ -1749,7 +1765,7 @@ fn render_config_profiles(
                     ),
                     Span::styled("  (Ctrl+E toggles)", Style::default().fg(theme.text_dim)),
                 ])),
-                rows[3],
+                rows[4],
             );
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
@@ -1757,7 +1773,7 @@ fn render_config_profiles(
                     Span::styled(form.api_vrf.as_str(), Style::default().fg(theme.accent)),
                     Span::styled("  (Ctrl+B cycles)", Style::default().fg(theme.text_dim)),
                 ])),
-                rows[4],
+                rows[5],
             );
             frame.render_widget(
                 Paragraph::new(Line::from(vec![
@@ -1768,7 +1784,7 @@ fn render_config_profiles(
                     ),
                     Span::styled("  (Ctrl+R cycles)", Style::default().fg(theme.text_dim)),
                 ])),
-                rows[5],
+                rows[6],
             );
 
             let (test_text, test_style) = match &form.test {
@@ -1783,25 +1799,25 @@ fn render_config_profiles(
                 ),
                 TestState::Failed(e) => (format!("✗ {e}"), Style::default().fg(theme.error)),
             };
-            frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[7]);
+            frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[8]);
 
             if let Some(msg) = &form.message {
                 frame.render_widget(
                     Paragraph::new(Span::styled(msg.clone(), Style::default().fg(theme.error))),
-                    rows[8],
+                    rows[9],
                 );
             }
 
             // Save+use is Ctrl+G (Ctrl+U is the field clear-line). On an edit form
-            // also advertise Ctrl+X, which clears the stored keyring token on save.
+            // also advertise Ctrl+X, which clears the stored token on save.
             let help = if form.editing.is_some() {
-                "Tab: field  Ctrl+T: test  Enter: save  Ctrl+G: save+use  Ctrl+X: clear token  Esc: back"
+                "Tab: field  Ctrl+K: token store  Ctrl+T: test  Enter: save  Ctrl+G: save+use  Ctrl+X: clear token  Esc: back"
             } else {
-                "Tab: field  Ctrl+T: test  Enter: save  Ctrl+G: save+use  Esc: back"
+                "Tab: field  Ctrl+K: token store  Ctrl+T: test  Enter: save  Ctrl+G: save+use  Esc: back"
             };
             frame.render_widget(
                 Paragraph::new(Span::styled(help, Style::default().fg(theme.text_dim))),
-                rows[9],
+                rows[10],
             );
         }
         ProfilesMode::ConfirmDelete { name, .. } => {


### PR DESCRIPTION
Reverses the 0.7.1 shape where a pasted token was blocked unless a real OS keyring existed — too much friction. Now a pasted API key in onboarding or the Settings profile builder just works.

## Behavior
- **Default `token_store = config`**: a pasted token is written to `config.toml` (`token = "..."`) and you're connected — **no keyring prompt** on a fresh install.
- **Keyring is opt-in**: `Ctrl+K` in the TUI or `nbox config token set` writes `token_store = "keyring"`, stores the token in the OS keyring, and clears the TOML token. The keyring is only ever consulted when a profile opts in.
- **Precedence**: `token_env` → `NBOX_TOKEN` → config token → (opt-in) keyring → none.

## Security (plaintext-on-disk done carefully)
- `config show`, `--json`, and `Debug` redact the config token (`ConfigToken` has a redacting `Debug`; `redact_secrets` covers profile tokens; `config show` redacts before both JSON and TOML output).
- Config writes are `0600` on Unix.
- Editor edit never reads the secret back into the form; an empty token field on edit *keeps* the existing token (preserved across same-name edits and renames); `Ctrl+X` clears it.

## Gate
fmt · clippy (both feature modes) · tests (both modes, 964 / 869) all green.

Known minors deferred: `config init` writes `0644` (never holds a token), the `0600` write-then-chmod race, Windows perms, and a cosmetic keyring-migrate message.