### PR TITLE
feat(tui): CIDR-containment filter for prefix/IP browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CIDR-containment filter for prefix/IP browse.** From the Nav rail, `/` on a
+  prefix browse now filters **server-side** by network containment (`within_include`
+  — the prefix + everything inside it) and on an IP-address browse by `parent`
+  (addresses inside the prefix), instead of falling back to global search. The value
+  is a CIDR, validated locally on Enter — a typo is an instant error, not a NetBox
+  400 round-trip; the pane title reads `within "10.0.0.0/24"`. Completes the browse
+  filter across every Nav-rail kind (name-bearing kinds by `name__ic`, prefix/IP by
+  containment); the router's `None` → search fallback remains for any future
+  non-filterable browse kind.
+
 ## [0.11.0] - 2026-06-23
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,12 +80,18 @@ Polish the read experience. No writes here.
   instead of opening global search — explicit (Enter to apply, not live typeahead), so it doesn't hammer
   NetBox while typing. The pane title shows the active filter + count (`Devices · name contains "bfr" · 52`),
   `1000+` signals the browse cap; `Esc` clears (Normal) / cancels the edit (BrowseFilter), `Ctrl+X`/empty-
-  Enter clear while editing. Prefix, aggregate, and IP-address keep `/` as global search — their key field
-  is a CIDR/inet column with no NetBox `__ic` lookup (an unknown filter param is silently ignored, so a name
-  filter there would match the whole table while looking applied).
-  - ☐ **CIDR-containment filter for prefix/IP browse.** The planned follow-up for the CIDR/inet-keyed
-    kinds: filter those browses by `within_include`/`parent` (network containment) so `/` narrows a prefix/IP
-    list by network instead of falling back to global search.
+  Enter clear while editing. Prefix and IP-address now filter by network containment
+  (the follow-up item below); aggregate keeps `/` as global search (it keys on a
+  CIDR column but isn't a Nav-rail browse kind).
+  - ☑ **CIDR-containment filter for prefix/IP browse.** The follow-up for the
+    CIDR/inet-keyed kinds: `/` on a prefix browse filters by `within_include`
+    (the prefix + everything inside it), on an IP-address browse by `parent`
+    (addresses inside the prefix) — so `/` narrows a prefix/IP list by network
+    instead of falling back to global search. The value is a CIDR, validated locally
+    on Enter (a typo is an instant error, not a NetBox 400); the pane title reads
+    `within "10.0.0.0/24"`. Every Nav-rail kind is now filterable; the router's
+    `None` → search arm stays as a defensive fallback for a future non-filterable
+    browse kind.
 - ☐ **Load-more / follow-`next` (the unifying browse fix).** A browse stops at the cap (1000) and the
   device-interfaces / prefix-children detail tabs stop at their sub-resource caps (200 / 50) — past that
   the only path is the filter. Pull the next page on scroll by **following the server's `next` cursor**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -88,10 +88,10 @@ See [AGENTS.md](../AGENTS.md) for the machine-readable surface and exit codes.
 `nbox` (no subcommand) launches the TUI — a three-pane home (a navigation rail of
 browsable kinds → results → a live detail preview):
 
-- `/` search — or, on a name-bearing browse kind (devices, sites, racks, VLANs,
-  VRFs, route-targets), a server-side substring filter (`name__ic`) on
-  that list; prefix/IP browse route `/` to search (NetBox has no CIDR/inet
-  substring lookup — containment filtering is planned), `:` command palette,
+- `/` search — or, on a browse kind, a server-side filter on that list: a name
+  substring (`name__ic`) for devices/sites/racks/VLANs/VRFs/route-targets, or
+  network containment for prefix (`within_include`) and IP (`parent`) browse
+  (type a CIDR, Enter; the title reads `within "10.0.0.0/24"`). `:` command palette,
   `f`/`F` filter / clear, `Tab`/`Shift+Tab` move between panes (or cycle detail
   tabs), `j`/`k` move (live-browse the kind while on the nav rail), `g`/`G`
   top/bottom, `Enter` open.

--- a/src/netbox/browse.rs
+++ b/src/netbox/browse.rs
@@ -24,23 +24,27 @@ use crate::util::format::api_to_web_url;
 /// request for the remainder.
 pub const BROWSE_CAP: usize = 1000;
 
-/// The query field a browse `filter` maps to for `kind` — a case-insensitive
-/// `contains` (`__ic`) lookup on the kind's name field (`name__ic` for the
-/// name-bearing kinds, `cid__ic` for circuits). `None` means the kind has no usable
-/// substring filter, so the TUI routes `/` to global search instead.
+/// The server-side filter a browse `filter` maps to for `kind`. Two shapes, both
+/// applied server-side so a browse narrows without pulling the whole table:
+/// - [`BrowseFilter::Name`] — a case-insensitive `contains` (`__ic`) on a
+///   CharField (`name__ic` for the name-bearing kinds, `cid__ic` for circuits).
+///   Free text: a substring of the name.
+/// - [`BrowseFilter::Containment`] — network containment on a CIDR/inet field.
+///   Prefix uses `within_include` (the prefix itself + everything inside it);
+///   IpAddress uses `parent` (addresses inside the prefix). The value is a CIDR,
+///   validated locally before it's sent (see the TUI's Enter handler) — a typo is
+///   an instant error, not a NetBox 400 round-trip.
 ///
-/// Prefix, aggregate, and IP-address are deliberately `None`: their key field is a
-/// CIDR/inet column, not a CharField, so NetBox exposes no `__ic` lookup on it — and
-/// an unknown filter param is silently ignored (returns the whole table), so a
-/// `prefix__ic`/`address__ic` filter would look applied while matching nothing it
-/// claims to. Containment filters (`within_include`/`parent`) are the correct future
-/// filter for those kinds. (Checked against NetBox 4.2–4.6 ipam filtersets.)
+/// `None` means the kind has no usable browse filter, so the TUI routes `/` to
+/// global search instead. Aggregate keys on a CIDR field but isn't a Nav-rail browse
+/// kind (inert); Asn/IpRange/Interface have no useful browse filter today.
+/// (NetBox filter facts checked against 4.2–4.6 ipam filtersets.)
 ///
 /// Maps more kinds than [`browse`] currently lists (VM/cluster/provider/tenant/…):
 /// forward-looking, so the field is ready if those become browsable. Today
 /// `browse_kind` is always one of the Nav-rail kinds, so those arms are inert.
 #[must_use]
-pub fn browse_filter_field(kind: ObjectKind) -> Option<&'static str> {
+pub fn browse_filter_field(kind: ObjectKind) -> Option<BrowseFilter> {
     match kind {
         ObjectKind::Device
         | ObjectKind::Site
@@ -52,16 +56,45 @@ pub fn browse_filter_field(kind: ObjectKind) -> Option<&'static str> {
         | ObjectKind::Cluster
         | ObjectKind::Provider
         | ObjectKind::Tenant
-        | ObjectKind::Contact => Some("name__ic"),
-        ObjectKind::Circuit => Some("cid__ic"),
-        // Prefix/Aggregate/IpAddress key on a CIDR/inet field with no NetBox
-        // substring lookup (see above) — `None`, so `/` falls back to search.
-        ObjectKind::Prefix
-        | ObjectKind::Aggregate
-        | ObjectKind::IpAddress
-        | ObjectKind::Asn
-        | ObjectKind::IpRange
-        | ObjectKind::Interface => None,
+        | ObjectKind::Contact => Some(BrowseFilter::Name("name__ic")),
+        ObjectKind::Circuit => Some(BrowseFilter::Name("cid__ic")),
+        // CIDR-containment: prefix/IP browse narrows by network instead of name.
+        ObjectKind::Prefix => Some(BrowseFilter::Containment("within_include")),
+        ObjectKind::IpAddress => Some(BrowseFilter::Containment("parent")),
+        // No usable browse filter → `None`, so `/` falls back to global search.
+        // (Aggregate keys on a CIDR field but isn't a Nav-rail browse kind — inert.)
+        ObjectKind::Aggregate | ObjectKind::Asn | ObjectKind::IpRange | ObjectKind::Interface => {
+            None
+        }
+    }
+}
+
+/// The server-side filter a browse `filter` maps to for a kind. See
+/// [`browse_filter_field`] for the per-kind mapping and the rationale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowseFilter {
+    /// Case-insensitive `contains` (`__ic`) on a name/cid field. Free text.
+    Name(&'static str),
+    /// Network containment on a CIDR/inet field (Prefix `within_include`,
+    /// IpAddress `parent`). The value is a CIDR, validated before it's sent.
+    Containment(&'static str),
+}
+
+impl BrowseFilter {
+    /// The NetBox query-param name (`name__ic` / `cid__ic` / `within_include` /
+    /// `parent`) to send with the filter value.
+    #[must_use]
+    pub const fn field(&self) -> &'static str {
+        match self {
+            Self::Name(f) | Self::Containment(f) => f,
+        }
+    }
+
+    /// True for CIDR-containment filters (prefix/IP), which validate their value
+    /// as a CIDR before sending. Name filters take free text.
+    #[must_use]
+    pub const fn is_containment(self) -> bool {
+        matches!(self, Self::Containment(_))
     }
 }
 
@@ -76,11 +109,14 @@ pub async fn browse(
     max: usize,
     filter: Option<&str>,
 ) -> Result<Vec<SearchResult>> {
-    // The optional name filter, as a query param applied to every kind's list.
+    // The optional server-side filter, as a query param applied to every kind's
+    // list. For Name filters the value is free text; for Containment (prefix/IP)
+    // it's a CIDR, validated by the caller (the TUI's Enter handler) before it
+    // reaches here.
     let filter_param: Option<(&'static str, String)> = filter
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .and_then(|v| browse_filter_field(kind).map(|field| (field, v.to_string())));
+        .and_then(|v| browse_filter_field(kind).map(|f| (f.field(), v.to_string())));
     let base = || -> Vec<(&str, String)> { filter_param.clone().into_iter().collect() };
     let mut out = match kind {
         ObjectKind::Device => {
@@ -298,15 +334,34 @@ mod tests {
 
     #[test]
     fn filter_field_maps_each_kind() {
-        assert_eq!(browse_filter_field(ObjectKind::Device), Some("name__ic"));
-        assert_eq!(browse_filter_field(ObjectKind::Rack), Some("name__ic"));
-        assert_eq!(browse_filter_field(ObjectKind::Circuit), Some("cid__ic"));
-        // CIDR/inet-keyed kinds have no NetBox substring lookup → `None` (so `/`
-        // routes to search, not a filter that would silently match the whole table).
-        assert_eq!(browse_filter_field(ObjectKind::Prefix), None);
+        // Name-bearing kinds → a `__ic` substring lookup.
+        assert_eq!(
+            browse_filter_field(ObjectKind::Device),
+            Some(BrowseFilter::Name("name__ic"))
+        );
+        assert_eq!(
+            browse_filter_field(ObjectKind::Rack),
+            Some(BrowseFilter::Name("name__ic"))
+        );
+        assert_eq!(
+            browse_filter_field(ObjectKind::Circuit),
+            Some(BrowseFilter::Name("cid__ic"))
+        );
+        // CIDR/inet-keyed browsable kinds → network containment (not a name
+        // substring — NetBox has no `__ic` on those columns).
+        assert_eq!(
+            browse_filter_field(ObjectKind::Prefix),
+            Some(BrowseFilter::Containment("within_include"))
+        );
+        assert_eq!(
+            browse_filter_field(ObjectKind::IpAddress),
+            Some(BrowseFilter::Containment("parent"))
+        );
+        // Kinds with no usable browse filter → `None` (so `/` routes to search).
+        // Aggregate keys on a CIDR field but isn't a Nav-rail browse kind (inert).
         assert_eq!(browse_filter_field(ObjectKind::Aggregate), None);
-        assert_eq!(browse_filter_field(ObjectKind::IpAddress), None);
         assert_eq!(browse_filter_field(ObjectKind::Asn), None);
+        assert_eq!(browse_filter_field(ObjectKind::IpRange), None);
     }
 
     #[tokio::test]
@@ -378,5 +433,67 @@ mod tests {
             1,
             "a cap-full browse is a single round trip"
         );
+    }
+
+    #[tokio::test]
+    async fn prefix_browse_pushes_within_include() {
+        // A prefix browse with a containment filter sends `within_include=<cidr>`
+        // (the prefix itself + everything inside it). The mock matches ONLY when
+        // that param is present, so an unfiltered request would get no reply.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/prefixes/"))
+            .and(query_param("within_include", "10.0.0.0/24"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{
+                    "id": 1, "url": "http://nb/api/ipam/prefixes/1/",
+                    "prefix": "10.0.0.0/24", "status": {"value": "active", "label": "Active"}
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let results = browse(
+            &client_for(&server),
+            ObjectKind::Prefix,
+            BROWSE_CAP,
+            Some("10.0.0.0/24"),
+        )
+        .await
+        .expect("filtered prefix browse");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].display, "10.0.0.0/24");
+    }
+
+    #[tokio::test]
+    async fn ip_browse_pushes_parent() {
+        // An IP-address browse with a containment filter sends `parent=<cidr>`
+        // (addresses inside the prefix). The mock matches ONLY when that param is
+        // present, so an unfiltered request would get no reply.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/ip-addresses/"))
+            .and(query_param("parent", "10.0.0.0/24"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{
+                    "id": 5, "url": "http://nb/api/ipam/ip-addresses/5/",
+                    "address": "10.0.0.1/32", "status": {"value": "active", "label": "Active"}
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let results = browse(
+            &client_for(&server),
+            ObjectKind::IpAddress,
+            BROWSE_CAP,
+            Some("10.0.0.0/24"),
+        )
+        .await
+        .expect("filtered IP browse");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].display, "10.0.0.1/32");
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1442,7 +1442,8 @@ impl App {
             KeyCode::Char('b') => return self.go_back(),
             KeyCode::Char('/') => {
                 // While browsing a filterable kind, `/` filters *that* list
-                // server-side (grep by name); otherwise it's the global search.
+                // server-side — a name substring for name-bearing kinds, a
+                // CIDR-containment filter for prefix/IP; otherwise it's global search.
                 match self
                     .browse_kind
                     .filter(|k| crate::netbox::browse::browse_filter_field(*k).is_some())
@@ -2538,7 +2539,9 @@ impl App {
 
     /// Edit the browse filter. Explicit (not live): typing only edits; Enter
     /// applies it server-side, an empty Enter or `Ctrl+X` clears it, Esc cancels
-    /// the edit (leaving the active filter untouched).
+    /// the edit (leaving the active filter untouched). For CIDR-containment filters
+    /// (prefix/IP browse) Enter validates the input as a CIDR first — an invalid
+    /// value stays in the edit with a status error rather than round-tripping a 400.
     fn handle_browse_filter_key(&mut self, key: KeyEvent) -> Vec<AppCommand> {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
@@ -2553,11 +2556,26 @@ impl App {
                 return self.rebrowse_current();
             }
             KeyCode::Enter => {
+                let value = self.filter_input.value().trim().to_string();
+                // Containment filters (prefix/IP browse) take a CIDR — validate it
+                // locally before sending, so a typo is an instant error, not a
+                // NetBox 400 round-trip. Stay in BrowseFilter mode (keep the typed
+                // text) so it can be fixed; the status line carries the reason.
+                let needs_cidr = self.browse_kind.is_some_and(|k| {
+                    crate::netbox::browse::browse_filter_field(k)
+                        .is_some_and(crate::netbox::browse::BrowseFilter::is_containment)
+                });
+                if !value.is_empty() && needs_cidr && value.parse::<ipnet::IpNet>().is_err() {
+                    self.set_transient_status(
+                        format!("invalid CIDR: \"{value}\" — e.g. 10.0.0.0/24"),
+                        Severity::Warning,
+                    );
+                    return Vec::new();
+                }
                 self.mode = Mode::Normal;
                 if self.fence_during_switch() {
                     return Vec::new();
                 }
-                let value = self.filter_input.value().trim().to_string();
                 self.browse_filter = (!value.is_empty()).then_some(value);
                 self.focus = Focus::List;
                 return self.rebrowse_current();
@@ -6248,12 +6266,11 @@ mod tests {
     }
 
     #[test]
-    fn slash_on_a_non_filterable_browse_opens_search_not_the_filter() {
-        // Prefix/IP key on a CIDR/inet field that NetBox has no `__ic` substring
-        // lookup for, so `browse_filter_field` is None — `/` must fall back to global
-        // search, never a filter that would silently match the whole table. This
-        // pins the router's behavioral flip (not just the field mapping): a router
-        // rewrite that ignored `browse_filter_field` would fail here.
+    fn slash_on_prefix_browse_opens_containment_filter() {
+        // Prefix browse now filters *server-side* by network containment
+        // (`within_include`), so `/` opens the browse filter, not global search.
+        // Pins the router's behavioral flip: prefix went None→Containment, so a
+        // router keyed off the old field mapping would route to search here.
         let mut a = app();
         a.focus = Focus::Nav;
         a.nav_selected = 1; // Prefixes
@@ -6263,11 +6280,98 @@ mod tests {
         a.handle_event(press(KeyCode::Char('/')));
         assert_eq!(
             a.mode,
-            Mode::Search,
-            "prefix `/` routes to search, not filter"
+            Mode::BrowseFilter,
+            "prefix `/` routes to the containment filter, not search"
         );
+
+        for c in "10.0.0.0/24".chars() {
+            a.handle_event(press(KeyCode::Char(c)));
+        }
+        let cmds = a.handle_event(press(KeyCode::Enter));
+        assert_eq!(a.mode, Mode::Normal);
+        assert_eq!(a.browse_filter.as_deref(), Some("10.0.0.0/24"));
+        assert!(
+            matches!(
+                cmds.as_slice(),
+                [AppCommand::Browse { kind: ObjectKind::Prefix, filter: Some(f), .. }] if f == "10.0.0.0/24"
+            ),
+            "got: {cmds:?}"
+        );
+    }
+
+    #[test]
+    fn slash_on_ip_browse_opens_containment_filter() {
+        // IP-address browse filters by `parent=<cidr>` containment — `/` opens the
+        // browse filter, not search (the companion to the prefix case above).
+        let mut a = app();
+        a.focus = Focus::Nav;
+        a.nav_selected = 2; // IPs
+        let _ = a.handle_event(press(KeyCode::Enter));
+        assert_eq!(a.browse_kind, Some(ObjectKind::IpAddress));
+
+        a.handle_event(press(KeyCode::Char('/')));
+        assert_eq!(a.mode, Mode::BrowseFilter, "ip `/` routes to the filter");
+
+        for c in "10.0.0.0/24".chars() {
+            a.handle_event(press(KeyCode::Char(c)));
+        }
+        let cmds = a.handle_event(press(KeyCode::Enter));
+        assert_eq!(a.mode, Mode::Normal);
+        assert!(
+            matches!(
+                cmds.as_slice(),
+                [AppCommand::Browse { kind: ObjectKind::IpAddress, filter: Some(f), .. }] if f == "10.0.0.0/24"
+            ),
+            "got: {cmds:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_cidr_in_browse_filter_stays_in_edit_with_an_error() {
+        // Containment filters take a CIDR — a typo is validated locally before
+        // sending, so it never round-trips a NetBox 400. Stays in BrowseFilter
+        // (the typed text is kept for fixing), no Browse command is issued, and
+        // the status line carries the reason.
+        let mut a = app();
+        a.focus = Focus::Nav;
+        a.nav_selected = 1; // Prefixes
+        let _ = a.handle_event(press(KeyCode::Enter));
+        a.handle_event(press(KeyCode::Char('/')));
+        assert_eq!(a.mode, Mode::BrowseFilter);
+
+        for c in "not-a-cidr".chars() {
+            a.handle_event(press(KeyCode::Char(c)));
+        }
+        let cmds = a.handle_event(press(KeyCode::Enter));
+        assert_eq!(
+            a.mode,
+            Mode::BrowseFilter,
+            "stays in the edit on a bad CIDR"
+        );
+        assert!(cmds.is_empty(), "no Browse command on an invalid CIDR");
+        assert!(
+            a.status.contains("invalid CIDR"),
+            "status explains the bad input: {:?}",
+            a.status
+        );
+        assert_eq!(a.browse_filter, None, "the filter is not set on a bad CIDR");
+    }
+
+    #[test]
+    fn slash_on_a_non_filterable_kind_falls_back_to_search() {
+        // Defensive fallback: a kind with no usable browse filter routes `/` to
+        // global search. No Nav-rail kind is in this state today (every rail kind
+        // is name- or containment-filterable), so this is pinned with a synthetic
+        // non-rail kind (Asn) set directly — it guards the router's `None` arm
+        // against a future non-filterable browse kind landing on the rail.
+        let mut a = app();
+        a.focus = Focus::Nav;
+        a.browse_kind = Some(ObjectKind::Asn);
+
+        a.handle_event(press(KeyCode::Char('/')));
+        assert_eq!(a.mode, Mode::Search, "non-filterable `/` routes to search");
         // The browse context survives — search layers on top of it.
-        assert_eq!(a.browse_kind, Some(ObjectKind::Prefix));
+        assert_eq!(a.browse_kind, Some(ObjectKind::Asn));
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -855,13 +855,19 @@ fn render_home_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 };
                 match &app.browse_filter {
                     Some(f) => {
-                        // "name contains" / "prefix contains" / "address contains" / …
-                        let field = crate::netbox::browse::browse_filter_field(kind)
-                            .map_or("name", |q| q.trim_end_matches("__ic"));
-                        format!(
-                            " {} · {field} contains \"{f}\" · {count} ",
-                            browse_label(kind)
-                        )
+                        // "name contains" for name filters; "within 10.0.0.0/8"
+                        // for the CIDR-containment filters (prefix/IP browse).
+                        match crate::netbox::browse::browse_filter_field(kind) {
+                            Some(crate::netbox::browse::BrowseFilter::Name(field)) => format!(
+                                " {} · {} contains \"{f}\" · {count} ",
+                                browse_label(kind),
+                                field.trim_end_matches("__ic"),
+                            ),
+                            Some(crate::netbox::browse::BrowseFilter::Containment(_)) => {
+                                format!(" {} · within \"{f}\" · {count} ", browse_label(kind))
+                            }
+                            None => format!(" {} · {count} ", browse_label(kind)),
+                        }
                     }
                     None => format!(" {} · {count} ", browse_label(kind)),
                 }
@@ -2241,8 +2247,8 @@ fn footer_nav(app: &App) -> &'static str {
         // (focus stays here), Enter commits and jumps into the list. `/` acts on the
         // settled browse_kind (what the list shows), not nav_selected — so the hint
         // matches the action even mid-scroll: `/ filter` for a name-bearing kind,
-        // `/ search` otherwise (prefix/IP, or Recent with no kind). Mirrors the
-        // router and the List-pane arm below.
+        // `/ search` otherwise (Recent with no kind). Mirrors the router and the
+        // List-pane arm below.
         Screen::Home if app.focus == Focus::Nav => {
             if app
                 .browse_kind
@@ -2254,8 +2260,9 @@ fn footer_nav(app: &App) -> &'static str {
             }
         }
         // A browse list (a kind picked from the Nav rail). Filterable kinds bind `/`
-        // to a name filter (Esc clears it); kinds with no substring filter
-        // (prefix/IP — CIDR/inet, see `browse_filter_field`) route `/` to search.
+        // to a server-side filter (Esc clears it): a name filter for name-bearing
+        // kinds, a CIDR-containment filter for prefix/IP. Kinds with no usable
+        // filter (none on the Nav rail today) route `/` to search.
         Screen::Home if app.browse_kind.is_some() && app.last_query.is_none() => {
             if app
                 .browse_kind
@@ -2357,6 +2364,44 @@ mod tests {
         assert!(
             text.contains("No matching"),
             "empty-state note shown: {text:?}"
+        );
+    }
+
+    #[test]
+    fn prefix_filtered_browse_title_says_within_not_contains() {
+        // A containment filter (prefix/IP browse) titles the pane `within "<cidr>"`,
+        // not `<field> contains "<cidr>"` — the filter is by network, not a name
+        // substring. Pins the BrowseFilter::Containment arm of the title builder.
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut a = app();
+        a.browse_kind = Some(ObjectKind::Prefix);
+        a.browse_filter = Some("10.0.0.0/24".to_string());
+        a.last_query = None;
+        a.results.clear();
+        a.view.clear();
+
+        let mut term = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        term.draw(|f| render_home_list(f, f.area(), &mut a))
+            .unwrap();
+        let text: String = term
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(
+            text.contains("within"),
+            "containment title says `within`: {text:?}"
+        );
+        assert!(
+            text.contains("10.0.0.0/24"),
+            "title carries the CIDR: {text:?}"
+        );
+        assert!(
+            !text.contains("contains"),
+            "containment does not use the name-filter wording: {text:?}"
         );
     }
 
@@ -2913,24 +2958,40 @@ mod tests {
     #[test]
     fn footer_nav_browse_hint_is_kind_aware() {
         // The browse-list footer advertises `/` by the kind's filterability: a
-        // name-bearing kind filters in place (`/ filter`, Esc clears it); a kind
-        // with no NetBox substring lookup (prefix/IP) routes `/` to global search
-        // (`/ search`). Guards the hint against drifting from the `/` router.
+        // name-bearing kind filters in place (`/ filter`, Esc clears it); a
+        // CIDR-containment kind (prefix/IP) also advertises `/ filter` now — the
+        // filter is by network, not name, but `/` still binds to it. A kind with no
+        // usable filter (none on the Nav rail today; pinned here with a synthetic
+        // Asn) routes `/` to global search (`/ search`). Guards the hint against
+        // drifting from the `/` router.
         let mut a = app();
         a.screen = Screen::Home;
         a.focus = Focus::List;
         a.last_query = None;
 
         a.browse_kind = Some(ObjectKind::Device);
-        let filterable = footer_nav(&a);
-        assert!(filterable.contains("/ filter"), "filterable: {filterable}");
+        let name_filter = footer_nav(&a);
+        assert!(name_filter.contains("/ filter"), "device: {name_filter}");
 
+        // Prefix now filters by network containment → `/ filter`, not `/ search`.
         a.browse_kind = Some(ObjectKind::Prefix);
+        let net_filter = footer_nav(&a);
+        assert!(
+            net_filter.contains("/ filter"),
+            "prefix browse advertises the containment filter: {net_filter}"
+        );
+        assert!(
+            !net_filter.contains("/ search"),
+            "prefix no longer routes `/` to search: {net_filter}"
+        );
+
+        // Defensive: a non-filterable kind (none on the rail today) routes `/` to search.
+        a.browse_kind = Some(ObjectKind::Asn);
         let plain = footer_nav(&a);
-        assert!(plain.contains("/ search"), "prefix: {plain}");
+        assert!(plain.contains("/ search"), "non-filterable: {plain}");
         assert!(
             !plain.contains("/ filter"),
-            "prefix browse must not advertise a filter: {plain}"
+            "non-filterable must not advertise a filter: {plain}"
         );
 
         // The Nav rail is the app's landing posture, and `/` acts there too — so its
@@ -2948,11 +3009,20 @@ mod tests {
             "rail keeps its browse prefix: {rail_filterable}"
         );
         a.browse_kind = Some(ObjectKind::Prefix);
+        let rail_prefix = footer_nav(&a);
+        assert!(
+            rail_prefix.contains("/ filter"),
+            "rail prefix advertises the containment filter: {rail_prefix}"
+        );
+        a.browse_kind = Some(ObjectKind::Asn);
         let rail_plain = footer_nav(&a);
-        assert!(rail_plain.contains("/ search"), "rail prefix: {rail_plain}");
+        assert!(
+            rail_plain.contains("/ search"),
+            "rail non-filterable: {rail_plain}"
+        );
         assert!(
             !rail_plain.contains("/ filter"),
-            "rail prefix must not advertise a filter: {rail_plain}"
+            "rail non-filterable must not advertise a filter: {rail_plain}"
         );
     }
 


### PR DESCRIPTION
Closes the roadmap's explicit "planned follow-up" to the 0.11.0 browse filter: prefix/IP browse now narrows **server-side by network containment** instead of falling back to global search. From the Nav rail, `/` on a prefix browse filters by `within_include` (the prefix + everything inside it); on an IP-address browse by `parent` (addresses inside the prefix).

This is the *correct* fix, not a forced substring: prefix/IP key on a CIDR/inet column with no NetBox `__ic` lookup, so the 0.11.0 filter deliberately skipped them. Containment is a different filter shape for a different key type.

## Behavior change to flag
**Every Nav-rail kind is now filterable** (name-bearing → `name__ic`/`cid__ic`; prefix → `within_include`; IP → `parent`). So prefix/IP `/` now opens the **containment filter** (was: global search). The router's `None` → search arm stays as a defensive fallback — no rail kind hits it today; pinned with a synthetic `Asn` in the tests in case a future non-filterable browse kind lands on the rail.

## Design decisions for review
1. **Enum over a second function.** `browse_filter_field` went `Option<&'static str>` → `Option<BrowseFilter>` (`Name(&str)` / `Containment(&str)`), carrying both the mode and the param name. Cleaner than a parallel `browse_filter_mode()` that'd drift out of sync. `field()` / `is_containment()` accessors; `BrowseFilter` is `Copy`.
2. **`within_include` for prefix, `parent` for IP** — the two params differ per kind (the old single-`&str` return couldn't express that). Both are already proven in `query.rs` (`prefix_children` uses `within=`, `prefix_ips` uses `parent=`). I chose `within_include` over strict `within` so "show me 10.0.0.0/8 and everything in it" includes the boundary — the natural browse question.
3. **Aggregate stays `None`.** It keys on a CIDR field but isn't a Nav-rail browse kind (inert); mapping it would be unreachable. Minimizes the diff. Easy to add if it ever becomes browsable.
4. **Local CIDR validation on Enter** (`ipnet::IpNet`, already a dep). A typo → instant status error, stays in the edit (typed text kept), never round-trips a NetBox 400. Name filters keep free-text. This is *better* UX than the name filter (which never validates) and avoids 400s.
5. **Pane title**: `· within "10.0.0.0/24" ·` for containment (vs `· name contains "x" ·`); footer hint flips `/ search` → `/ filter` for prefix/IP.

## Complementarity with the prefix tree (`T`)
The tree is a navigable expand/collapse hierarchy; this is a flat filtered list you scroll/copy/pipe. Different UX for "browse a slice of the IP space" — they coexist. (I flagged this overlap earlier; the roadmap's call was to build it anyway, and I agree now that the flat-list path is a distinct workflow.)

## Tests (+6)
- `prefix_browse_pushes_within_include` / `ip_browse_pushes_parent` — wiremock pins the containment param on the request (mirrors the existing `device_browse_pushes_the_name_filter`).
- `slash_on_prefix_browse_opens_containment_filter` / `slash_on_ip_browse_opens_containment_filter` — the router flip.
- `invalid_cidr_in_browse_filter_stays_in_edit_with_an_error` — validation: stays in edit, no Browse command, status set.
- `slash_on_a_non_filterable_kind_falls_back_to_search` — the defensive `None` arm (synthetic Asn).
- `prefix_filtered_browse_title_says_within_not_contains` — the title wording.
- Updated the two tests whose premise flipped (footer/hint for prefix now `/ filter`).

## Gate
`scripts/smoke.sh` green end-to-end: fmt, both pedantic clippy modes, both test modes (829 lib / 737 no-default-features), `cargo audit`, build smoke, man/completion gen. No live-instance dependency.

## Docs
- CHANGELOG `[Unreleased]` entry.
- ROADMAP: CIDR-containment ☐→☑; browse-filter entry updated to point at the follow-up. **The 0.11.0 release line is left intact** (it records what 0.11.0 shipped — prefix/IP → search was true then).
- FEATURES.md drops the stale "prefix/IP route `/` to search" line.

Ready for review when you're up. No urgency — I held the design decisions defensible so you can push back on any of #2–#4 (especially the `within_include` vs `within` choice and leaving Aggregate out) without a rework.