### PR TITLE
Expose circuit path device refs + the rendered diagram in JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ nbox vlan <vid|name> [--site <name|slug>] [--group <name|slug>]
 nbox interface <device> <interface>
 nbox site <name|slug>
 nbox rack <name|id>
-nbox circuit <cid|id>                 # JSON adds a `terminations` array (A/Z endpoints + patch)
+nbox circuit <cid|id>                 # JSON: `terminations` (A/Z), each path hop a `device` ref + a `diagram`
 nbox provider <slug|name|id>
 nbox aggregate <cidr|id>
 nbox asn <number>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   interface cable-path view); the A and Z sides are walked concurrently, and a hop
   that can't continue (e.g. an unwired panel) stops cleanly rather than guessing.
   The TUI circuit detail gains a **`p` path tab** and navigable links to the
-  provider, the sites, and every device along the path; `-o json` carries a
-  structured `terminations` array (each with its `path`). Previously a circuit
-  showed only flat attributes (provider/type/status/rate) with no indication of
-  where it landed. Commit/port rates are humanized (e.g. `400 Gbps`).
+  provider, the sites, and every device along the path. `-o json` (and the MCP
+  `nbox_get` / `nbox://circuit/{ref}` resource) carries a structured `terminations`
+  array — each hop in its `path` includes a `device` ref (`{id, name}`) so an agent
+  can jump straight to the device — plus the rendered `diagram` lines so an agent
+  or script can show the A↔Z art verbatim. Previously a circuit showed only flat
+  attributes (provider/type/status/rate) with no indication of where it landed.
+  Commit/port rates are humanized (e.g. `400 Gbps`).
 - **`nbox profile remove <name>`** deletes a profile from the config
   (format-preserving). It refuses to remove the active profile (switch with `nbox
   profile use <other>` first) or the only profile, mirroring the TUI's delete

--- a/src/domain/circuit_view.rs
+++ b/src/domain/circuit_view.rs
@@ -13,6 +13,24 @@ use crate::netbox::models::circuits::{Circuit, CircuitTermination};
 use crate::netbox::models::common::BriefObject;
 use crate::output::plain::KeyValues;
 
+/// A minimal device reference, so a consumer (agent) can navigate to the device
+/// along a path — `nbox_get kind=device ref=<id|name>`.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeviceRef {
+    pub id: u64,
+    pub name: String,
+}
+
+impl DeviceRef {
+    /// Build from a related-object brief, preferring the stable `name`.
+    pub fn from_brief(b: &BriefObject) -> Self {
+        Self {
+            id: b.id,
+            name: b.name_label(),
+        }
+    }
+}
+
 /// One cabled hop along a termination's path: what it reaches and over which
 /// cable. A patch panel shows up as a non-endpoint hop; the final device
 /// interface (when the chain resolves to one) is the endpoint.
@@ -25,9 +43,10 @@ pub struct PathHop {
     pub cable: Option<String>,
     /// True when this hop is a device interface — the resolved far endpoint.
     pub endpoint: bool,
-    /// The device at this hop, for building a navigable link (not serialized).
-    #[serde(skip)]
-    pub device: Option<BriefObject>,
+    /// The device at this hop — `{id, name}` — so a consumer can jump straight to
+    /// it (`nbox_get kind=device`). Also drives the TUI's related-object links.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device: Option<DeviceRef>,
 }
 
 /// A circuit termination plus its resolved cable path (built by the walker in
@@ -106,10 +125,11 @@ pub struct CircuitView {
     /// The A/Z terminations (A first), each with its endpoint + resolved path.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub terminations: Vec<CircuitTerminationView>,
-    /// The circuit path as a multi-line ASCII A↔Z diagram. Not serialized — it's a
-    /// rendering for the plain/TUI surfaces, while the structured `terminations`
-    /// (each with its `path`) remain the machine-readable form.
-    #[serde(skip)]
+    /// The circuit path as a multi-line ASCII A↔Z diagram. Serialized too (skip
+    /// when empty) so an agent or script can render the path verbatim for a user;
+    /// the structured `terminations` (each with its `path`) remain the
+    /// machine-readable form for navigation.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub diagram: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
@@ -481,6 +501,53 @@ mod tests {
         let plain = view.to_plain();
         assert!(plain.contains("Circuit Path"));
         assert!(plain.contains("↳ edge-1 xe-0/0/0  ·  #200"));
+    }
+
+    #[test]
+    fn serializes_device_refs_and_the_diagram() {
+        let c = circuit(json!({
+            "id": 1, "url": "u", "cid": "ACME-1",
+            "type": {"id": 2, "display": "Wave"},
+            "status": {"value": "active", "label": "Active"},
+            "commit_rate": 10_000_000
+        }));
+        let term_a = termination(json!({
+            "id": 1, "term_side": "A",
+            "termination": {"id": 1, "display": "DC1", "name": "DC1"},
+            "termination_type": "dcim.site"
+        }));
+        let term_z = termination(json!({
+            "id": 2, "term_side": "Z",
+            "termination": {"id": 2, "display": "ACME Cloud"},
+            "termination_type": "circuits.providernetwork"
+        }));
+        let resolved = vec![
+            ResolvedTermination {
+                termination: term_a,
+                path: vec![PathHop {
+                    to: "edge-1 xe-0/0/0".to_string(),
+                    cable: Some("#200".to_string()),
+                    endpoint: true,
+                    device: Some(DeviceRef {
+                        id: 8,
+                        name: "edge-1".to_string(),
+                    }),
+                }],
+            },
+            ResolvedTermination {
+                termination: term_z,
+                path: Vec::new(),
+            },
+        ];
+        let v = serde_json::to_value(CircuitView::build(c, resolved)).unwrap();
+        // The device ref is serialized so an agent can navigate to it.
+        assert_eq!(v["terminations"][0]["path"][0]["device"]["id"], 8);
+        assert_eq!(v["terminations"][0]["path"][0]["device"]["name"], "edge-1");
+        // The rendered diagram is serialized too (a non-empty array of lines).
+        assert!(
+            v["diagram"].as_array().is_some_and(|a| !a.is_empty()),
+            "diagram should serialize: {v}"
+        );
     }
 
     #[test]

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::ApiSurface;
 use crate::domain::aggregate_view::AggregateView;
 use crate::domain::asn_view::AsnView;
-use crate::domain::circuit_view::{CircuitView, PathHop, ResolvedTermination};
+use crate::domain::circuit_view::{CircuitView, DeviceRef, PathHop, ResolvedTermination};
 use crate::domain::cluster_view::ClusterView;
 use crate::domain::contact_view::ContactView;
 use crate::domain::device_detail::{CableRow, DeviceDetail, IfaceRow, IpRow, VlanRow};
@@ -371,7 +371,7 @@ fn port_kind(url: Option<&str>) -> PortKind {
 struct NextHop {
     url: Option<String>,
     to: String,
-    device: Option<BriefObject>,
+    device: Option<DeviceRef>,
     id: u64,
     kind: PortKind,
     cable: Option<String>,
@@ -391,7 +391,7 @@ async fn resolve_termination_path(client: &NetBoxClient, t: &CircuitTermination)
     let mut cur = NextHop {
         url: peer.url.clone(),
         to: peer.endpoint_label(),
-        device: peer.device.as_deref().cloned(),
+        device: peer.device.as_deref().map(DeviceRef::from_brief),
         id: peer.id,
         kind: port_kind(peer.url.as_deref()),
         // The first cable crossed is the termination's own.
@@ -533,11 +533,9 @@ fn next_hop_from_peer(peer: &serde_json::Value, cable: Option<String>) -> Option
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let device = peer
-        .get("device")
-        .and_then(|d| serde_json::from_value::<BriefObject>(d.clone()).ok());
+    let device = peer.get("device").and_then(device_ref_from_value);
     let to = match &device {
-        Some(d) => format!("{} {port}", d.name_label()),
+        Some(d) => format!("{} {port}", d.name),
         None => port,
     };
     Some(NextHop {
@@ -548,6 +546,18 @@ fn next_hop_from_peer(peer: &serde_json::Value, cable: Option<String>) -> Option
         id,
         cable,
     })
+}
+
+/// A [`DeviceRef`] from a port's nested `device` JSON object (id + bare name).
+fn device_ref_from_value(d: &serde_json::Value) -> Option<DeviceRef> {
+    let id = d.get("id").and_then(serde_json::Value::as_u64)?;
+    let name = d
+        .get("name")
+        .or_else(|| d.get("display"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some(DeviceRef { id, name })
 }
 
 /// A cable's label from a JSON object: its display/label, else NetBox's `#<id>`.
@@ -598,7 +608,7 @@ fn circuit_links(c: &Circuit, terminations: &[ResolvedTermination]) -> Vec<Objec
                     kind: ObjectKind::Device,
                     id: dev.id,
                     relation: format!("{side}-side device"),
-                    label: dev.name_label(),
+                    label: dev.name.clone(),
                 });
             }
         }
@@ -2283,8 +2293,6 @@ mod tests {
             "termination_type": "circuits.providernetwork"
         }))
         .unwrap();
-        let panel: BriefObject =
-            serde_json::from_value(json!({"id": 9, "name": "panel-1"})).unwrap();
         let resolved = vec![
             ResolvedTermination {
                 termination: term_a,
@@ -2292,7 +2300,10 @@ mod tests {
                     to: "panel-1 7".to_string(),
                     cable: Some("#100".to_string()),
                     endpoint: false,
-                    device: Some(panel),
+                    device: Some(DeviceRef {
+                        id: 9,
+                        name: "panel-1".to_string(),
+                    }),
                 }],
             },
             ResolvedTermination {

--- a/tests/circuit_path_tests.rs
+++ b/tests/circuit_path_tests.rs
@@ -123,6 +123,9 @@ async fn circuit_path_walks_through_a_wired_panel_to_the_device() {
         a.path[0].endpoint,
         "the router interface is the resolved endpoint"
     );
+    // The hop carries a navigable device ref ({id, name}).
+    let dev = a.path[0].device.as_ref().expect("device ref");
+    assert_eq!((dev.id, dev.name.as_str()), (8, "edge-1"));
     assert_eq!(a.path[1].to, "panel-1 R1");
     assert_eq!(a.path[1].cable.as_deref(), Some("#100"));
     assert!(!a.path[1].endpoint);


### PR DESCRIPTION
## What

Two agent-facing additions to the circuit cable-path JSON (follow-up to #68):

1. **Device refs in the path** — each hop in `terminations[].path` now serializes a `device` ref (`{id, name}`), so an agent can navigate straight to the device (`nbox_get kind=device ref=<id|name>`) instead of parsing it out of the `to` display label.
2. **The rendered diagram** — the A↔Z ASCII `diagram` (array of lines) is now serialized too, so an agent or script can show the art to a user verbatim rather than rebuilding it from the structured terminations.

Example (`nbox circuit <cid> -o json`):

```json
{
  "cid": "ACME-1001",
  "terminations": [
    { "side": "A", "endpoint": "DC1", "endpoint_kind": "site",
      "path": [
        { "to": "edge-1 xe-0/0/0", "cable": "#200", "endpoint": true,
          "device": { "id": 8, "name": "edge-1" } },
        { "to": "panel-1 7", "cable": "#100", "endpoint": false,
          "device": { "id": 9, "name": "panel-1" } }
      ] },
    { "side": "Z", "endpoint": "ACME Cloud", "endpoint_kind": "provider network" }
  ],
  "diagram": [
    "   A  DC1  (site)",
    "      ↳ edge-1 xe-0/0/0  ·  #200",
    "      ↳ panel-1 7  ·  #100",
    "      │",
    "      ┿ Wave · 10 Gbps · Active",
    "      │",
    "   Z  ACME Cloud  (provider network)"
  ]
}
```

## How
Replaces the skipped `BriefObject` on `PathHop` with a small serializable `DeviceRef { id, name }`, and un-skips `CircuitView.diagram` (skip-when-empty). Both flow through every JSON surface for free — CLI `-o json`, MCP `nbox_get`, and the `nbox://circuit/{ref}` resource — since they share the one `CircuitView` serialization. The structured `terminations` stay the navigation form; the `diagram` is the render-for-humans form.

## Tests
- `serializes_device_refs_and_the_diagram` — asserts `path[].device.{id,name}` and a non-empty `diagram` array in the serialized view.
- The walker integration test now asserts the resolved hop carries the `device` ref.

## Gate
`cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, `clippy --no-default-features`, and `cargo test` in both feature modes — all green.