### PR TITLE
fix(browse): brief site list to avoid count-annotation timeout (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-06-22
+
+### Fixed
+
+- **Browsing sites no longer times out on large instances.** NetBox's full site
+  list serializer attaches per-site aggregate counts (device / prefix / rack / vlan
+  / circuit), each a subquery over a large table — slow enough to exceed the request
+  timeout on a sizable instance (observed: 100 sites > 120s, while the nav count and
+  every other browse kind return in well under a second). The site browse now
+  requests NetBox's `brief` representation, which omits those counts and returns the
+  `name` + `slug` the browse index shows (~400× faster in testing). Opening a site
+  still fetches the full object for its detail view, so nothing is lost there. Only
+  the site browse is affected; the other kinds already list quickly and keep their
+  full columns.
+
 ## [0.8.0] - 2026-06-22
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "nbox"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nbox"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.88" # floor: `let`-chains, stable since 1.88, used throughout
 description = "Terminal UI and CLI for NetBox — fast search, IPAM lookups, and device context"

--- a/src/netbox/browse.rs
+++ b/src/netbox/browse.rs
@@ -44,7 +44,17 @@ pub async fn browse(
                 .collect()
         }
         ObjectKind::Site => {
-            let rows: Vec<Site> = client.list_all(Endpoint::Sites, vec![], max).await?;
+            // The full site serializer attaches per-site aggregate counts
+            // (device/prefix/rack/vlan/circuit), each a subquery over a large table
+            // — slow enough to time out the list on a sizable instance (observed:
+            // 100 sites > 120s, vs 0.3s with brief). The browse index only needs
+            // name + slug, both in NetBox's `brief` representation, so ask for brief
+            // to skip the counts. Opening a site still fetches the full object for
+            // its detail view, so nothing is lost there. Sites is the only browse
+            // kind heavy enough to need this; the rest list fine at full.
+            let rows: Vec<Site> = client
+                .list_all(Endpoint::Sites, vec![("brief", "true".to_string())], max)
+                .await?;
             rows.into_iter()
                 .map(|s| SearchResult {
                     kind: ObjectKind::Site,
@@ -186,4 +196,50 @@ pub async fn nav_counts(client: &NetBoxClient) -> Vec<(ObjectKind, u32)> {
     .into_iter()
     .filter_map(|(kind, res)| res.ok().map(|c| (kind, c)))
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProfileConfig;
+    use serde_json::json;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client_for(server: &MockServer) -> NetBoxClient {
+        let profile = ProfileConfig {
+            url: server.uri(),
+            ..Default::default()
+        };
+        NetBoxClient::new(&profile, None).unwrap()
+    }
+
+    #[tokio::test]
+    async fn site_browse_requests_brief_to_skip_count_annotations() {
+        // Regression: the site list serializer's per-site aggregate counts are slow
+        // enough to time out the list on a large instance, so browse must request
+        // `brief=true`. This mock matches ONLY when brief=true is present, so a
+        // browse that drops it gets no response and the call fails here.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/dcim/sites/"))
+            .and(query_param("brief", "true"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{
+                    "id": 7, "url": "http://nb/api/dcim/sites/7/", "name": "iad1", "slug": "iad1"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let results = browse(&client_for(&server), ObjectKind::Site, BROWSE_CAP)
+            .await
+            .expect("browse sites");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].display, "iad1");
+        // The subtitle is the slug, which brief includes — so the browse column
+        // survives the brief switch (no column loss for sites).
+        assert_eq!(results[0].subtitle.as_deref(), Some("iad1"));
+    }
 }


### PR DESCRIPTION
## Problem

Browsing **sites** in the TUI times out on a real instance:

```
error: sending request to NetBox: ... /api/dcim/sites/?limit=100&offset=0: operation timed out
```

…while the nav **count for sites shows up fine**. That split is the tell.

## Root cause

NetBox's *full* site list serializer attaches per-site aggregate counts (`device_count`, `prefix_count`, `rack_count`, `vlan_count`, `circuit_count`, …), each a subquery over a large table. The count query (`limit=1`) is cheap, but serializing a full page of sites runs those subqueries per row. Measured against a live 149-site instance:

| Request | Time |
|---|---|
| `?limit=1` (nav count) | **0.19s** ✓ |
| `?limit=100` (full list) | **>120s — timed out** ✗ |
| `?limit=100&brief=true` | **0.29s** ✓ |

Raising `timeout_secs` doesn't help (it's >2 minutes). Every *other* browse kind (devices, racks, prefixes, IPs, vlans, vrfs, route-targets) lists in 0.2–0.8s at full — **sites is the only heavy one.**

## Fix

Request NetBox's `brief` representation for the **site browse** only. Brief omits the counts and returns `id/url/name/slug` — and the site browse index only renders `name` + `slug`, so there's **no column loss**. Opening a site still fetches the full object for its detail view. Other kinds are untouched (they're already fast and keep their full columns).

~400× faster (0.3s vs >120s) on the affected instance.

## Verification

- New unit test `site_browse_requests_brief_to_skip_count_annotations` (wiremock matches only when `brief=true` is sent).
- Confirmed against the live instance: all 149 sites' brief payloads carry the required `id/url/name/slug`, so they deserialize cleanly.
- Gate green: fmt, clippy (all-features), tests.

Bumps 0.8.0 → 0.8.1.