### PR TITLE
Redesign the first-run onboarding wizard (simple + advanced, host-derived name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guards — so you can drop a stray profile (e.g. one left by the onboarding
   wizard) without hand-editing the file.
 
+### Changed
+
+- **First-run onboarding wizard redesign.** The wizard now leads with the URL and
+  shows a simple three-field screen (url / name / token); the niche knobs
+  (`token_env`, `auth_scheme`, `verify_tls`) tuck behind a `Ctrl+A` "advanced"
+  toggle. The profile **name is no longer hardcoded to `default`** — it's derived
+  from the URL host (`https://netbox.acme.com` → `acme`, falling back to `prod`
+  for an IP/empty host), shown live as a placeholder and committed on save unless
+  you type your own. This stops the wizard from planting a stray `default` profile
+  that duplicates one you add later.
+
 ### Fixed
 
 - The `--no-tui` first-run setup hint printed the wrong `profile add` syntax

--- a/src/tui/cheese.rs
+++ b/src/tui/cheese.rs
@@ -238,6 +238,13 @@ impl TextInput {
         self.state.end();
     }
 
+    /// Replace the placeholder shown when the field is empty. Used by the
+    /// onboarding wizard to surface a live, URL-derived name suggestion that
+    /// updates as the user types the URL. PURE: no I/O.
+    pub fn set_placeholder(&mut self, placeholder: impl Into<String>) {
+        self.placeholder = placeholder.into();
+    }
+
     /// The cursor position (in chars from the start), for placing the terminal
     /// cursor on a focused field.
     pub fn cursor_pos(&self) -> usize {
@@ -337,6 +344,40 @@ impl TextInput {
         self.cursor_position(area, &sigil)
     }
 
+    /// Render just the field's value (no sigil/prompt) into `area`, returning the
+    /// terminal cursor cell when `focused`. The label-less counterpart to
+    /// [`render_with_focus`](Self::render_with_focus): a caller laying fields out
+    /// individually (the onboarding wizard, which reorders/hides fields) draws the
+    /// label itself, then this paints the value cell after it. Mirrors the per-row
+    /// widget setup in [`FormInput::render`] (empty prompt, placeholder, masking)
+    /// so a field renders identically whichever path draws it.
+    pub fn render_value(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        focused: bool,
+    ) -> Option<Position> {
+        self.state.set_focused(focused);
+        let palette = cheese_palette(theme);
+        let widget = Input::new("")
+            .prompt("")
+            .placeholder(&self.placeholder)
+            .password_mode(self.masked)
+            .password_char(MASK_CHAR)
+            .palette(&palette);
+        frame.render_stateful_widget(widget, area, &mut self.state);
+        if focused {
+            let x = area
+                .x
+                .saturating_add(self.cursor_display_col())
+                .min(area.right().saturating_sub(1));
+            Some(Position::new(x, area.y))
+        } else {
+            None
+        }
+    }
+
     /// Compute the terminal cursor cell, mirroring cheese's render math: the
     /// prompt (`sigil` + a trailing space) sits at `area.x`, the text starts
     /// after it, and the cursor sits `cursor_pos` display columns into the text.
@@ -417,6 +458,16 @@ impl FormInput {
         if !self.fields.is_empty() {
             let len = self.fields.len();
             self.focus = (self.focus + len - 1) % len;
+        }
+    }
+
+    /// Focus the field at `idx` directly (clamped to range). The onboarding wizard
+    /// uses this to traverse a *subset* of fields in a custom order — Tab there
+    /// walks the visible fields (which omit the hidden/advanced ones), not the raw
+    /// `0..len` sequence [`focus_next`](Self::focus_next) follows.
+    pub fn set_focus(&mut self, idx: usize) {
+        if !self.fields.is_empty() {
+            self.focus = idx.min(self.fields.len() - 1);
         }
     }
 

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::DefaultTerminal;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
@@ -59,8 +59,14 @@ pub enum WizardAction {
 /// behaviour (Tab field movement, Ctrl+S/Ctrl+L controls, Ctrl+T test, Enter
 /// save) — onboarding is just the same form, standalone, before the `App` exists.
 pub struct OnboardingWizard {
-    /// The add-form, prefilled with a sensible default profile name.
+    /// The reused add-[`ProfileForm`]. The name field starts blank — it's derived
+    /// from the url host on save (see [`suggest_name_from_url`]), so onboarding
+    /// never plants a stray `default` profile.
     pub form: ProfileForm,
+    /// When `true`, the advanced fields (token_env, auth_scheme, verify_tls) show
+    /// and Tab reaches them; toggled with `Ctrl+A`. Off by default, so the first
+    /// screen is just url / name / token.
+    pub advanced: bool,
 }
 
 impl Default for OnboardingWizard {
@@ -70,18 +76,18 @@ impl Default for OnboardingWizard {
 }
 
 impl OnboardingWizard {
-    /// A fresh wizard with the name field defaulted to `default`, focus on `url`
-    /// so the user starts where the real input is.
+    /// A fresh wizard focused on `url` — the first thing the user supplies, and
+    /// what the profile name is derived from. The name field is left blank (its
+    /// live placeholder shows the suggestion); a still-blank name is filled from
+    /// the url on save. Advanced fields start collapsed.
     #[must_use]
     pub fn new() -> Self {
         let mut form = ProfileForm::add();
-        // Seed a sensible default name; the user can change it.
-        if let Some(input) = form.form_input_mut().input_mut(field::NAME) {
-            input.set_value("default");
+        form.form_input_mut().set_focus(field::URL);
+        Self {
+            form,
+            advanced: false,
         }
-        // Start focus on the url field (name already has a default).
-        form.form_input_mut().focus_next();
-        Self { form }
     }
 
     /// Handle a key, returning the [`WizardAction`] the driver should act on.
@@ -103,8 +109,28 @@ impl OnboardingWizard {
                 self.form.toggle_verify_tls();
                 WizardAction::None
             }
-            // Ctrl+T tests the connection; Enter saves (and finishes).
-            KeyCode::Char('t') if ctrl => match self.form.validate() {
+            // Ctrl+A reveals/hides the advanced fields (token_env, auth_scheme,
+            // verify_tls). Collapsing pulls focus back if it sat on a hidden field.
+            KeyCode::Char('a') if ctrl => {
+                self.advanced = !self.advanced;
+                self.clamp_focus();
+                WizardAction::None
+            }
+            // Tab/Shift-Tab walk the *visible* fields in display order, so a hidden
+            // token_env is skipped (the form's raw `focus_next` would land on it).
+            KeyCode::Tab => {
+                self.focus_step(true);
+                WizardAction::None
+            }
+            KeyCode::BackTab => {
+                self.focus_step(false);
+                WizardAction::None
+            }
+            // Ctrl+T tests the connection; Enter saves (and finishes). Both treat
+            // the name as optional — a blank name is filled from the url suggestion
+            // so the user only has to supply a url (test reverts it, since the probe
+            // ignores the name and the live suggestion should stay visible).
+            KeyCode::Char('t') if ctrl => match self.validate_optional_name(false) {
                 Ok(()) => {
                     self.form.test = TestState::Testing;
                     self.form.message = None;
@@ -115,7 +141,7 @@ impl OnboardingWizard {
                     WizardAction::None
                 }
             },
-            KeyCode::Enter => match self.form.validate() {
+            KeyCode::Enter => match self.validate_optional_name(true) {
                 Ok(()) => WizardAction::Save,
                 Err(e) => {
                     self.form.message = Some(e);
@@ -152,6 +178,136 @@ impl OnboardingWizard {
             token,
         }
     }
+
+    /// The text fields shown (in display order) for the current mode. Simple mode
+    /// hides `token_env`; both modes hide the numeric tuning fields (`timeout_secs`/
+    /// `page_size` — edited in the config file or the Settings modal). `url` leads.
+    fn visible_fields(&self) -> &'static [usize] {
+        if self.advanced {
+            &[field::URL, field::NAME, field::TOKEN, field::TOKEN_ENV]
+        } else {
+            &[field::URL, field::NAME, field::TOKEN]
+        }
+    }
+
+    /// Move focus to the next (`forward`) or previous visible field, wrapping at
+    /// both ends.
+    fn focus_step(&mut self, forward: bool) {
+        let order = self.visible_fields();
+        let len = order.len();
+        if len == 0 {
+            return;
+        }
+        let cur = self.form.form_input().focus();
+        let pos = order.iter().position(|&f| f == cur).unwrap_or(0);
+        let next = if forward {
+            (pos + 1) % len
+        } else {
+            (pos + len - 1) % len
+        };
+        self.form.form_input_mut().set_focus(order[next]);
+    }
+
+    /// After collapsing the advanced fields, pull focus back to `url` if it sat on
+    /// a now-hidden field.
+    fn clamp_focus(&mut self) {
+        let order = self.visible_fields();
+        let cur = self.form.form_input().focus();
+        if !order.contains(&cur) {
+            self.form.form_input_mut().set_focus(order[0]);
+        }
+    }
+
+    /// Fill the name from the url-derived suggestion when it's blank; returns
+    /// whether it set a value (so the caller can revert it). Never overwrites a
+    /// name the user typed.
+    fn fill_name_from_url_if_blank(&mut self) -> bool {
+        if self.form.name().trim().is_empty() {
+            let suggestion = suggest_name_from_url(&self.form.url());
+            if let Some(input) = self.form.form_input_mut().input_mut(field::NAME) {
+                input.set_value(suggestion);
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Validate with the name treated as optional: fill it from the url suggestion
+    /// when blank, so the shared [`ProfileForm::validate`] (which requires a name)
+    /// passes on a url alone. With `commit`, a successful validation keeps the
+    /// auto-filled name (Enter → save); otherwise — or on failure — it's reverted
+    /// so the live placeholder suggestion stays (test ignores the name, and a
+    /// failed save shouldn't strand a half-derived name in the field).
+    fn validate_optional_name(&mut self, commit: bool) -> Result<(), String> {
+        let auto_filled = self.fill_name_from_url_if_blank();
+        let result = self.form.validate();
+        if auto_filled
+            && (!commit || result.is_err())
+            && let Some(input) = self.form.form_input_mut().input_mut(field::NAME)
+        {
+            input.set_value("");
+        }
+        result
+    }
+}
+
+/// Suggest a profile name from a NetBox URL's host: strip the scheme and any
+/// port/path, drop a single leading `www.`/`netbox.` label, take the next DNS
+/// label, and keep only `[a-z0-9-]` (lowercased). Falls back to `prod` for an
+/// empty host or a bare IP address — so the wizard never has to invent `default`.
+///
+/// `https://netbox.acme.com` → `acme`; `https://acme.example.com:8443/x` → `acme`;
+/// `https://10.0.0.5` / `https://[::1]:8080` → `prod`.
+fn suggest_name_from_url(url: &str) -> String {
+    let fallback = || "prod".to_string();
+    // Authority = between the scheme and the first '/', '?' or '#'.
+    let after_scheme = url.split("://").nth(1).unwrap_or(url).trim();
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim();
+    // Bracketed IPv6 (`[::1]`) has no usable name.
+    if authority.is_empty() || authority.starts_with('[') {
+        return fallback();
+    }
+    // Strip a `host:port` suffix (host has no colon; IPv6 was handled above).
+    let host = authority.split(':').next().unwrap_or("");
+    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
+    if labels.is_empty() {
+        return fallback();
+    }
+    // A bare IPv4 (all-numeric labels) has no usable name.
+    if labels.iter().all(|l| l.chars().all(|c| c.is_ascii_digit())) {
+        return fallback();
+    }
+    // Drop one leading generic label so `netbox.acme.com` → `acme`.
+    let start = match labels.first().copied() {
+        Some("www" | "netbox") if labels.len() > 1 => 1,
+        _ => 0,
+    };
+    let cleaned: String = labels[start]
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-')
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if cleaned.is_empty() {
+        fallback()
+    } else {
+        cleaned
+    }
+}
+
+/// The display label for a form field index (the wizard lays fields out itself).
+fn field_label(idx: usize) -> &'static str {
+    match idx {
+        field::URL => "url",
+        field::NAME => "name",
+        field::TOKEN => "token",
+        field::TOKEN_ENV => "token_env",
+        _ => "",
+    }
 }
 
 /// What [`persist`] did, so the driver can show the right status / steer the user.
@@ -175,7 +331,18 @@ pub struct PersistOutcome {
 /// the user when no token source was given. Pure but for the file write
 /// (mirroring the editor's profile save).
 pub fn persist(form: &ProfileForm, path: &Path) -> Result<PersistOutcome> {
-    let name = form.name();
+    // The wizard leaves the name blank to mean "derive it from the url"; resolve
+    // it here too (not only in the Enter handler) so a direct save still names the
+    // profile sensibly instead of writing an empty name.
+    let name = {
+        let typed = form.name();
+        let typed = typed.trim();
+        if typed.is_empty() {
+            suggest_name_from_url(&form.url())
+        } else {
+            typed.to_string()
+        }
+    };
     let url = form.url();
     let token_env = form.token_env();
     let auth_scheme = form.auth_scheme;
@@ -345,9 +512,20 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
         );
         return;
     }
-    // A roomy centered panel; clamp to the available area.
+    // Keep the name field's placeholder in sync with the live url-derived
+    // suggestion, so an empty name shows what it will become on save.
+    let suggestion = suggest_name_from_url(&wizard.form.url());
+    if let Some(input) = wizard.form.form_input_mut().input_mut(field::NAME) {
+        input.set_placeholder(format!("{suggestion}   (suggested)"));
+    }
+
+    // The panel grows when the advanced fields are showing.
+    let visible = wizard.visible_fields();
+    let advanced_rows = if wizard.advanced { 2 } else { 0 };
+    // intro + blank + fields + [auth + verify] + hint + blank + test + message + footer
+    let content_h = 1 + 1 + visible.len() as u16 + advanced_rows + 1 + 1 + 1 + 1 + 1;
     let popup_w = 64.min(area.width);
-    let popup_h = 16.min(area.height);
+    let popup_h = (content_h + 2).min(area.height);
     let popup_x = area.x + area.width.saturating_sub(popup_w) / 2;
     let popup_y = area.y + area.height.saturating_sub(popup_h) / 2;
     let popup = Rect::new(popup_x, popup_y, popup_w, popup_h);
@@ -365,61 +543,113 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
     let inner = block.inner(popup);
     frame.render_widget(block, popup);
 
-    let rows = Layout::vertical([
-        Constraint::Length(2), // intro
-        Constraint::Length(4), // the FormInput rows
-        Constraint::Length(1), // auth_scheme
-        Constraint::Length(1), // verify_tls
-        Constraint::Length(1), // blank
-        Constraint::Length(1), // test state
-        Constraint::Length(1), // message
-        Constraint::Min(1),    // help
-    ])
-    .split(inner);
+    let mut y = inner.y;
 
+    // Intro (one line), then a blank row.
     frame.render_widget(
-        Paragraph::new(vec![
-            Line::from(Span::styled(
-                "Let's set up your first NetBox profile.",
-                Style::default().fg(theme.header),
-            )),
-            Line::from(Span::styled(
-                "Paste a token to save it, or name a token_env / set NBOX_TOKEN.",
-                Style::default().fg(theme.text_dim),
-            )),
-        ]),
-        rows[0],
+        Paragraph::new(Span::styled(
+            "Set up your first NetBox profile.",
+            Style::default().fg(theme.header),
+        )),
+        Rect::new(inner.x, y, inner.width, 1),
     );
+    y = y.saturating_add(2);
 
-    if let Some(pos) = wizard.form.form_input_mut().render(frame, rows[1], theme) {
-        frame.set_cursor_position(pos);
+    // Label column width: the widest visible label, plus the advanced labels when
+    // they're showing, so the value cells line up.
+    let mut label_w = visible
+        .iter()
+        .map(|&i| field_label(i).len())
+        .max()
+        .unwrap_or(0);
+    if wizard.advanced {
+        label_w = label_w.max("auth_scheme".len());
     }
 
-    let scheme = match wizard.form.auth_scheme {
-        AuthScheme::Auto => "auto",
-        AuthScheme::Bearer => "bearer",
-        AuthScheme::Token => "token",
-    };
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("auth_scheme  ", Style::default().fg(theme.header)),
-            Span::styled(scheme, Style::default().fg(theme.accent)),
-            Span::styled("  (Ctrl+S cycles)", Style::default().fg(theme.text_dim)),
-        ])),
-        rows[2],
-    );
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("verify_tls   ", Style::default().fg(theme.header)),
-            Span::styled(
-                if wizard.form.verify_tls { "on" } else { "off" },
-                Style::default().fg(theme.accent),
-            ),
-            Span::styled("  (Ctrl+L toggles)", Style::default().fg(theme.text_dim)),
-        ])),
-        rows[3],
-    );
+    // The text fields, in display order: a label cell + the field's value cell.
+    let mut cursor = None;
+    for &idx in visible {
+        if y >= inner.bottom() {
+            break;
+        }
+        let label_cell = format!("{:<label_w$}  ", field_label(idx));
+        let lw = label_cell.chars().count() as u16;
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                label_cell,
+                Style::default().fg(theme.text_dim),
+            )),
+            Rect::new(inner.x, y, lw.min(inner.width), 1),
+        );
+        let value_x = inner.x.saturating_add(lw);
+        let value_w = inner.width.saturating_sub(lw);
+        if value_w > 0 {
+            let focused = wizard.form.form_input().focus() == idx;
+            if let Some(input) = wizard.form.form_input_mut().input_mut(idx)
+                && let Some(pos) =
+                    input.render_value(frame, Rect::new(value_x, y, value_w, 1), theme, focused)
+            {
+                cursor = Some(pos);
+            }
+        }
+        y = y.saturating_add(1);
+    }
 
+    // Advanced controls (auth_scheme, verify_tls) — only when expanded.
+    if wizard.advanced {
+        let scheme = match wizard.form.auth_scheme {
+            AuthScheme::Auto => "auto",
+            AuthScheme::Bearer => "bearer",
+            AuthScheme::Token => "token",
+        };
+        if y < inner.bottom() {
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        format!("{:<label_w$}  ", "auth_scheme"),
+                        Style::default().fg(theme.text_dim),
+                    ),
+                    Span::styled(scheme, Style::default().fg(theme.accent)),
+                    Span::styled("  (Ctrl+S cycles)", Style::default().fg(theme.text_dim)),
+                ])),
+                Rect::new(inner.x, y, inner.width, 1),
+            );
+            y = y.saturating_add(1);
+        }
+        if y < inner.bottom() {
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled(
+                        format!("{:<label_w$}  ", "verify_tls"),
+                        Style::default().fg(theme.text_dim),
+                    ),
+                    Span::styled(
+                        if wizard.form.verify_tls { "on" } else { "off" },
+                        Style::default().fg(theme.accent),
+                    ),
+                    Span::styled("  (Ctrl+L toggles)", Style::default().fg(theme.text_dim)),
+                ])),
+                Rect::new(inner.x, y, inner.width, 1),
+            );
+            y = y.saturating_add(1);
+        }
+    }
+
+    // Advanced toggle hint, then a blank row.
+    if y < inner.bottom() {
+        let hint = if wizard.advanced {
+            "▾ Ctrl+A  hide advanced"
+        } else {
+            "▸ Ctrl+A  advanced (token_env, auth_scheme, verify_tls)"
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(hint, Style::default().fg(theme.text_dim))),
+            Rect::new(inner.x, y, inner.width, 1),
+        );
+        y = y.saturating_add(2);
+    }
+
+    // Test state.
     let (test_text, test_style) = match &wizard.form.test {
         TestState::Idle => (String::new(), Style::default().fg(theme.text_dim)),
         TestState::Testing => (
@@ -432,22 +662,36 @@ fn render(frame: &mut ratatui::Frame, area: Rect, wizard: &mut OnboardingWizard,
         ),
         TestState::Failed(e) => (format!("✗ {e}"), Style::default().fg(theme.error)),
     };
-    frame.render_widget(Paragraph::new(Span::styled(test_text, test_style)), rows[5]);
+    if y < inner.bottom() {
+        frame.render_widget(
+            Paragraph::new(Span::styled(test_text, test_style)),
+            Rect::new(inner.x, y, inner.width, 1),
+        );
+        y = y.saturating_add(1);
+    }
 
-    if let Some(msg) = &wizard.form.message {
+    // Optional message line.
+    if y < inner.bottom()
+        && let Some(msg) = &wizard.form.message
+    {
         frame.render_widget(
             Paragraph::new(Span::styled(msg.clone(), Style::default().fg(theme.error))),
-            rows[6],
+            Rect::new(inner.x, y, inner.width, 1),
         );
     }
 
+    // Footer help, pinned to the last inner row.
     frame.render_widget(
         Paragraph::new(Span::styled(
-            "Tab: field  Ctrl+T: test  Enter: save & continue  Esc: quit",
+            "Tab: field  Ctrl+A: advanced  Ctrl+T: test  Enter: save",
             Style::default().fg(theme.text_dim),
         )),
-        rows[7],
+        Rect::new(inner.x, inner.bottom().saturating_sub(1), inner.width, 1),
     );
+
+    if let Some(pos) = cursor {
+        frame.set_cursor_position(pos);
+    }
 }
 
 #[cfg(test)]
@@ -470,11 +714,13 @@ mod tests {
     }
 
     #[test]
-    fn new_wizard_defaults_name_and_focuses_url() {
+    fn new_wizard_starts_blank_name_focused_on_url() {
         let w = OnboardingWizard::new();
-        assert_eq!(w.form.name(), "default");
-        // Focus starts on the url field (name is pre-seeded).
+        // The name starts blank — it's derived from the url host on save, not
+        // pre-seeded to `default`.
+        assert!(w.form.name().is_empty());
         assert_eq!(w.form.form_input().focus(), field::URL);
+        assert!(!w.advanced, "advanced fields start collapsed");
     }
 
     #[test]
@@ -557,13 +803,14 @@ mod tests {
         let mut w = OnboardingWizard::new();
         type_into(&mut w, "https://nb.example");
         let outcome = persist(&w.form, &path).unwrap();
-        assert_eq!(outcome.name, "default");
+        // Name derived from the url host (`nb.example` → `nb`), not `default`.
+        assert_eq!(outcome.name, "nb");
 
         // The on-disk config has the profile and names it active.
         let text = std::fs::read_to_string(&path).unwrap();
         let cfg: Config = toml::from_str(&text).unwrap();
-        assert_eq!(cfg.active_profile.as_deref(), Some("default"));
-        let prof = &cfg.profiles["default"];
+        assert_eq!(cfg.active_profile.as_deref(), Some("nb"));
+        let prof = &cfg.profiles["nb"];
         assert_eq!(prof.url, "https://nb.example");
         // No token was typed, so the file carries no token.
         assert!(!text.contains("token ="), "no token should be invented");
@@ -591,7 +838,7 @@ mod tests {
         assert!(text.contains("token = \"nbt_secret.value\""), "{text}");
         let cfg: Config = toml::from_str(&text).unwrap();
         assert_eq!(
-            cfg.profiles["default"]
+            cfg.profiles["nb"]
                 .token
                 .as_ref()
                 .map(crate::config::ConfigToken::expose),
@@ -622,7 +869,7 @@ mod tests {
         persist(&w.form, &path).unwrap();
 
         let cfg: Config = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        let prof = &cfg.profiles["default"];
+        let prof = &cfg.profiles["nb"];
         assert_eq!(prof.timeout_secs, Some(30), "typed timeout persisted");
         assert_eq!(prof.page_size, Some(250), "typed page_size persisted");
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
@@ -635,12 +882,18 @@ mod tests {
         let path = temp_config("tokenenv");
         let _ = std::fs::remove_file(&path);
         let mut w = OnboardingWizard::new();
-        type_into(&mut w, "https://nb.example");
-        // Tab to token_env and set it.
-        for _ in field::URL..field::TOKEN_ENV {
-            w.handle_key(key(KeyCode::Tab));
-        }
-        type_into(&mut w, "NETBOX_TOKEN");
+        // Set url + token_env directly (token_env is an advanced field now); this
+        // test exercises persist, not the wizard's field navigation.
+        w.form
+            .form_input_mut()
+            .input_mut(field::URL)
+            .unwrap()
+            .set_value("https://nb.example");
+        w.form
+            .form_input_mut()
+            .input_mut(field::TOKEN_ENV)
+            .unwrap()
+            .set_value("NETBOX_TOKEN");
         let outcome = persist(&w.form, &path).unwrap();
         assert!(!outcome.stored_in_config);
         assert_eq!(outcome.token_env.as_deref(), Some("NETBOX_TOKEN"));
@@ -651,7 +904,7 @@ mod tests {
 
         let cfg: Config = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(
-            cfg.profiles["default"].token_env.as_deref(),
+            cfg.profiles["nb"].token_env.as_deref(),
             Some("NETBOX_TOKEN")
         );
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
@@ -670,5 +923,156 @@ mod tests {
         assert!(outcome.token_env.is_none());
         assert!(outcome.needs_env_guidance);
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn suggest_name_strips_a_generic_host_label() {
+        assert_eq!(suggest_name_from_url("https://netbox.acme.com"), "acme");
+        assert_eq!(suggest_name_from_url("https://www.acme.com"), "acme");
+        assert_eq!(
+            suggest_name_from_url("https://acme.example.com:8443/api"),
+            "acme"
+        );
+        assert_eq!(suggest_name_from_url("https://corp.net"), "corp");
+        // No scheme still resolves a host.
+        assert_eq!(suggest_name_from_url("netbox.lab.internal"), "lab");
+    }
+
+    #[test]
+    fn suggest_name_falls_back_to_prod_for_ip_or_empty() {
+        assert_eq!(suggest_name_from_url("https://10.0.0.5"), "prod");
+        assert_eq!(suggest_name_from_url("https://10.0.0.5:8000/"), "prod");
+        assert_eq!(suggest_name_from_url("https://[::1]:8080"), "prod");
+        assert_eq!(suggest_name_from_url(""), "prod");
+        assert_eq!(suggest_name_from_url("https://"), "prod");
+    }
+
+    #[test]
+    fn ctrl_a_toggles_the_advanced_field_set() {
+        let mut w = OnboardingWizard::new();
+        assert!(!w.advanced);
+        assert_eq!(
+            w.visible_fields().to_vec(),
+            vec![field::URL, field::NAME, field::TOKEN]
+        );
+        w.handle_key(ctrl('a'));
+        assert!(w.advanced);
+        assert_eq!(
+            w.visible_fields().to_vec(),
+            vec![field::URL, field::NAME, field::TOKEN, field::TOKEN_ENV]
+        );
+        w.handle_key(ctrl('a'));
+        assert!(!w.advanced);
+    }
+
+    #[test]
+    fn tab_walks_visible_fields_and_skips_hidden_token_env() {
+        let mut w = OnboardingWizard::new();
+        // Simple mode: url → name → token → wrap to url; token_env is never focused.
+        assert_eq!(w.form.form_input().focus(), field::URL);
+        w.handle_key(key(KeyCode::Tab));
+        assert_eq!(w.form.form_input().focus(), field::NAME);
+        w.handle_key(key(KeyCode::Tab));
+        assert_eq!(w.form.form_input().focus(), field::TOKEN);
+        w.handle_key(key(KeyCode::Tab));
+        assert_eq!(
+            w.form.form_input().focus(),
+            field::URL,
+            "wraps past token, skipping the hidden token_env"
+        );
+        w.handle_key(key(KeyCode::BackTab));
+        assert_eq!(w.form.form_input().focus(), field::TOKEN);
+    }
+
+    #[test]
+    fn collapsing_advanced_pulls_focus_off_a_hidden_field() {
+        let mut w = OnboardingWizard::new();
+        w.handle_key(ctrl('a')); // expand
+        for _ in 0..3 {
+            w.handle_key(key(KeyCode::Tab)); // url → name → token → token_env
+        }
+        assert_eq!(w.form.form_input().focus(), field::TOKEN_ENV);
+        w.handle_key(ctrl('a')); // collapse — token_env is now hidden
+        assert_eq!(
+            w.form.form_input().focus(),
+            field::URL,
+            "focus falls back to url when its field is hidden"
+        );
+    }
+
+    #[test]
+    fn blank_name_is_filled_from_the_url_on_save() {
+        let mut w = OnboardingWizard::new();
+        type_into(&mut w, "https://netbox.acme.com");
+        assert_eq!(w.handle_key(key(KeyCode::Enter)), WizardAction::Save);
+        assert_eq!(
+            w.form.name(),
+            "acme",
+            "blank name derived from the url host"
+        );
+    }
+
+    #[test]
+    fn a_failed_save_reverts_the_auto_filled_name() {
+        let mut w = OnboardingWizard::new();
+        // No url ⇒ validation fails on the url; the name auto-filled for the
+        // validation attempt is reverted so the live suggestion placeholder returns.
+        assert_eq!(w.handle_key(key(KeyCode::Enter)), WizardAction::None);
+        assert!(w.form.message.as_deref().unwrap().contains("url"));
+        assert!(
+            w.form.name().is_empty(),
+            "auto-filled name reverted after a failed save"
+        );
+    }
+
+    #[test]
+    fn a_typed_name_is_not_overwritten_by_the_suggestion() {
+        let mut w = OnboardingWizard::new();
+        type_into(&mut w, "https://netbox.acme.com");
+        w.handle_key(key(KeyCode::Tab)); // url → name
+        assert_eq!(w.form.form_input().focus(), field::NAME);
+        type_into(&mut w, "edge");
+        assert_eq!(w.handle_key(key(KeyCode::Enter)), WizardAction::Save);
+        assert_eq!(w.form.name(), "edge");
+    }
+
+    /// Render the wizard onto a [`TestBackend`] and return the flattened buffer
+    /// text, so a test can assert what's on screen (and that drawing never panics).
+    fn rendered_text(w: &mut OnboardingWizard) -> String {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        let theme = Theme::default();
+        terminal.draw(|f| render(f, f.area(), w, &theme)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
+    }
+
+    #[test]
+    fn render_simple_mode_draws_core_fields_without_advanced_controls() {
+        let mut w = OnboardingWizard::new();
+        let text = rendered_text(&mut w);
+        assert!(text.contains("Welcome to nbox"));
+        assert!(text.contains("url"));
+        assert!(text.contains("name"));
+        assert!(text.contains("Ctrl+A")); // the advanced toggle hint
+        // The auth/tls controls are advanced-only — hidden on the first screen.
+        assert!(!text.contains("Ctrl+S"));
+        assert!(!text.contains("Ctrl+L"));
+    }
+
+    #[test]
+    fn render_advanced_mode_reveals_the_auth_and_tls_controls() {
+        let mut w = OnboardingWizard::new();
+        w.handle_key(ctrl('a')); // expand the advanced fields
+        let text = rendered_text(&mut w);
+        assert!(text.contains("Ctrl+S"), "auth_scheme control shown");
+        assert!(text.contains("Ctrl+L"), "verify_tls control shown");
+        assert!(text.contains("hide advanced"));
     }
 }


### PR DESCRIPTION
## What

Redesigns the first-run onboarding wizard to the "simple + advanced collapsed" shape, and **fixes the root cause of the duplicate-profile gotcha** from #66: the wizard hardcoded the profile name to `default`, so a user who onboarded in the TUI and then `nbox profile add`ed a real profile ended up with two.

### The wizard now

```
┌ Welcome to nbox 0.9.0 ──────────────────────────── Esc: quit ┐
│Set up your first NetBox profile.                              │
│                                                              │
│url     https://netbox.acme.com                               │
│name    acme   (suggested)                                    │
│token   paste token to save (optional)                        │
│▸ Ctrl+A  advanced (token_env, auth_scheme, verify_tls)       │
│                                                              │
│Tab: field  Ctrl+A: advanced  Ctrl+T: test  Enter: save       │
└──────────────────────────────────────────────────────────────┘
```

Press **Ctrl+A** to reveal `token_env` / `auth_scheme` / `verify_tls`.

- **URL-first, three-field simple screen** (url / name / token). The advanced knobs hide behind `Ctrl+A`.
- **Name derived from the URL host** — `https://netbox.acme.com` → `acme` (a leading `www.`/`netbox.` label is dropped; an IP or empty host falls back to `prod`). Shown live as a placeholder, committed on save only if you left it blank — so **no more stray `default` profile**. Type your own name and it's kept verbatim.
- **Tab walks only the visible fields** (a hidden `token_env` is skipped); collapsing pulls focus back off a now-hidden field.

### How

The wizard renders its fields individually now (it reorders and hides them), so this adds three small helpers in `cheese.rs` — `TextInput::render_value` / `TextInput::set_placeholder` / `FormInput::set_focus`. **The shared add/edit `ProfileForm` used by the config editor is untouched** — all the new behavior lives in `onboarding.rs`.

## Tests
- Name derivation (`suggest_name_from_url`): host-label strip + IP/empty → `prod`.
- `Ctrl+A` toggles the visible field set; Tab skips the hidden `token_env`; collapsing re-anchors focus.
- Blank name filled from the URL on save; **reverted** on a failed save (so the live suggestion returns); a typed name is never overwritten.
- `TestBackend` render smoke tests for both simple and advanced modes (assert content + no panic).
- Existing wizard/persist tests updated for the host-derived name.

## Gate
`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `clippy --no-default-features`, and `cargo test` in both feature modes — all green. Visual confirmed via a `TestBackend` frame dump.