### PR TITLE
fix(auth): tolerate a pasted Bearer/Token prefix; surface NetBox auth detail

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -558,19 +558,53 @@ pub fn resolve_token(
         .as_ref()
         .and_then(|name| std::env::var(name).ok());
     let nbox = std::env::var("NBOX_TOKEN").ok();
-    if let Some(t) = select_env_token(token_env, nbox) {
-        return Some(t);
+    let raw = select_env_token(token_env, nbox)
+        .or_else(|| {
+            profile
+                .token
+                .as_ref()
+                .map(|t| t.expose().to_string())
+                .filter(|t| !t.is_empty())
+        })
+        .or_else(|| {
+            (profile.token_store == TokenStore::Keyring)
+                .then(|| {
+                    let account = crate::secret::account_key(
+                        &config_path.display().to_string(),
+                        profile_name,
+                    );
+                    crate::secret::keyring_get(&account)
+                })
+                .flatten()
+        })?;
+    // Normalize whatever the source gave us: a `Bearer `/`Token ` prefix or stray
+    // whitespace from a paste must not reach the wire. NetBox's "copy" button hands
+    // you the full `Authorization` header value, so this is the common case.
+    normalize_token(&raw)
+}
+
+/// Strip surrounding whitespace and an accidental `Bearer `/`Token ` scheme prefix
+/// from a token value. NetBox's UI copies the full `Authorization` header value
+/// (`Bearer nbt_…`), so pasting that verbatim — into the token field, a `token_env`
+/// var, or `NBOX_TOKEN` — still works: nbox adds the scheme itself from
+/// `auth_scheme`. Returns `None` when nothing usable remains.
+pub(crate) fn normalize_token(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let mut value = trimmed;
+    for scheme in ["Bearer", "Token"] {
+        if let Some(rest) = trimmed
+            .get(..scheme.len())
+            .filter(|p| p.eq_ignore_ascii_case(scheme))
+            .map(|_| &trimmed[scheme.len()..])
+            && (rest.is_empty() || rest.starts_with(char::is_whitespace))
+        {
+            // A scheme *word* followed by whitespace (or nothing) — so a real token
+            // like "Tokenxyz" is never mistaken for a "Token " prefix.
+            value = rest.trim();
+            break;
+        }
     }
-    if let Some(token) = &profile.token
-        && !token.expose().is_empty()
-    {
-        return Some(token.expose().to_string());
-    }
-    if profile.token_store != TokenStore::Keyring {
-        return None;
-    }
-    let account = crate::secret::account_key(&config_path.display().to_string(), profile_name);
-    crate::secret::keyring_get(&account)
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 /// Report the *source* of the resolved token for `profile` without exposing the
@@ -1763,6 +1797,52 @@ search = "graphql"
         let rendered = serde_json::to_string(&cfg).unwrap();
         assert!(rendered.contains("<redacted>"));
         assert!(!rendered.contains("nbt_supersecret"));
+    }
+
+    #[test]
+    fn normalize_token_strips_scheme_prefix_and_whitespace() {
+        // NetBox's copy button hands you "Bearer nbt_…"; pasting it verbatim must
+        // still yield a bare key. Case-insensitive; stray whitespace is trimmed.
+        assert_eq!(
+            normalize_token("  nbt_abc.def  ").as_deref(),
+            Some("nbt_abc.def")
+        );
+        assert_eq!(
+            normalize_token("Bearer nbt_abc.def").as_deref(),
+            Some("nbt_abc.def")
+        );
+        assert_eq!(
+            normalize_token("bearer  nbt_abc.def").as_deref(),
+            Some("nbt_abc.def")
+        );
+        assert_eq!(
+            normalize_token("Token 0123abcd").as_deref(),
+            Some("0123abcd")
+        );
+        assert_eq!(
+            normalize_token("Bearer nbt_abc.def\n").as_deref(),
+            Some("nbt_abc.def")
+        );
+        assert_eq!(normalize_token("   "), None);
+        assert_eq!(normalize_token("Bearer   "), None);
+    }
+
+    #[test]
+    fn resolve_token_strips_a_bearer_prefix_from_the_config_token() {
+        // The exact footgun: a "Bearer nbt_…" pasted into the config token field
+        // (NetBox's copy value) still resolves to the bare key on the wire.
+        let profile = ProfileConfig {
+            url: "https://nb.example".into(),
+            token: Some(ConfigToken::new("Bearer nbt_abc.def")),
+            ..Default::default()
+        };
+        if std::env::var("NBOX_TOKEN").is_err() {
+            let path = Path::new("/nbox/test/bearer-strip/config.toml");
+            assert_eq!(
+                resolve_token(&profile, path, "default").as_deref(),
+                Some("nbt_abc.def")
+            );
+        }
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,13 +10,15 @@ use thiserror::Error;
 /// An error condition with a stable, documented exit code.
 #[derive(Debug, Error)]
 pub enum NboxError {
-    /// HTTP 401 — missing, wrong, or expired token.
-    #[error("authentication failed (HTTP 401) — check the token for this profile")]
-    Authentication,
+    /// HTTP 401 — missing, wrong, or expired token. The `String` is the server's
+    /// reason as a ready-to-print suffix (`": Invalid token"`, or empty).
+    #[error("authentication failed (HTTP 401){0} — check the token for this profile")]
+    Authentication(String),
 
-    /// HTTP 403 — the token is valid but lacks permission.
-    #[error("permission denied (HTTP 403) — the token cannot access this resource")]
-    PermissionDenied,
+    /// HTTP 403 — the token is rejected or lacks permission. The `String` is the
+    /// server's reason as a ready-to-print suffix (`": Invalid v2 token"`, or empty).
+    #[error("permission denied (HTTP 403){0} — check the token for this profile")]
+    PermissionDenied(String),
 
     /// A lookup matched nothing. Carries a friendly, actionable message.
     #[error("{0}")]
@@ -48,7 +50,7 @@ impl NboxError {
     pub fn exit_code(&self) -> i32 {
         match self {
             NboxError::Usage(_) => 2,
-            NboxError::Authentication | NboxError::PermissionDenied => 3,
+            NboxError::Authentication(_) | NboxError::PermissionDenied(_) => 3,
             NboxError::NotFound(_) => 4,
             NboxError::Ambiguous { .. } => 5,
             NboxError::Api { .. } => 1,
@@ -86,8 +88,8 @@ mod tests {
     #[test]
     fn exit_codes_are_stable() {
         assert_eq!(NboxError::Usage("x".into()).exit_code(), 2);
-        assert_eq!(NboxError::Authentication.exit_code(), 3);
-        assert_eq!(NboxError::PermissionDenied.exit_code(), 3);
+        assert_eq!(NboxError::Authentication(String::new()).exit_code(), 3);
+        assert_eq!(NboxError::PermissionDenied(String::new()).exit_code(), 3);
         assert_eq!(NboxError::NotFound("x".into()).exit_code(), 4);
         assert_eq!(
             NboxError::Ambiguous {
@@ -122,8 +124,8 @@ mod tests {
         // is the real path `main` takes, since handlers wrap errors with context.
         let cases: [(NboxError, i32); 6] = [
             (NboxError::Usage("bad combo".into()), 2),
-            (NboxError::Authentication, 3),
-            (NboxError::PermissionDenied, 3),
+            (NboxError::Authentication(String::new()), 3),
+            (NboxError::PermissionDenied(String::new()), 3),
             (NboxError::NotFound("nope".into()), 4),
             (
                 NboxError::Ambiguous {
@@ -154,7 +156,7 @@ mod tests {
     #[test]
     fn exit_code_survives_multiple_context_layers() {
         // Several nested context layers — the deepest typed error still wins.
-        let err = anyhow::Error::from(NboxError::Authentication)
+        let err = anyhow::Error::from(NboxError::Authentication(String::new()))
             .context("authenticating to NetBox")
             .context("running `nbox device edge01`")
             .context("dispatching command");
@@ -166,7 +168,7 @@ mod tests {
         // A typed error buried beneath an untyped (string) context layer — the
         // realistic shape when a handler adds a `.with_context(|| "...")` note —
         // is still recovered by walking the chain.
-        let err = anyhow::Error::from(NboxError::PermissionDenied)
+        let err = anyhow::Error::from(NboxError::PermissionDenied(String::new()))
             .context("fetching /api/dcim/sites/")
             .context("running `nbox site iad1`");
         assert_eq!(NboxError::exit_code_for(&err), 3);

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -393,14 +393,36 @@ async fn retry_on_rate_limit(res: &reqwest::Response, attempt: u32, what: &str) 
     true
 }
 
+/// Extract a printable reason suffix from a NetBox auth-error body. NetBox returns
+/// `{"detail":"Invalid v2 token"}` on a rejected token (401/403), so surface that
+/// real cause instead of a generic "permission denied" — the difference between a
+/// 5-minute fix (regenerate the token) and an hour of chasing config. Returns
+/// `": <reason>"`, or empty when the body has no usable detail.
+fn auth_detail(body: &str) -> String {
+    let body = body.trim();
+    if body.is_empty() {
+        return String::new();
+    }
+    let detail = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| v.get("detail").and_then(|d| d.as_str()).map(str::to_string))
+        .unwrap_or_else(|| truncate(body, 200));
+    let detail = detail.trim();
+    if detail.is_empty() {
+        String::new()
+    } else {
+        format!(": {detail}")
+    }
+}
+
 /// Map a non-success HTTP status to a typed [`NboxError`] so exit codes are
 /// consistent no matter which path hit the error: 401→auth, 403→perms, 404→not
 /// found, everything else→generic API error. (Note: `get_optional` intercepts
 /// 404 earlier as `Ok(None)`; this covers raw 404s on `get`, e.g. `nbox raw`.)
 fn status_error(status: reqwest::StatusCode, body: &str) -> NboxError {
     match status {
-        reqwest::StatusCode::UNAUTHORIZED => NboxError::Authentication,
-        reqwest::StatusCode::FORBIDDEN => NboxError::PermissionDenied,
+        reqwest::StatusCode::UNAUTHORIZED => NboxError::Authentication(auth_detail(body)),
+        reqwest::StatusCode::FORBIDDEN => NboxError::PermissionDenied(auth_detail(body)),
         reqwest::StatusCode::NOT_FOUND => {
             let body = body.trim();
             if body.is_empty() {
@@ -539,6 +561,19 @@ mod tests {
     fn backoff_grows() {
         assert!(backoff(0) < backoff(1));
         assert!(backoff(1) < backoff(2));
+    }
+
+    #[test]
+    fn auth_detail_extracts_netbox_detail() {
+        // NetBox's `{"detail": "..."}` becomes a ": reason" suffix the auth error
+        // appends; non-JSON falls back to the body; empty stays empty.
+        assert_eq!(
+            auth_detail(r#"{"detail":"Invalid v2 token"}"#),
+            ": Invalid v2 token"
+        );
+        assert_eq!(auth_detail("Forbidden"), ": Forbidden");
+        assert_eq!(auth_detail("   "), "");
+        assert_eq!(auth_detail(""), "");
     }
 
     #[test]

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -281,13 +281,10 @@ impl ProfileForm {
     /// rendered (the field is masked) or logged. Trimming (L6) drops a trailing
     /// newline/space a paste can leave behind, which would otherwise break auth.
     pub fn token(&self) -> Option<String> {
-        let v = self
-            .inputs
-            .value(field::TOKEN)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if v.is_empty() { None } else { Some(v) }
+        // Normalize on read so a pasted `Bearer …`/`Token …` header value (NetBox's
+        // copy button) or stray whitespace is cleaned before it's saved or used for
+        // test-connect — the stored token stays a bare key.
+        crate::config::normalize_token(self.inputs.value(field::TOKEN).unwrap_or(""))
     }
 
     /// The trimmed `timeout_secs` field parsed to an optional interval: empty ⇒

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -190,7 +190,10 @@ async fn http_401_maps_to_authentication_error() {
         .chain()
         .find_map(|e| e.downcast_ref::<NboxError>())
         .expect("an NboxError should be in the chain");
-    assert!(matches!(typed, NboxError::Authentication), "got: {typed:?}");
+    assert!(
+        matches!(typed, NboxError::Authentication(_)),
+        "got: {typed:?}"
+    );
     assert_eq!(NboxError::exit_code_for(&err), 3);
 }
 
@@ -202,7 +205,7 @@ async fn http_403_maps_to_permission_denied_error() {
         .find_map(|e| e.downcast_ref::<NboxError>())
         .expect("an NboxError should be in the chain");
     assert!(
-        matches!(typed, NboxError::PermissionDenied),
+        matches!(typed, NboxError::PermissionDenied(_)),
         "got: {typed:?}"
     );
     assert_eq!(NboxError::exit_code_for(&err), 3);


### PR DESCRIPTION
## Why
NetBox's UI "copy token" button hands you the **full `Authorization` header value** (`Bearer nbt_…`), so users paste the scheme prefix into the token field (or `token_env`/`NBOX_TOKEN`). nbox then sent `Token Bearer nbt_…` and NetBox `403`'d it — and the generic *"permission denied — the token cannot access this resource"* gave no hint why. This bit a real user for ~an hour.

## Fix
- **`normalize_token()`** strips a leading `Bearer`/`Token` scheme word (+ whitespace) from *any* token source at resolution; `ProfileForm::token()` normalizes on read so saves/test-connect store a bare key. nbox still adds the scheme itself from `auth_scheme`. Fixes already-dirty configs too. (Matches a scheme *word* + whitespace, so a real token like `Tokenxyz` is untouched.)
- **401/403 surface NetBox's `detail`** (e.g. `Invalid v2 token`) instead of the generic message — the difference between "regenerate the token" and an hour of chasing config.

## Verified
- New unit tests: `normalize_token_strips_scheme_prefix_and_whitespace`, `resolve_token_strips_a_bearer_prefix_from_the_config_token`, `auth_detail_extracts_netbox_detail`.
- **End-to-end against a live NetBox Cloud 4.6.2 instance**: a `token = "Bearer nbt_…"` that previously `403`'d now connects.

## Gate
fmt · clippy (both feature modes) · tests (both modes, 967 / 872) all green.