### PR TITLE
docs: accuracy true-up across the doc tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ MCP prompts are later. See `docs/MCP.md`.
   prints the token).
   Select a profile with `--profile <name>` or set the active one.
 - Backends: REST is canonical. GraphQL is an opt-in per-surface accelerator set
-  under `[profiles.<name>.api]` (`vrf` = `rest`|`graphql`; missing = REST). nbox
+  under `[profiles.<name>.api]` (`vrf`/`route_target` = `rest`|`graphql`; missing = REST). nbox
   probes `/graphql/`, adapts to NetBox 4.2/4.3/4.5+ filter/pagination shapes, and
   falls back to REST (with the reason in `nbox status`) when a surface isn't
   supported. The output shape is identical either way. **Search is always REST** —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ split: the wire layer (`netbox/`) stays separate from the view models
 - `src/output/` — plain / JSON / CSV rendering
 - `src/tui/` — ratatui app (pure `handle_event`, spawned network commands)
 - `src/config.rs`, `src/error.rs`, `src/cli.rs`, `src/lib.rs`
-- `src/cache.rs` — the in-memory read cache; `src/mcp/` — the MCP server
+- `src/cache/` — the in-memory read cache; `src/mcp/` — the MCP server
 
 ### Adding a new object lookup
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [Installation](#installation) below for setup instructions.
 
 - **Fast shell lookups** — `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`, `route-target`, and `interface`, each as a one-liner.
 - **Normalized search** — one `search` query runs in parallel across devices, sites, racks, IPs, prefixes, VLANs, circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs, clusters, VRFs, and route targets, returning ranked, deduped hits. Scope it with `--site`/`--region`/`--site-group`/`--location` (one at a time, exact scope), or narrow by `--status`/`--tenant`/`--role`/`--tag`/`--vrf`.
-- **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` for free addresses and blocks (computed locally with `ipnet`).
+- **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` for free addresses and blocks (read-only — nothing is reserved).
 - **A k9s-style TUI** — a three-pane home (navigation rail → results → live preview), an overview dashboard, a hierarchical prefix tree, cross-object navigation between related objects (every detail's related-object tabs are navigable — open an interface from a device and see its cable path drawn as an A↔Z diagram), fuzzy filters, recents, and an in-app profile + settings editor. Twelve themes; `NO_COLOR` honored.
 - **Agent-ready** — `nbox serve` is a read-only MCP server: the same lookups exposed as nine tools (plus every object as an `nbox://{kind}/{ref}` resource), returning the exact JSON view models the CLI does, so AI agents (Claude Code, Claude Desktop, …) query NetBox safely. Stdio for a local subprocess, or a loopback HTTP transport with OIDC resource-server auth for a network-reachable, read-only deployment. See [docs/MCP.md](docs/MCP.md); [SKILL.md](SKILL.md) is an installable Agent Skill that drives the CLI on matching requests.
 - **Scriptable** — `-o plain|json|csv`, `--fields`, `--raw`, versioned `--envelope`, and stable exit codes; stdout stays clean for piping, logs go to stderr. See [docs/SCRIPTING.md](docs/SCRIPTING.md).
@@ -109,8 +109,8 @@ Read-only — nothing is reserved. Both take `--vrf` to scope the prefix.
 ### Pull data into a script
 
 ```bash
-nbox device edge01 --json | jq '.primary_ip4.address'
-nbox search edge01 -o csv --cols name,site,status > devices.csv
+nbox device edge01 --json | jq '.primary_ip4'
+nbox search edge01 -o csv --cols kind,display,url > devices.csv
 nbox prefix 10.44.208.0/24 --json --envelope --raw   # versioned, single-line
 ```
 
@@ -274,7 +274,7 @@ nbox open <kind>/<ref>            # device, ip, prefix, vlan, site, rack, circui
 nbox raw GET <api-path>           # raw read-only API request (escape hatch)
 nbox serve [--http <addr>]        # read-only MCP server for AI agents (stdio, or loopback/OIDC HTTP)
 nbox config <init|path|show|token>    # token: status reports the resolved source (never echoed)
-nbox profile <add|use|list|show>
+nbox profile <add|use|remove|list|show>
 nbox completions <bash|zsh|fish|powershell|elvish>
 nbox man [DIR]                    # man pages: `nbox man > nbox.1` (top-level),
                                   # or `nbox man man/` for the full per-subcommand set

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,9 +23,9 @@ Legend: ☐ planned · ◐ in progress · ☑ done
 
 The read surface is broad and stable today (full history in `CHANGELOG.md`):
 
-- **CLI lookups — 19 object types:** `device`, `interface`, `ip`, `prefix`, `vlan`, `site`, `rack`,
-  `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, plus
-  `search`, `journal`, `tags`, `status`, `open`, `raw GET`. NetBox 4.2+ polymorphic scope + VRF
+- **CLI lookups — 18 object types:** `device`, `interface`, `ip`, `prefix`, `vlan`, `site`, `rack`,
+  `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`,
+  `route-target`, plus `search`, `journal`, `tags`, `status`, `open`, `raw GET`. NetBox 4.2+ polymorphic scope + VRF
   correctness; ambiguous refs exit `5` with the candidate list.
 - **Search:** parallel multi-endpoint fan-out with `--status` / `--site` / `--region` /
   `--site-group` / `--location` / `--tenant` / `--role` / `--tag` / `--vrf` filters (per-endpoint
@@ -36,7 +36,7 @@ The read surface is broad and stable today (full history in `CHANGELOG.md`):
 - **MCP server (`nbox serve`):** stdio **and** HTTP (Streamable HTTP), OAuth 2.1 OIDC resource-server
   mode (RFC 9728 metadata, audit log, per-caller rate limit), 9 read tools + a `nbox://{kind}/{ref}`
   resource template (DESIGN §24; read-only Pattern 3).
-- **TUI:** list/preview split with focus, scrolling + position cues, 11 themes, command palette,
+- **TUI:** list/preview split with focus, scrolling + position cues, 12 themes, command palette,
   fuzzy filter, recents, auto-refresh, device tabs, open-in-browser/copy, profile switcher
   (`P`/`Ctrl+P`), and an in-app **Config modal** (`S`) — profile editor (add/edit/select/delete),
   settings, and **first-run onboarding**.
@@ -75,6 +75,17 @@ Polish the read experience. No writes here.
   as plain text — the tab bar now pins in a fixed band for any tabbed detail and one shared builder renders
   rows everywhere, so the device IP/VLAN, prefix children/addresses, and site/rack device tabs are navigable
   too. Services (`s`) stay text (no detail to open).
+- ☑ **Server-side browse filter (Nav rail).** From the Nav rail, `/` on a name-bearing kind
+  (devices/racks/sites/VLANs/VRFs/route-targets) filters that list **server-side** by name (`name__ic`)
+  instead of opening global search — explicit (Enter to apply, not live typeahead), so it doesn't hammer
+  NetBox while typing. The pane title shows the active filter + count (`Devices · name contains "bfr" · 52`),
+  `500+` signals the browse cap; `Esc` clears (Normal) / cancels the edit (BrowseFilter), `Ctrl+X`/empty-
+  Enter clear while editing. Prefix, aggregate, and IP-address keep `/` as global search — their key field
+  is a CIDR/inet column with no NetBox `__ic` lookup (an unknown filter param is silently ignored, so a name
+  filter there would match the whole table while looking applied).
+  - ☐ **CIDR-containment filter for prefix/IP browse.** The planned follow-up for the CIDR/inet-keyed
+    kinds: filter those browses by `within_include`/`parent` (network containment) so `/` narrows a prefix/IP
+    list by network instead of falling back to global search.
 - ☐ **Demo recording** — an asciinema/VHS cast for the README.
 - ☐ **Interface journal.** Surface an interface's journal entries (operator notes) like the other
   kinds now that the interface is a first-class TUI detail. Needs an `interface` entry in the journal /
@@ -155,6 +166,15 @@ Polish the read experience. No writes here.
   now render their selection cursor (also un-breaking the device IP/VLAN, prefix children, site/rack tabs);
   Nav-rail counts abbreviated + the rail widened so large instances don't clip; `nbox raw GET` accepts a path
   with or without `/api/` and rejects absolute URLs. Shipped to crates.io / Homebrew tap / GHCR.
+- ☑ **Release `0.10.0`** — **circuit terminations + A↔Z path.** `nbox circuit <cid>` resolves the
+  circuit's A/Z terminations and renders the path (walking through patch panels to the far device, since
+  NetBox exposes no `/trace/` for circuit terminations) as a vertical A↔Z diagram; the TUI circuit detail
+  gains a `p` path tab + navigable links to the provider/sites/devices along the path; `-o json` / MCP
+  `nbox_get` / `nbox://circuit/{ref}` carry a structured `terminations` array (each hop's `path` includes a
+  `device` ref + the rendered `diagram` lines). Also `nbox profile remove <name>` (refuses the active/only
+  profile), a first-run onboarding redesign (URL-led three-field screen, profile name derived from the URL
+  host), and a `--no-tui` setup-hint fix (the URL is a positional, not `--url`). Shipped to crates.io /
+  Homebrew tap / GHCR.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ TUI, so output is consistent across both.
 - **`error.rs`** — `NboxError` with stable exit codes (see below).
 - **`config.rs`** — typed config, profiles, token resolution, format-preserving
   writes (`toml_edit`).
-- **`cache.rs`** — a small, bounded, in-memory per-profile read cache (one short
+- **`cache/`** — a small, bounded, in-memory per-profile read cache (one short
   TTL, clamped 5–300s) so a burst of identical reads (TUI back-navigation, a
   chatty agent) doesn't re-hit NetBox; re-keyed/cleared on profile switch.
 - **`mcp/`** — the read-only MCP server (`nbox serve`): stdio plus a loopback

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -18,7 +18,7 @@ which.
 | IP → prefix → VLAN → scope in one step | ✓ (one command) | ◐ (clicks across pages) | ◐ (several requests, manual joins) | ◐ (several calls, manual joins) |
 | Cross-object-type search in one query | ✓ (ranked, deduped) | ✗ (per-type search pages) | ◐ (one request per endpoint) | ◐ (one call per endpoint) |
 | Prefix utilization + navigable prefix tree | ✓ | ✓ (visual) | ◐ (compute from children) | ◐ (compute from children) |
-| Next free IP / next free prefix | ✓ (`next-ip` / `next-prefix`, computed locally) | ◐ (available-IPs view) | ◐ (available endpoints) | ◐ (available methods) |
+| Next free IP / next free prefix | ✓ (`next-ip` / `next-prefix`, nothing reserved) | ◐ (available-IPs view) | ◐ (available endpoints) | ◐ (available methods) |
 | Works over SSH with no runtime | ✓ (single static binary) | ✗ (needs a browser) | ◐ (only if curl present) | ✗ (needs Python + the package) |
 | Machine output (JSON/CSV) + stable exit codes | ✓ (built in) | ✗ | ◐ (you build it) | ◐ (you build it) |
 | Built-in AI-agent access (MCP) | ✓ (`nbox serve`) | ✗ | ✗ | ✗ |
@@ -30,9 +30,9 @@ Notes:
 
 - nbox is **read-only** today — writes are deferred. For anything that mutates
   NetBox, use the web UI or pynetbox.
-- "Computed locally" for `next-ip` / `next-prefix` means nbox derives free
-  addresses and blocks with the `ipnet` crate from the prefix it reads; nothing
-  is reserved in NetBox.
+- `next-ip` / `next-prefix` query NetBox's available-IPs / available-prefixes
+  endpoints (read-only; nothing is reserved in NetBox); `next-prefix --length L`
+  picks the first fitting block locally with `ipnet`.
 - nbox targets NetBox **4.2+**. REST is canonical; GraphQL is an opt-in
   accelerator for the VRF and route-target views.
 
@@ -87,7 +87,7 @@ Notes:
 nb.dcim.devices.get(name="edge01").primary_ip4.address
 
 # nbox
-nbox device edge01 --json | jq -r '.primary_ip4.address'   # one call, JSON to jq
+nbox device edge01 --json | jq -r '.primary_ip4'   # one call, JSON to jq
 ```
 
 ### What is this IP (address → prefix → VLAN → scope)
@@ -112,7 +112,7 @@ curl -s -H "Authorization: Token $TOKEN" "$NB/api/dcim/devices/?q=edge01"   # re
 
 # nbox: one ranked, deduped query across every searchable type
 nbox search edge01                                         # devices, IPs, prefixes, VLANs, …
-nbox search edge01 -o csv --cols name,site,status          # tabular, for a spreadsheet
+nbox search edge01 -o csv --cols kind,display,url          # tabular, for a spreadsheet
 ```
 
 ### Next free /26 in a prefix
@@ -121,7 +121,7 @@ nbox search edge01 -o csv --cols name,site,status          # tabular, for a spre
 # pynetbox: query the available-prefixes endpoint, then pick a /26
 nb.ipam.prefixes.get(prefix="10.0.0.0/8").available_prefixes.list()   # then filter for a /26
 
-# nbox: computed locally, nothing reserved
+# nbox: read-only, nothing reserved
 nbox next-prefix 10.0.0.0/8 --length 26                    # first free /26 (add --vrf to scope)
 nbox next-ip 10.44.208.0/24 --count 4                      # or the next free addresses
 ```

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # NetBox Compatibility
 
-nbox targets **NetBox 4.2+** over the REST API and is verified through **4.6** (the
+nbox targets **NetBox 4.2+** over the REST API and is verified through **4.6.2** (the
 current stable). Each release in the 4.2–4.6 range moved an API contract nbox
 depends on; nbox handles the differences at runtime (version probe + schema probe)
 rather than pinning a single version. The table below is the matrix; the behavior is

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -6,7 +6,7 @@ nbox is a read-only NetBox client — a CLI and a TUI over the same core.
 
 | Command | What |
 | ------- | ---- |
-| `nbox search <q>` | Parallel search across devices/sites/IPs/prefixes/VLANs/circuits/aggregates/ASNs/IP-ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets. Filters: `--status/--site/--region/--site-group/--location/--tenant/--role/--tag/--vrf`, `--limit`, `--cols`, `--partial`. |
+| `nbox search <q>` | Parallel search across devices/sites/racks/IPs/prefixes/VLANs/circuits/aggregates/ASNs/IP-ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets. Filters: `--status/--site/--region/--site-group/--location/--tenant/--role/--tag/--vrf`, `--limit`, `--cols`, `--partial`. |
 | `nbox device <name\|slug\|id> [--journal]` | Device + interfaces, IPs, cables, VLANs, services. |
 | `nbox interface <device> <iface>` | One interface: type, MTU, MAC, mode, VLANs, cable, **cable path** (an A↔Z trace diagram naming the device at each end), addresses. |
 | `nbox ip <addr> [--vrf] [--journal]` | IP + most-specific parent prefix (VRF-scoped) and its VLAN plus the prefix's `scope`/`scope_type` (site, location, region, …). |
@@ -23,7 +23,7 @@ nbox is a read-only NetBox client — a CLI and a TUI over the same core.
 | `nbox vrf <name\|rd\|id>` | VRF as a routing context: summary (RD, tenant, enforce-unique, import/export route targets, counts) plus its prefix tree and scoped addresses. |
 | `nbox route-target <name\|id>` | Route target (e.g. 65000:100): tenant/description plus the VRFs that import and export it (navigable). |
 | `nbox tags` | List tags. |
-| `nbox journal <kind> <ref>` | Recent journal entries for an object. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target. `--journal` on a detail lookup folds the most recent entries inline (default 5); `--journal-limit <N>` overrides the cap and implies `--journal`. (`tenant`/`contact`/`provider`/`vm`/`cluster`/`vrf` have no inline `--journal` flag — use `nbox journal`.) |
+| `nbox journal <kind> <ref>` | Recent journal entries for an object. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target. `--journal` on a detail lookup folds the most recent entries inline (default 5); `--journal-limit <N>` overrides the cap and implies `--journal`. (`tenant`/`contact`/`provider`/`vm`/`cluster`/`vrf`/`route-target` have no inline `--journal` flag — use `nbox journal`.) |
 | `nbox status` | Connection + per-surface `api` routing (configured/effective) + capabilities + NetBox/Django/Python versions. |
 | `nbox open <kind>/<ref>` | Open an object in the browser. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target, and `interface/<device>/<name>` (the interface name may contain slashes, e.g. `xe-0/0/1`). |
 | `nbox raw GET <path>` | Raw read-only API request (escape hatch). |
@@ -88,9 +88,13 @@ See [AGENTS.md](../AGENTS.md) for the machine-readable surface and exit codes.
 `nbox` (no subcommand) launches the TUI — a three-pane home (a navigation rail of
 browsable kinds → results → a live detail preview):
 
-- `/` search, `:` command palette, `f`/`F` filter / clear, `Tab`/`Shift+Tab` move
-  between panes (or cycle detail tabs), `j`/`k` move (live-browse the kind while on
-  the nav rail), `g`/`G` top/bottom, `Enter` open.
+- `/` search — or, on a name-bearing browse kind (devices, sites, racks, VLANs,
+  VRFs, route-targets), a server-side substring filter (`name__ic`) on
+  that list; prefix/IP browse route `/` to search (NetBox has no CIDR/inet
+  substring lookup — containment filtering is planned), `:` command palette,
+  `f`/`F` filter / clear, `Tab`/`Shift+Tab` move between panes (or cycle detail
+  tabs), `j`/`k` move (live-browse the kind while on the nav rail), `g`/`G`
+  top/bottom, `Enter` open.
 - `o` open in browser, `y` copy, `R` related objects (jump between connected
   objects), navigable device tabs `i`/`p`/`c`/`v`/`s` (`j`/`k` + `Enter` opens a
   row — interfaces/cables open the interface detail, which has a cable-path A↔Z

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -177,11 +177,11 @@ a ≤120 s clock-skew leeway). The 9 read-only tools require the `nbox:read` sco
 JWKS is cached by `kid` (an unknown `kid` triggers a single rate-limited refresh,
 then rejects; a transient JWKS outage keeps serving from the cache).
 
-Failures use the standard challenges: a missing/invalid/expired token → `401`
-with `WWW-Authenticate: Bearer resource_metadata="…", error="invalid_token"`; an
-authenticated request lacking the scope → `403` with
-`WWW-Authenticate: Bearer error="insufficient_scope", scope="nbox:read"`. The
-token is never logged or echoed in an error.
+Failures use the standard challenges: a missing token → `401` with a bare
+`WWW-Authenticate: Bearer resource_metadata="…"`; an invalid/expired token →
+`401` with `… error="invalid_token"`; an authenticated request lacking the
+scope → `403` with `WWW-Authenticate: Bearer error="insufficient_scope",
+scope="nbox:read"`. The token is never logged or echoed in an error.
 
 ```toml
 [serve]
@@ -324,7 +324,7 @@ All tools are annotated read-only.
 | Tool | Purpose |
 | ---- | ------- |
 | `nbox_status` | Connection target, per-surface `api` routing (configured vs effective backend), capabilities, and NetBox/Django/Python versions. Call first to confirm reachability and inspect the `api`/`capabilities` objects. |
-| `nbox_search` | Free-text search across devices, sites, IPs, prefixes, VLANs, circuits, aggregates, ASNs, IP ranges, tenants, contacts, providers, virtual machines, clusters, VRFs, and route targets. Optional `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag`, and `vrf` filters (`vrf` filters IP/prefix results only; only one scope filter at a time). Use it to find an object's exact reference. |
+| `nbox_search` | Free-text search across devices, sites, racks, IPs, prefixes, VLANs, circuits, aggregates, ASNs, IP ranges, tenants, contacts, providers, virtual machines, clusters, VRFs, and route targets. Optional `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag`, and `vrf` filters (`vrf` filters IP/prefix results only; only one scope filter at a time). Use it to find an object's exact reference. |
 | `nbox_get` | Fetch one object by `kind` + `ref`. An ambiguous `ref` returns a candidate list; pass `vrf` (ip/prefix) or `site`/`group` (vlan) to disambiguate. |
 | `nbox_get_interface` | One interface on a device: its config, assigned addresses, and cable-path trace. |
 | `nbox_next_ip` | Next available address(es) within a prefix. `count`, `vrf`. Nothing is reserved. |

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -35,7 +35,7 @@ nbox device edge01 --json                            # pretty JSON
 nbox device edge01 --json --raw                      # one compact line
 nbox device edge01 --json --envelope                 # { schema_version, data }
 nbox device edge01 --json --fields name,status,site  # trim to three fields
-nbox search edge -o csv --cols name,site,status      # CSV table of hits
+nbox search edge -o csv --cols kind,display,url      # CSV table of hits
 ```
 
 `-o csv` is for tabular/list results (e.g. `search`) — arrays render as a table.
@@ -86,8 +86,8 @@ otherwise documented are illustrative — confirm them against your own
 `nbox <cmd> --json` output before relying on them in a pipeline.
 
 ```bash
-nbox device edge01 --json | jq -r '.primary_ip4.address'         # device primary IPv4 (confirmed path)
-nbox search edge -o csv --cols name,site,status                  # CSV of search hits, three columns
+nbox device edge01 --json | jq -r '.primary_ip4'                 # device primary IPv4 (a string like 10.44.208.55/32)
+nbox search edge -o csv --cols kind,display,url                  # CSV of search hits, three columns
 nbox next-ip 10.44.208.0/24 --count 4 --json | jq -r '.available[]'    # next 4 free addresses, one per line
 nbox next-prefix 10.0.0.0/8 --length 26 --json | jq -r '.available[0]' # first free /26
 nbox tags --json | jq -r '.tags[] | "\(.name)\t\(.slug)"'             # tags as name<TAB>slug


### PR DESCRIPTION
Cross-checks every factual claim in the docs against the code (post browse-filter + list_all-perf merge) and fixes what was stale. Docs-only — no code touched.

## Changes
- **CLI surface / examples** — `jq '.primary_ip4.address'` → `.primary_ip4` (DeviceView flattens it to a String); search CSV `--cols name,site,status` → `--cols kind,display,url` (real `SearchResult` keys); `next-ip`/`next-prefix` "computed locally" → "read-only, nothing reserved" (they query NetBox's available-ips/available-prefixes; only `--length` selection is local ipnet); `nbox profile` gains `remove`; AGENTS `[api]` surfaces `vrf`/`route_target`.
- **Feature/MCP refs** — `search`/`nbox_search` kind lists add `racks`; TUI `/` documents the server-side browse filter (name-bearing vs prefix/IP→search); journal no-inline list adds `route-target`; MCP OIDC 401 split (missing→bare Bearer `resource_metadata`, invalid/expired→`error="invalid_token"`).
- **History/roadmap/arch** — object types 19→18 (with vrf+route-target); themes 11→12; record the shipped browse filter + planned CIDR-containment follow-up; add the 0.10.0 line; `src/cache.rs`→`src/cache/`; COMPATIBILITY verified-through 4.6→4.6.2.

## Validation
All 13 substantive claims verified against `src/`:
`primary_ip4` (domain/device_view.rs:31) · `SearchResult` keys (netbox/search.rs:213) · available-ips/prefixes + local `--length` (netbox/query.rs, lib.rs:1122) · `ProfileCommand::Remove` · `[api].route_target` (config.rs:348) · search includes Rack (search.rs:1096) · route-target has no `--journal` flag · `src/cache/` module dir · `Theme::list()` = 12 · OIDC challenge split (mcp/http.rs:901-910) · 18 object types · 4.6.2.