### PR TITLE
Add `nbox profile remove`; fix the profile-add setup hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`nbox profile remove <name>`** deletes a profile from the config
+  (format-preserving). It refuses to remove the active profile (switch with `nbox
+  profile use <other>` first) or the only profile, mirroring the TUI's delete
+  guards — so you can drop a stray profile (e.g. one left by the onboarding
+  wizard) without hand-editing the file.
+
+### Fixed
+
+- The `--no-tui` first-run setup hint printed the wrong `profile add` syntax
+  (`--url <url>`); the URL is a positional argument. The hint now matches the CLI
+  and the docs: `nbox profile add <name> <url> [--token-env <VAR>]`.
+
 ## [0.9.0] - 2026-06-22
 
 ### Added

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -195,6 +195,7 @@ nbox profile add work https://netbox.example.com --token-env NETBOX_TOKEN
 nbox profile use work
 nbox profile list
 nbox profile show [name]
+nbox profile remove <name>   # can't remove the active or only profile
 ```
 
 Pick a profile per-invocation with `--profile <name>`, or point at an alternate

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -533,6 +533,11 @@ pub enum ProfileCommand {
         /// Profile name.
         name: String,
     },
+    /// Remove a profile.
+    Remove {
+        /// Profile name.
+        name: String,
+    },
     /// List configured profiles.
     List,
     /// Show a profile (defaults to the active one).

--- a/src/config.rs
+++ b/src/config.rs
@@ -1289,6 +1289,39 @@ pub fn run_profile(
             eprintln!("active profile set to '{name}'");
             Ok(())
         }
+        ProfileCommand::Remove { name } => {
+            let mut doc = load_doc_or_new(&path)?;
+            // Mirror the TUI's delete guards: don't strand the config by removing
+            // the only profile, and don't remove the active one out from under the
+            // user (they'd be left with a dangling `active_profile`).
+            let (exists, only) = {
+                let profiles = doc.get("profiles").and_then(|p| p.as_table());
+                (
+                    profiles.is_some_and(|t| t.contains_key(&name)),
+                    profiles.is_some_and(toml_edit::Table::is_empty)
+                        || profiles.is_some_and(|t| t.len() == 1),
+                )
+            };
+            if !exists {
+                bail!("no profile named '{name}'");
+            }
+            if only {
+                bail!("can't remove the only profile '{name}'");
+            }
+            let active_is_target = doc
+                .get("active_profile")
+                .and_then(|v| v.as_str())
+                .is_some_and(|a| a == name);
+            if active_is_target {
+                bail!(
+                    "can't remove the active profile '{name}' — switch with `nbox profile use <other>` first"
+                );
+            }
+            remove_profile(&mut doc, &name)?;
+            write_doc(&path, &doc)?;
+            eprintln!("removed profile '{name}'");
+            Ok(())
+        }
         ProfileCommand::List => {
             let cfg = load(&path)?;
             let names: Vec<&String> = cfg.profiles.keys().collect();
@@ -1660,6 +1693,88 @@ search = "graphql"
         let rendered = serde_json::to_string(&cfg).unwrap();
         assert!(rendered.contains("<redacted>"));
         assert!(!rendered.contains("nbt_supersecret"));
+    }
+
+    #[test]
+    fn profile_remove_drops_a_non_active_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let jopts = crate::output::json::JsonOptions::default();
+        // The first add becomes active; the second is just a peer.
+        run_profile(
+            ProfileCommand::Add {
+                name: "work".into(),
+                url: "https://netbox.example.com".into(),
+                token_env: None,
+            },
+            Some(&path),
+            crate::output::Format::Plain,
+            &jopts,
+        )
+        .unwrap();
+        run_profile(
+            ProfileCommand::Add {
+                name: "lab".into(),
+                url: "https://lab.example.com".into(),
+                token_env: None,
+            },
+            Some(&path),
+            crate::output::Format::Plain,
+            &jopts,
+        )
+        .unwrap();
+        run_profile(
+            ProfileCommand::Remove { name: "lab".into() },
+            Some(&path),
+            crate::output::Format::Plain,
+            &jopts,
+        )
+        .unwrap();
+        let cfg = load(&path).unwrap();
+        assert!(cfg.profiles.contains_key("work"));
+        assert!(!cfg.profiles.contains_key("lab"));
+        assert_eq!(cfg.active_profile.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn profile_remove_refuses_missing_active_and_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let jopts = crate::output::json::JsonOptions::default();
+        let add = |name: &str, url: &str| {
+            run_profile(
+                ProfileCommand::Add {
+                    name: name.to_string(),
+                    url: url.to_string(),
+                    token_env: None,
+                },
+                Some(&path),
+                crate::output::Format::Plain,
+                &jopts,
+            )
+        };
+        let remove = |name: &str| {
+            run_profile(
+                ProfileCommand::Remove {
+                    name: name.to_string(),
+                },
+                Some(&path),
+                crate::output::Format::Plain,
+                &jopts,
+            )
+        };
+        add("work", "https://netbox.example.com").unwrap();
+        // Unknown profile name.
+        assert!(remove("nope").is_err());
+        // Removing the only profile would strand the config.
+        assert!(remove("work").is_err());
+        // With a peer present, the active profile is still protected.
+        add("lab", "https://lab.example.com").unwrap();
+        let err = remove("work").unwrap_err();
+        assert!(err.to_string().contains("active profile"));
+        // Nothing was removed by the refused calls.
+        let cfg = load(&path).unwrap();
+        assert_eq!(cfg.profiles.len(), 2);
     }
 
     #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1604,7 +1604,7 @@ fn no_tui_onboarding_refusal() -> anyhow::Error {
         "no usable config and --no-tui set: the interactive onboarding wizard is suppressed.\n\n\
          Set up a profile non-interactively first:\n  \
          nbox config init\n  \
-         nbox profile add <name> --url <url> [--token-env <VAR>]\n\
+         nbox profile add <name> <url> [--token-env <VAR>]\n\
          then export NBOX_TOKEN or set the profile's token_env."
             .to_string(),
     )


### PR DESCRIPTION
## What

Two small CLI fixes that came out of a first-run report (a stray duplicate profile + a bad setup hint).

### `nbox profile remove <name>` (new)
Deletes a profile from the config, format-preserving (reuses the existing `config::remove_profile` toml_edit helper that the TUI already uses). Guards mirror the TUI's delete behavior:

- **active profile** → refused (`switch with \`nbox profile use <other>\` first`)
- **only profile** → refused (won't strand the config)
- **unknown name** → `no profile named '<name>'`

This gives a shell one-liner to drop a profile the first-run **onboarding wizard** leaves behind. The wizard always names its profile `default` (`onboarding.rs`), so a user who onboards in the TUI and then `profile add`s a real profile ends up with a duplicate `default` they previously had to hand-edit out.

### Fix the `--no-tui` setup hint
`no_tui_onboarding_refusal()` printed:

```
nbox profile add <name> --url <url> [--token-env <VAR>]
```

`--url` doesn't exist — the URL is a **positional** argument (`cli.rs`), so copy-pasting the hint errored with `unexpected argument '--url'`. Every user-facing doc (README, CONFIG, TROUBLESHOOTING, SCRIPTING) already used the correct positional form; only this in-code hint was wrong. Now:

```
nbox profile add <name> <url> [--token-env <VAR>]
```

## Tests
- `profile_remove_drops_a_non_active_profile`
- `profile_remove_refuses_missing_active_and_only`
- Smoke-tested on the real binary: remove a stray non-active profile succeeds; active / only / missing are all refused.

## Gate
`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `clippy --no-default-features`, and `cargo test` in both feature modes — all green.