### PR TITLE
feat: MAC reverse-lookup (`nbox mac <addr>`) as a first-class kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ nbox vm <name|id>
 nbox cluster <name|id>
 nbox vrf <name|rd|id>
 nbox route-target <name|id>
+nbox mac <addr>                   # any common form (aa:bb:cc:dd:ee:ff, AABB.CCDD.EEFF, …) is normalized; reverse-resolves to the carrying interface(s)/device(s)
 nbox search <query> [--limit N] [--status S] [--site <name|slug|id>] [--region <name|slug|id>] [--site-group <name|slug|id>] [--location <name|slug|id>] [--tenant SLUG] [--role SLUG] [--tag SLUG] [--vrf <id|rd|name>] [--cols a,b,c] [--partial]
 nbox tags
 nbox journal <kind> <ref>
@@ -81,7 +82,7 @@ stderr. Every tool is annotated read-only.
 | ---- | ------- |
 | `nbox_status` | Connection + active backend capabilities + NetBox/Django/Python versions (call first to confirm reachability and inspect `capabilities`). |
 | `nbox_search` | Search devices/sites/racks/IPs/prefixes/VLANs/circuits/aggregates/ASNs/IP ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets; `query` (required), `limit`, `status`, `site`, `region`, `site_group`, `location`, `tenant`, `role`, `tag` (one scope filter at a time), `vrf` (id\|rd\|name; filters IP/prefix results only). Find a reference before `nbox_get`; a result's `kind` (e.g. `ip_address`) feeds straight into `nbox_get`, which accepts it as an alias for `ip`. |
-| `nbox_get` | One object: `kind` (device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, cluster, vrf, route_target) + `ref`; `vrf`/`site`/`group` disambiguate (an ambiguous ref returns the candidates). |
+| `nbox_get` | One object: `kind` (device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, cluster, vrf, route_target, mac) + `ref`; `vrf`/`site`/`group` disambiguate (an ambiguous ref returns the candidates). |
 | `nbox_get_interface` | One interface on a device: config, addresses, cable-path trace. |
 | `nbox_next_ip` | Next available address(es) in a prefix (nothing reserved); `count`, `vrf`. |
 | `nbox_next_prefix` | Available child prefix(es) in a prefix; `length` for a block of a size, else all free blocks; `vrf`. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **MAC reverse-lookup (`nbox mac <addr>`).** A new first-class kind (NetBox
+  4.2+) that reverse-resolves a MAC address to the interface(s)/device(s) that
+  carry it — a top operator/agent query nbox couldn't answer. Any common MAC
+  form is accepted and normalized (`aa:bb:cc:dd:ee:ff`, `AABB.CCDD.EEFF`,
+  `aa-bb-…`, `aabbccddeeff`, a trailing `/48` is stripped); a non-MAC is a usage
+  error (exit 2) with no NetBox round-trip. MACs aren't enforced globally unique,
+  so several carrying interfaces surface as ambiguous (exit 5) with the candidate
+  list, not a silent first-pick. Available on the CLI (`nbox mac`), via MCP
+  (`nbox_get` kind `mac` / `nbox://mac/<addr>`), and `nbox open mac/<addr>`.
+  Polymorphic assignment (physical interface *or* VM interface) is rendered as
+  `"<parent> <interface>"`.
+
 - **CIDR-containment filter for prefix/IP browse.** From the Nav rail, `/` on a
   prefix browse now filters **server-side** by network containment (`within_include`
   — the prefix + everything inside it) and on an IP-address browse by `parent`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [Installation](#installation) below for setup instructions.
 
 ## Features
 
-- **Fast shell lookups** — `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`, `route-target`, and `interface`, each as a one-liner.
+- **Fast shell lookups** — `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`, `route-target`, `mac`, and `interface`, each as a one-liner.
 - **Normalized search** — one `search` query runs in parallel across devices, sites, racks, IPs, prefixes, VLANs, circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs, clusters, VRFs, and route targets, returning ranked, deduped hits. Scope it with `--site`/`--region`/`--site-group`/`--location` (one at a time, exact scope), or narrow by `--status`/`--tenant`/`--role`/`--tag`/`--vrf`.
 - **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` for free addresses and blocks (read-only — nothing is reserved).
 - **A k9s-style TUI** — a three-pane home (navigation rail → results → live preview), an overview dashboard, a hierarchical prefix tree, cross-object navigation between related objects (every detail's related-object tabs are navigable — open an interface from a device and see its cable path drawn as an A↔Z diagram), fuzzy filters, server-side name filtering on the browse list, recents, and an in-app profile + settings editor. Twelve themes; `NO_COLOR` honored.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,9 +23,9 @@ Legend: ☐ planned · ◐ in progress · ☑ done
 
 The read surface is broad and stable today (full history in `CHANGELOG.md`):
 
-- **CLI lookups — 18 object types:** `device`, `interface`, `ip`, `prefix`, `vlan`, `site`, `rack`,
+- **CLI lookups — 19 object types:** `device`, `interface`, `ip`, `prefix`, `vlan`, `site`, `rack`,
   `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`,
-  `route-target`, plus `search`, `journal`, `tags`, `status`, `open`, `raw GET`. NetBox 4.2+ polymorphic scope + VRF
+  `route-target`, `mac`, plus `search`, `journal`, `tags`, `status`, `open`, `raw GET`. NetBox 4.2+ polymorphic scope + VRF
   correctness; ambiguous refs exit `5` with the candidate list.
 - **Search:** parallel multi-endpoint fan-out with `--status` / `--site` / `--region` /
   `--site-group` / `--location` / `--tenant` / `--role` / `--tag` / `--vrf` filters (per-endpoint
@@ -213,9 +213,16 @@ NetBox has moved to 4.6 (tick-tock cadence; 4.7 "tock" — may break — is the 
 A 2026-06 feature scan surfaced read-only, non-goal-respecting surface nbox doesn't yet
 cover. All of these stay within the read-only product and the explicit non-goals.
 
-- ☐ **MAC addresses as a first-class kind** _(NetBox 4.2)_. MACs became standalone objects
-  (multi-per-interface, primary designation). Add `nbox mac <addr>` to reverse-resolve
-  MAC → interface → device — a top operator/agent query nbox can't answer today. Highest value.
+- ☑ **MAC addresses as a first-class kind** _(NetBox 4.2)_. `nbox mac <addr>`
+  reverse-resolves a MAC to the interface(s)/device(s) that carry it — a top
+  operator/agent query nbox couldn't answer. Any common MAC form is normalized
+  first (a non-MAC is a usage error, no round-trip); MACs aren't globally unique,
+  so several carrying interfaces surface as ambiguous (exit 5) with the candidate
+  list. Polymorphic assignment (physical interface *or* VM interface) renders as
+  `"<parent> <interface>"`. On the CLI, MCP (`nbox_get` kind `mac` /
+  `nbox://mac/<addr>`), and `nbox open mac/<addr>`. Lookup-only (exact
+  `mac_address=`) — not browsable/searchable, since MACs aren't substring-meaningful.
+  Highest value, shipped.
 - ☐ **New object kinds from 4.2/4.6.** `virtual-circuit` (+ terminations, 4.2), and the 4.6
   additions `virtual-machine-type`, `rack-group`, `cable-bundle` — small, formulaic lookups
   that keep kind coverage current. (Each: model + `nbox <kind>` + detail view; `cable-bundle`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -22,10 +22,11 @@ nbox is a read-only NetBox client — a CLI and a TUI over the same core.
 | `nbox cluster <name\|id>` | Cluster: type, group, status, tenant, scope (site/region/…), device + VM counts, description, tags, custom fields. |
 | `nbox vrf <name\|rd\|id>` | VRF as a routing context: summary (RD, tenant, enforce-unique, import/export route targets, counts) plus its prefix tree and scoped addresses. |
 | `nbox route-target <name\|id>` | Route target (e.g. 65000:100): tenant/description plus the VRFs that import and export it (navigable). |
+| `nbox mac <addr>` | Reverse-resolve a MAC to the interface(s)/device(s) that carry it (NetBox 4.2+). Any common form is normalized (`aa:bb:cc:dd:ee:ff`, `AABB.CCDD.EEFF`, `aa-bb-…`, `aabbccddeeff`); a non-MAC is a usage error, several carrying interfaces are ambiguous. |
 | `nbox tags` | List tags. |
 | `nbox journal <kind> <ref>` | Recent journal entries for an object. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target. `--journal` on a detail lookup folds the most recent entries inline (default 5); `--journal-limit <N>` overrides the cap and implies `--journal`. (`tenant`/`contact`/`provider`/`vm`/`cluster`/`vrf`/`route-target` have no inline `--journal` flag — use `nbox journal`.) |
 | `nbox status` | Connection + per-surface `api` routing (configured/effective) + capabilities + NetBox/Django/Python versions. |
-| `nbox open <kind>/<ref>` | Open an object in the browser. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target, and `interface/<device>/<name>` (the interface name may contain slashes, e.g. `xe-0/0/1`). |
+| `nbox open <kind>/<ref>` | Open an object in the browser. Kinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target, mac, and `interface/<device>/<name>` (the interface name may contain slashes, e.g. `xe-0/0/1`). |
 | `nbox raw GET <path>` | Raw read-only API request (escape hatch). |
 
 Every detail lookup surfaces the object's `tags` (joined slugs in plain output, a

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -335,10 +335,10 @@ All tools are annotated read-only.
 
 `nbox_get` and `nbox_journal` take a `kind` and a `ref`. `kind` is one of
 `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `aggregate`,
-`asn`, `ip_range`, `tenant`, `contact`, `provider`, `vm`, `cluster`, `vrf`, `route_target` — both
+`asn`, `ip_range`, `tenant`, `contact`, `provider`, `vm`, `cluster`, `vrf`, `route_target`, `mac` — both
 tools accept the full set. `ref` is the natural reference for that kind: a
 name/slug/ID for named objects, a CIDR for prefix and aggregate, an address for
-ip, a VID or name for vlan, the AS number for asn, a name/RD/ID for vrf, a name (e.g. 65000:100) or ID for route_target.
+ip, a VID or name for vlan, the AS number for asn, a name/RD/ID for vrf, a name (e.g. 65000:100) or ID for route_target, a MAC address (any common form, normalized) for mac.
 
 `nbox_get` also accepts `ip_address` as an alias for `ip` — that's the `kind` a
 `nbox_search` result carries, so a search → get chain can pass the hit's `kind`
@@ -355,7 +355,7 @@ nbox://{kind}/{ref}
 
 `kind` is the same set as `nbox_get` (`device`, `ip`, `prefix`, `vlan`, `site`,
 `rack`, `circuit`, `aggregate`, `asn`, `ip_range`, `tenant`, `contact`,
-`provider`, `vm`, `cluster`, `vrf`, `route_target`); `ref` is the same natural reference. Reading a resource returns the
+`provider`, `vm`, `cluster`, `vrf`, `route_target`, `mac`); `ref` is the same natural reference. Reading a resource returns the
 object as JSON — the exact view model `nbox_get` returns. Examples:
 `nbox://device/edge01`, `nbox://ip/10.0.0.1`, `nbox://site/iad1`.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -328,6 +328,15 @@ pub enum Command {
         value: String,
     },
 
+    /// Show a MAC address — reverse-resolve it to the interface(s)/device(s)
+    /// that carry it (NetBox 4.2+).
+    Mac {
+        /// The MAC address. Any common form is accepted and normalized
+        /// (`aa:bb:cc:dd:ee:ff`, `AABB.CCDD.EEFF`, `aa-bb-…`, `aabbccddeeff`,
+        /// a trailing `/48` is stripped).
+        value: String,
+    },
+
     /// Show a VLAN by VID or name.
     Vlan {
         /// VLAN VID or name.

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -25,6 +25,7 @@ use crate::domain::interface_view::InterfaceView;
 use crate::domain::ip_range_view::IpRangeView;
 use crate::domain::ip_view::{IpView, assigned_label, most_specific};
 use crate::domain::journal_view::{JournalEntryRow, JournalView};
+use crate::domain::mac_view::MacView;
 use crate::domain::prefix_view::PrefixView;
 use crate::domain::provider_view::ProviderView;
 use crate::domain::rack_view::RackView;
@@ -39,7 +40,7 @@ use crate::netbox::client::NetBoxClient;
 use crate::netbox::endpoints::Endpoint;
 use crate::netbox::models::circuits::{Circuit, CircuitTermination, Provider};
 use crate::netbox::models::common::BriefObject;
-use crate::netbox::models::dcim::{Device, Interface, Rack, Site};
+use crate::netbox::models::dcim::{Device, Interface, MacAddress, Rack, Site};
 use crate::netbox::models::ipam::{
     Aggregate, Asn, IpAddress, IpRange, Prefix, RouteTarget, Vlan, VlanGroup, Vrf,
 };
@@ -673,6 +674,33 @@ pub async fn asn_view_by_ref(
         .await?
         .ok_or_else(|| not_found("ASN", value))?;
     Ok(AsnView::from_model(asn))
+}
+
+/// `mac <addr>`: reverse-resolve a MAC to its assignment. MACs aren't enforced
+/// globally unique (the same MAC can appear on several interfaces), so >1
+/// candidate surfaces as `Ambiguous` (exit 5) with the candidate list — the
+/// caller normalizes the MAC before passing it in. Shared by CLI/MCP.
+pub async fn mac_view_by_ref(
+    client: &NetBoxClient,
+    mac: &str,
+    value: &str,
+    not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
+) -> Result<MacView> {
+    let candidates = client.mac_candidates(mac).await?;
+    let m = resolve_unique("MAC", value, candidates, label_mac, not_found)?;
+    Ok(MacView::from_model(m))
+}
+
+/// A MAC candidate's one-line label for the ambiguous-match list: the MAC plus
+/// its assignment (e.g. `aa:…:ff → edge01 xe-0/0/1`), so an ambiguous MAC names
+/// the competing interfaces.
+fn label_mac(m: &MacAddress) -> String {
+    let assigned = m
+        .assigned_object
+        .as_ref()
+        .and_then(crate::domain::mac_view::assigned_label)
+        .unwrap_or_else(|| "unassigned".to_string());
+    format!("{} → {}", m.mac_address, assigned)
 }
 
 /// `ip-range <start|id>`: resolve an IP range and build its view. Shared by CLI/MCP.
@@ -1849,6 +1877,13 @@ pub async fn load_detail(client: &NetBoxClient, kind: ObjectKind, id: u64) -> Re
             // link); it's reached only by id, from a device's interfaces/cables tab.
             return load_interface_detail_view(client, id).await;
         }
+        ObjectKind::Mac => {
+            let m: MacAddress = client
+                .get(&format!("/api/dcim/mac-addresses/{id}/"), &[])
+                .await?;
+            let v = MacView::from_model(m);
+            (format!("mac {}", v.mac_address), v.to_key_values().render())
+        }
     };
     Ok(DetailView::new(kind, id, title, body)
         .with_tabs(tabs)
@@ -2115,6 +2150,21 @@ pub async fn load_detail_by_ref(
                 .parse()
                 .map_err(|_| tui_not_found("interface", value))?;
             return load_interface_detail_view(client, id).await;
+        }
+        ObjectKind::Mac => {
+            // A MAC is normalized before lookup; a non-MAC input is a usage error
+            // (not a NetBox round-trip). Resolve → Ambiguous (exit 5) if several
+            // interfaces carry it, else the flat MAC view.
+            let mac = crate::mac::normalize(value).ok_or_else(|| tui_not_found("MAC", value))?;
+            let candidates = client.mac_candidates(&mac).await?;
+            let m = resolve_unique("MAC", value, candidates, label_mac, &tui_not_found)?;
+            let id = m.id;
+            let v = MacView::from_model(m);
+            (
+                id,
+                format!("mac {}", v.mac_address),
+                v.to_key_values().render(),
+            )
         }
     };
     Ok(DetailView::new(kind, id, title, body)

--- a/src/domain/mac_view.rs
+++ b/src/domain/mac_view.rs
@@ -1,0 +1,192 @@
+//! The MAC-address view: a flat `MacView` for `nbox mac <addr>` (CLI + MCP).
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::netbox::models::dcim::MacAddress;
+use crate::output::plain::KeyValues;
+
+/// A MAC address plus its assignment. The reverse-resolve answer for
+/// `nbox mac <addr>` — which interface(s)/device(s) carry this MAC.
+#[derive(Debug, Clone, Serialize)]
+pub struct MacView {
+    pub id: u64,
+    /// The MAC in NetBox's canonical form.
+    pub mac_address: String,
+    /// The dotted content type of the assigned object (`dcim.interface`,
+    /// `virtualization.vminterface`, …), or `None` for an unassigned MAC.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assigned_object_type: Option<String>,
+    /// A readable label for the assigned interface/VM-interface —
+    /// `"<device> <interface>"` (e.g. `edge01 xe-0/0/1`) or just the interface
+    /// name. `None` when the MAC is unassigned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assigned: Option<String>,
+    /// The owning device's name (when assigned to a physical interface), for a
+    /// quick "which device" without re-parsing `assigned`. `None` for VM
+    /// interfaces and unassigned MACs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub custom_fields: BTreeMap<String, Value>,
+}
+
+impl MacView {
+    /// Normalize a wire [`MacAddress`] into a flat view.
+    #[must_use]
+    pub fn from_model(m: MacAddress) -> Self {
+        let assigned = m.assigned_object.as_ref().and_then(assigned_label);
+        // Pull the owning device name straight from the assigned brief — it's
+        // already there for a physical interface, so no second fetch is needed.
+        let device = m
+            .assigned_object
+            .as_ref()
+            .and_then(|v| v.get("device"))
+            .and_then(|d| {
+                d.get("display")
+                    .or_else(|| d.get("name"))
+                    .and_then(|x| x.as_str())
+                    .map(str::to_string)
+            });
+        Self {
+            id: m.id,
+            mac_address: m.mac_address,
+            assigned_object_type: m.assigned_object_type,
+            assigned,
+            device,
+            description: m.description.and_then(crate::domain::util::non_empty),
+            owner: m.owner.map(|b| b.label()),
+            tags: m.tags.into_iter().map(|t| t.slug).collect(),
+            custom_fields: crate::domain::custom::fields(&m.custom_fields),
+        }
+    }
+
+    /// Plain-text rendering (`-o plain`): the MAC + its assignment, one row each.
+    #[must_use]
+    pub fn to_key_values(&self) -> KeyValues {
+        let mut kv = KeyValues::new();
+        kv.push("mac", self.mac_address.clone());
+        kv.push_opt("assigned_object_type", self.assigned_object_type.clone());
+        kv.push_opt("assigned", self.assigned.clone());
+        kv.push_opt("device", self.device.clone());
+        kv.push_opt("description", self.description.clone());
+        kv.push_opt("owner", self.owner.clone());
+        if !self.tags.is_empty() {
+            kv.push("tags", self.tags.join(", "));
+        }
+        kv
+    }
+}
+
+/// Label a MAC's `assigned_object` brief, tolerating its polymorphic shape. NetBox
+/// returns either a `dcim.interface` (carries a `device`) or a
+/// `virtualization.vminterface` (carries a `virtual_machine`); both expose a
+/// `display`/`name` and the parent's `display`/`name`. Mirrors `ip_view`'s
+/// `assigned_label` but handles the VM-interface parent too.
+///
+/// Returns `"<parent> <interface>"` when the parent is present, else the bare
+/// interface name — so `edge01 xe-0/0/1` for a device interface and
+/// `web-01 eth0` for a VM interface.
+pub(crate) fn assigned_label(v: &serde_json::Value) -> Option<String> {
+    let iface = v
+        .get("display")
+        .and_then(|x| x.as_str())
+        .or_else(|| v.get("name").and_then(|x| x.as_str()))?;
+    // A physical interface carries `device`; a VM interface carries
+    // `virtual_machine`. Either way the brief nests a `display`/`name`.
+    let parent = v
+        .get("device")
+        .or_else(|| v.get("virtual_machine"))
+        .and_then(|p| {
+            p.get("display")
+                .or_else(|| p.get("name"))
+                .and_then(|x| x.as_str())
+        });
+    Some(match parent {
+        Some(name) => format!("{name} {iface}"),
+        None => iface.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn mac(id: u64, addr: &str, assigned: Option<serde_json::Value>) -> MacAddress {
+        serde_json::from_value(json!({
+            "id": id,
+            "url": format!("http://nb/api/dcim/mac-addresses/{id}/"),
+            "mac_address": addr,
+            "assigned_object": assigned,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn from_model_labels_a_device_interface_assignment() {
+        let m = mac(
+            1,
+            "aa:bb:cc:dd:ee:ff",
+            Some(json!({
+                "display": "xe-0/0/1",
+                "device": {"display": "edge01"}
+            })),
+        );
+        let v = MacView::from_model(m);
+        assert_eq!(v.mac_address, "aa:bb:cc:dd:ee:ff");
+        assert_eq!(v.assigned.as_deref(), Some("edge01 xe-0/0/1"));
+        assert_eq!(v.device.as_deref(), Some("edge01"));
+    }
+
+    #[test]
+    fn from_model_labels_a_vm_interface_assignment() {
+        let m = mac(
+            2,
+            "11:22:33:44:55:66",
+            Some(json!({
+                "name": "eth0",
+                "virtual_machine": {"display": "web-01"}
+            })),
+        );
+        let v = MacView::from_model(m);
+        assert_eq!(v.assigned.as_deref(), Some("web-01 eth0"));
+        // A VM interface has no `device` — `device` stays None.
+        assert_eq!(v.device, None);
+    }
+
+    #[test]
+    fn from_model_handles_an_unassigned_mac() {
+        let m = mac(3, "aa:bb:cc:dd:ee:00", None);
+        let v = MacView::from_model(m);
+        assert_eq!(v.assigned, None);
+        assert_eq!(v.device, None);
+    }
+
+    #[test]
+    fn assigned_label_falls_back_to_the_bare_interface_name() {
+        let bare = json!({"name": "eth0"});
+        assert_eq!(assigned_label(&bare).as_deref(), Some("eth0"));
+    }
+
+    #[test]
+    fn to_key_values_renders_mac_and_assignment() {
+        let m = mac(
+            1,
+            "aa:bb:cc:dd:ee:ff",
+            Some(json!({"display": "xe-0/0/1", "device": {"display": "edge01"}})),
+        );
+        let rendered = MacView::from_model(m).to_key_values().render();
+        assert!(rendered.contains("mac: aa:bb:cc:dd:ee:ff"), "{rendered}");
+        assert!(rendered.contains("assigned: edge01 xe-0/0/1"), "{rendered}");
+        assert!(rendered.contains("device: edge01"), "{rendered}");
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -18,6 +18,7 @@ pub mod interface_view;
 pub mod ip_range_view;
 pub mod ip_view;
 pub mod journal_view;
+pub mod mac_view;
 pub mod prefix_view;
 pub mod provider_view;
 pub mod rack_view;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod cli;
 pub mod config;
 pub mod domain;
 pub mod error;
+pub mod mac;
 pub mod mcp;
 pub mod netbox;
 pub mod output;
@@ -336,6 +337,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Some(Command::Cluster { value }) => run_cluster(&ctx, &value).await,
         Some(Command::Vrf { value }) => run_vrf(&ctx, &value).await,
         Some(Command::RouteTarget { value }) => run_route_target(&ctx, &value).await,
+        Some(Command::Mac { value }) => run_mac(&ctx, &value).await,
         Some(Command::Vlan {
             value,
             site,
@@ -1306,6 +1308,21 @@ async fn run_route_target(ctx: &Ctx, value: &str) -> Result<()> {
     emit(ctx, &detail, || println!("{}", detail.to_plain()))
 }
 
+/// `nbox mac <addr>` — reverse-resolve a MAC to its interface(s)/device(s).
+/// The input is normalized first (any common MAC form); a non-MAC is a usage
+/// error (exit 2), no match is not-found (4), and >1 interface carrying it is
+/// ambiguous (5) — MACs aren't enforced globally unique.
+async fn run_mac(ctx: &Ctx, value: &str) -> Result<()> {
+    let client = connect(ctx)?;
+    let mac = crate::mac::normalize(value).ok_or_else(|| {
+        error::NboxError::Usage(format!(
+            "invalid MAC address \"{value}\" — try aa:bb:cc:dd:ee:ff"
+        ))
+    })?;
+    let view = detail::mac_view_by_ref(&client, &mac, value, &not_found).await?;
+    emit(ctx, &view, || view.to_key_values().print())
+}
+
 /// `nbox open <kind/ref>` — resolve an object and open it in the browser.
 async fn run_open(ctx: &Ctx, object_ref: &str) -> Result<()> {
     let (kind, value) = parse_object_ref(object_ref)?;
@@ -1400,8 +1417,24 @@ pub(crate) async fn resolve_object_url(
                 .ok_or_else(|| not_found("device", device))?;
             client.device_interface(dev.id, name).await?.map(|i| i.url)
         }
+        "mac" => {
+            // Normalize first; a non-MAC is a usage error. Open the first match —
+            // if several interfaces carry it, the operator narrows from the
+            // ambiguous error `nbox mac` would raise on a direct lookup.
+            let mac = crate::mac::normalize(value).ok_or_else(|| {
+                error::NboxError::Usage(format!(
+                    "invalid MAC address \"{value}\" — try aa:bb:cc:dd:ee:ff"
+                ))
+            })?;
+            client
+                .mac_candidates(&mac)
+                .await?
+                .into_iter()
+                .next()
+                .map(|m| m.url)
+        }
         other => anyhow::bail!(
-            "unknown object kind \"{other}\" (expected: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, interface)"
+            "unknown object kind \"{other}\" (expected: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target, interface, mac)"
         ),
     };
     Ok(url)
@@ -1414,7 +1447,7 @@ fn parse_object_ref(s: &str) -> Result<(&str, &str)> {
         .filter(|(kind, value)| !kind.is_empty() && !value.is_empty())
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "object reference must be `<kind>/<ref>` (e.g. device/edge01)\n\nKinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target"
+                "object reference must be `<kind>/<ref>` (e.g. device/edge01)\n\nKinds: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target, mac"
             )
         })
 }
@@ -1519,8 +1552,20 @@ pub(crate) async fn resolve_content_type_id(
             .route_target_by_ref(value)
             .await?
             .map(|rt| ("ipam.routetarget", rt.id)),
+        "mac" => {
+            // Normalize first; a non-MAC is a usage error here too. MACs aren't
+            // journalable in NetBox, so this resolves the id only (for `nbox open`).
+            let mac = crate::mac::normalize(value)
+                .ok_or_else(|| anyhow::anyhow!("invalid MAC address \"{value}\""))?;
+            client
+                .mac_candidates(&mac)
+                .await?
+                .into_iter()
+                .next()
+                .map(|m| ("dcim.macaddress", m.id))
+        }
         other => anyhow::bail!(
-            "unknown object kind \"{other}\" (expected: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target)"
+            "unknown object kind \"{other}\" (expected: device, ip, prefix, vlan, site, rack, circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, cluster, vrf, route-target, mac)"
         ),
     };
     resolved.ok_or_else(|| not_found(kind, value))

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,0 +1,121 @@
+//! MAC address normalization for the `nbox mac` reverse-lookup.
+//!
+//! Operators paste MACs in every format — `aa:bb:cc:dd:ee:ff`,
+//! `AA:BB:CC:DD:EE:FF`, `aabb.ccdd.eeff` (Cisco), `aa-bb-cc-dd-ee-ff`,
+//! `aabbccddeeff` (bare), even with a trailing `/48`. NetBox stores and matches
+//! the canonical lowercase colon-separated form, so the input is normalized
+//! before it's sent as the `mac_address=` filter — a miss here means a
+//! reverse-lookup that *should* hit returns nothing.
+
+/// Normalize a MAC address to NetBox's canonical form: lowercase, colon-separated
+/// octets (`aa:bb:cc:dd:ee:ff`). Accepts the common separator forms (`:` `-` `.`),
+/// the bare 12-hex-digit form, and a trailing `/48` (the interface suffix some
+/// tools append). Returns `None` for anything that isn't exactly six octets of
+/// hex after stripping separators — the caller surfaces that as a usage error.
+///
+/// # Examples
+/// ```
+/// assert_eq!(nbox::mac::normalize("aa:bb:cc:dd:ee:ff"), Some("aa:bb:cc:dd:ee:ff".to_string()));
+/// assert_eq!(nbox::mac::normalize("AABB.CCDD.EEFF"), Some("aa:bb:cc:dd:ee:ff".to_string()));
+/// assert_eq!(nbox::mac::normalize("aa-bb-cc-dd-ee-ff/48"), Some("aa:bb:cc:dd:ee:ff".to_string()));
+/// assert_eq!(nbox::mac::normalize("aabbccddeeff"), Some("aa:bb:cc:dd:ee:ff".to_string()));
+/// assert_eq!(nbox::mac::normalize("not-a-mac"), None);
+/// ```
+#[must_use]
+pub fn normalize(input: &str) -> Option<String> {
+    // Strip a trailing interface-length suffix (`/48`) — some tools paste it.
+    let s = input.trim().trim_end_matches("/48");
+    // Keep only hex digits; any non-hex char is treated as a separator.
+    let hex: String = s
+        .chars()
+        .filter(char::is_ascii_hexdigit)
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+    // A MAC is exactly six octets (12 hex digits).
+    if hex.len() != 12 || hex.chars().any(|c| !c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let octets: Vec<&str> = (0..6).map(|i| &hex[i * 2..i * 2 + 2]).collect();
+    Some(octets.join(":"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_colon_separated() {
+        assert_eq!(
+            normalize("aa:bb:cc:dd:ee:ff"),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn lowercases_uppercase_hex() {
+        assert_eq!(
+            normalize("AA:BB:CC:DD:EE:FF"),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn normalizes_cisco_dotted_form() {
+        assert_eq!(
+            normalize("aabb.ccdd.eeff"),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn normalizes_dash_separated() {
+        assert_eq!(
+            normalize("aa-bb-cc-dd-ee-ff"),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn normalizes_bare_twelve_hex_digits() {
+        assert_eq!(
+            normalize("aabbccddeeff"),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn strips_a_trailing_interface_length_suffix() {
+        assert_eq!(
+            normalize("aa:bb:cc:dd:ee:ff/48"),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_a_non_mac() {
+        assert_eq!(normalize("not-a-mac"), None);
+    }
+
+    #[test]
+    fn rejects_too_few_digits() {
+        assert_eq!(normalize("aa:bb:cc:dd:ee"), None);
+    }
+
+    #[test]
+    fn rejects_too_many_digits() {
+        assert_eq!(normalize("aa:bb:cc:dd:ee:ff:00"), None);
+    }
+
+    #[test]
+    fn rejects_non_hex() {
+        assert_eq!(normalize("aa:bb:cc:dd:ee:gg"), None);
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        assert_eq!(
+            normalize("  aa:bb:cc:dd:ee:ff  "),
+            Some("aa:bb:cc:dd:ee:ff".to_string())
+        );
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -73,12 +73,17 @@ pub enum GetKind {
     Cluster,
     Vrf,
     RouteTarget,
+    /// A MAC address (NetBox 4.2+). Reverse-resolves a MAC to the interface(s)/
+    /// device(s) that carry it. The `ref` is the MAC string (any common form is
+    /// normalized); a non-MAC is `invalid_params`, >1 interface carrying it is
+    /// ambiguous.
+    Mac,
 }
 
 impl GetKind {
     /// Every kind, in the order the docs and `nbox://{kind}/{ref}` template list
     /// them — the same set `nbox_get` accepts.
-    const ALL: [GetKind; 17] = [
+    const ALL: [GetKind; 18] = [
         GetKind::Device,
         GetKind::Ip,
         GetKind::Prefix,
@@ -96,6 +101,7 @@ impl GetKind {
         GetKind::Cluster,
         GetKind::Vrf,
         GetKind::RouteTarget,
+        GetKind::Mac,
     ];
 
     /// The `snake_case` slug used in `nbox://{kind}/{ref}` URIs and the `kind`
@@ -119,6 +125,7 @@ impl GetKind {
             GetKind::Cluster => "cluster",
             GetKind::Vrf => "vrf",
             GetKind::RouteTarget => "route_target",
+            GetKind::Mac => "mac",
         }
     }
 
@@ -720,6 +727,14 @@ impl NboxMcp {
             GetKind::RouteTarget => {
                 serde_json::to_value(detail::route_target_detail_by_ref(c, r, &not_found).await?)?
             }
+            GetKind::Mac => {
+                let mac = crate::mac::normalize(r).ok_or_else(|| {
+                    NboxError::Usage(format!(
+                        "invalid MAC address \"{r}\" — try aa:bb:cc:dd:ee:ff"
+                    ))
+                })?;
+                serde_json::to_value(detail::mac_view_by_ref(c, &mac, r, &not_found).await?)?
+            }
         };
         Ok(Json(value))
     }
@@ -789,6 +804,7 @@ impl NboxMcp {
             GetKind::Cluster => "cluster",
             GetKind::Vrf => "vrf",
             GetKind::RouteTarget => "route-target",
+            GetKind::Mac => "mac",
         };
         crate::resolve_content_type_id(&self.client, cli_kind, value).await
     }

--- a/src/netbox/browse.rs
+++ b/src/netbox/browse.rs
@@ -66,6 +66,10 @@ pub fn browse_filter_field(kind: ObjectKind) -> Option<BrowseFilter> {
         ObjectKind::Aggregate | ObjectKind::Asn | ObjectKind::IpRange | ObjectKind::Interface => {
             None
         }
+        // MAC isn't substring-meaningful (you reverse-resolve by exact MAC), so
+        // there's no browse filter — not browsable. (Listed for exhaustiveness; a
+        // MAC is never a Nav-rail kind.)
+        ObjectKind::Mac => None,
     }
 }
 

--- a/src/netbox/endpoints.rs
+++ b/src/netbox/endpoints.rs
@@ -30,6 +30,7 @@ pub enum Endpoint {
     IpRanges,
     JournalEntries,
     Tags,
+    MacAddresses,
 }
 
 impl Endpoint {
@@ -63,6 +64,7 @@ impl Endpoint {
             Endpoint::IpRanges => "/api/ipam/ip-ranges/",
             Endpoint::JournalEntries => "/api/extras/journal-entries/",
             Endpoint::Tags => "/api/extras/tags/",
+            Endpoint::MacAddresses => "/api/dcim/mac-addresses/",
         }
     }
 

--- a/src/netbox/models/dcim.rs
+++ b/src/netbox/models/dcim.rs
@@ -187,6 +187,48 @@ pub struct Rack {
     pub custom_fields: serde_json::Value,
 }
 
+/// A MAC address (`/api/dcim/mac-addresses/`, NetBox 4.2+). Standalone objects
+/// since 4.2 — an interface or VM interface can carry several, with a primary
+/// designation. The reverse-resolve query (`nbox mac <addr>`) is a top
+/// operator/agent ask (which device owns this MAC?).
+///
+/// `assigned_object` is polymorphic: a `dcim.interface` (carries a `device`) or
+/// a `virtualization.vminterface` (carries a `virtual_machine`). It's left as
+/// raw JSON and labeled by the view layer (see `mac_view::assigned_label`),
+/// mirroring how `IpAddress` handles its `assigned_object`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MacAddress {
+    pub id: u64,
+    pub url: String,
+    /// NetBox's `display` (the MAC +, when assigned, the interface).
+    #[serde(default)]
+    pub display: Option<String>,
+    /// The MAC in NetBox's canonical form (e.g. `aa:bb:cc:dd:ee:ff`).
+    pub mac_address: String,
+    /// The dotted content type of the assigned object (`dcim.interface`,
+    /// `virtualization.vminterface`, …), or `None` for an unassigned MAC.
+    #[serde(default)]
+    pub assigned_object_type: Option<String>,
+    /// The id of the assigned object, or `None` for an unassigned MAC.
+    #[serde(default)]
+    pub assigned_object_id: Option<u64>,
+    /// The assigned interface/VM-interface brief (polymorphic; labeled in the
+    /// view). `None` when the MAC is unassigned.
+    #[serde(default)]
+    pub assigned_object: Option<serde_json::Value>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// The owner (a user/group, NetBox 4.5+); same shape as a brief object.
+    #[serde(default)]
+    pub owner: Option<BriefObject>,
+    #[serde(default)]
+    pub comments: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<Tag>,
+    #[serde(default)]
+    pub custom_fields: serde_json::Value,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/netbox/query.rs
+++ b/src/netbox/query.rs
@@ -8,7 +8,9 @@ use crate::error::NboxError;
 use crate::netbox::client::NetBoxClient;
 use crate::netbox::endpoints::Endpoint;
 use crate::netbox::models::circuits::{Circuit, Provider};
-use crate::netbox::models::dcim::{Device, Interface, Location, Rack, Region, Site, SiteGroup};
+use crate::netbox::models::dcim::{
+    Device, Interface, Location, MacAddress, Rack, Region, Site, SiteGroup,
+};
 use crate::netbox::models::extras::{JournalEntry, TagInfo};
 use crate::netbox::models::ipam::{
     Aggregate, Asn, AvailableIp, AvailablePrefix, IpAddress, IpRange, Prefix, RouteTarget, Service,
@@ -200,6 +202,21 @@ impl NetBoxClient {
             .list(
                 Endpoint::IpAddresses,
                 vec![("address", address.to_string())],
+            )
+            .await?;
+        Ok(page.results)
+    }
+
+    /// All MAC addresses matching `mac` (NetBox 4.2+). MACs aren't enforced
+    /// globally unique — the same MAC can appear on several interfaces — so this
+    /// returns the full candidate set; the resolver surfaces >1 as ambiguous
+    /// (exit 5) rather than silently picking one. `mac` should be normalized to
+    /// NetBox's canonical form first (see `normalize_mac`).
+    pub async fn mac_candidates(&self, mac: &str) -> Result<Vec<MacAddress>> {
+        let page: Page<MacAddress> = self
+            .list(
+                Endpoint::MacAddresses,
+                vec![("mac_address", mac.to_string())],
             )
             .await?;
         Ok(page.results)

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -60,6 +60,12 @@ pub enum ObjectKind {
     /// (its attributes + cable-path trace), addressed by numeric id. Kept last to
     /// preserve the existing variants' order.
     Interface,
+    /// A MAC address (NetBox 4.2+). A reverse-lookup kind, not a search/browse
+    /// kind: `nbox mac <addr>` resolves a MAC to the interface(s)/device(s)
+    /// that carry it (MACs aren't substring-meaningful, so there's no browse
+    /// filter and no search fan-out). Addressed by the MAC string. Kept last to
+    /// preserve the existing variants' order.
+    Mac,
 }
 
 impl ObjectKind {
@@ -84,6 +90,7 @@ impl ObjectKind {
             ObjectKind::Vrf => "vrf",
             ObjectKind::RouteTarget => "route-target",
             ObjectKind::Interface => "interface",
+            ObjectKind::Mac => "mac",
         }
     }
 
@@ -116,6 +123,8 @@ impl ObjectKind {
             // Not Nav-browsable (no global interface list) — opened only from a
             // device's interfaces/cables tabs; labelled for completeness.
             ObjectKind::Interface => "DEVICE",
+            // Not Nav-browsable — a reverse-lookup kind; labelled for completeness.
+            ObjectKind::Mac => "ASSIGNED",
         }
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -3991,6 +3991,7 @@ fn object_web_url(base_url: &str, kind: ObjectKind, id: u64) -> String {
         ObjectKind::Vrf => format!("ipam/vrfs/{id}/"),
         ObjectKind::RouteTarget => format!("ipam/route-targets/{id}/"),
         ObjectKind::Interface => format!("dcim/interfaces/{id}/"),
+        ObjectKind::Mac => format!("dcim/mac-addresses/{id}/"),
     };
 
     let mut base = base_url.to_string();

--- a/tests/error_contract_tests.rs
+++ b/tests/error_contract_tests.rs
@@ -137,3 +137,66 @@ async fn generic_api_error_exits_1_and_keeps_stdout_clean() {
 
     assert_error_contract(&output, 1, "NetBox API request failed");
 }
+
+/// Run `nbox mac <value>` against a mock NetBox at `config`.
+fn run_mac(config: &tempfile::NamedTempFile, value: &str) -> CommandOutput {
+    run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "mac".as_ref(),
+        value.as_ref(),
+    ])
+}
+
+#[tokio::test]
+async fn mac_invalid_input_exits_2_without_a_netbox_round_trip() {
+    // A non-MAC is a usage error (exit 2), normalized locally — no request is
+    // sent. (No mock is mounted, so a round trip would 404 and exit 1 here.)
+    let config = temp_config("http://unused.example/");
+    let output = run_mac(&config, "not-a-mac");
+    assert_error_contract(&output, 2, "invalid MAC address");
+}
+
+#[tokio::test]
+async fn mac_not_found_exits_4_and_keeps_stdout_clean() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/mac-addresses/"))
+        .and(query_param("mac_address", "aa:bb:cc:dd:ee:ff"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page(Vec::new())))
+        .mount(&server)
+        .await;
+
+    let config = temp_config(&server.uri());
+    // Any accepted form normalizes to the same canonical MAC before the request.
+    let output = run_mac(&config, "AABB.CCDD.EEFF");
+    assert_error_contract(&output, 4, "no MAC matched");
+}
+
+#[tokio::test]
+async fn mac_ambiguous_exits_5_and_lists_the_interfaces() {
+    // The same MAC on two interfaces → ambiguous (exit 5), naming both so the
+    // operator can disambiguate.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/mac-addresses/"))
+        .and(query_param("mac_address", "aa:bb:cc:dd:ee:ff"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(page(vec![
+            json!({"id": 7, "url": "u", "mac_address": "aa:bb:cc:dd:ee:ff",
+                  "assigned_object": {"display": "xe-0/0/1", "device": {"display": "edge01"}}}),
+            json!({"id": 8, "url": "u", "mac_address": "aa:bb:cc:dd:ee:ff",
+                  "assigned_object": {"display": "xe-0/0/2", "device": {"display": "edge01"}}}),
+        ])))
+        .mount(&server)
+        .await;
+
+    let config = temp_config(&server.uri());
+    let output = run_mac(&config, "aa:bb:cc:dd:ee:ff");
+    assert_error_contract(&output, 5, "MAC \"aa:bb:cc:dd:ee:ff\" is ambiguous");
+    assert!(
+        output.stderr.contains("edge01 xe-0/0/1") && output.stderr.contains("edge01 xe-0/0/2"),
+        "stderr should name the carrying interfaces: {:?}",
+        output.stderr
+    );
+}

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -1076,3 +1076,61 @@ async fn cluster_contains_with_multiple_matches_is_ambiguous() {
         "got: {msg}"
     );
 }
+
+#[tokio::test]
+async fn mac_candidates_uses_mac_address_filter() {
+    // The reverse-lookup filter is `mac_address=<canonical>`. The mock matches
+    // ONLY when that param is present, so an unfiltered request would get no reply.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/mac-addresses/"))
+        .and(query_param("mac_address", "aa:bb:cc:dd:ee:ff"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 7, "url": "http://nb/api/dcim/mac-addresses/7/",
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "assigned_object": {"display": "xe-0/0/1", "device": {"display": "edge01"}}
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let macs = client(&server)
+        .mac_candidates("aa:bb:cc:dd:ee:ff")
+        .await
+        .unwrap();
+    assert_eq!(macs.len(), 1);
+    assert_eq!(macs[0].mac_address, "aa:bb:cc:dd:ee:ff");
+}
+
+#[tokio::test]
+async fn mac_candidates_can_return_multiple_for_an_ambiguous_mac() {
+    // MACs aren't globally unique — the same MAC on two interfaces returns both,
+    // which the resolver surfaces as ambiguous (exit 5), not a silent first-pick.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/mac-addresses/"))
+        .and(query_param("mac_address", "aa:bb:cc:dd:ee:ff"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 2, "next": null, "previous": null,
+            "results": [
+                {"id": 7, "url": "u", "mac_address": "aa:bb:cc:dd:ee:ff",
+                 "assigned_object": {"display": "xe-0/0/1", "device": {"display": "edge01"}}},
+                {"id": 8, "url": "u", "mac_address": "aa:bb:cc:dd:ee:ff",
+                 "assigned_object": {"display": "xe-0/0/2", "device": {"display": "edge01"}}}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let macs = client(&server)
+        .mac_candidates("aa:bb:cc:dd:ee:ff")
+        .await
+        .unwrap();
+    assert_eq!(
+        macs.len(),
+        2,
+        "an ambiguous MAC returns every interface that carries it"
+    );
+}


### PR DESCRIPTION
The roadmap's "Highest value" NetBox-4.6-tracking item: a new read-only kind (NetBox 4.2+) that reverse-resolves a MAC address to the interface(s)/device(s) that carry it — a top operator/agent query nbox couldn't answer ("which device owns this MAC?").

`nbox mac <addr>` (and MCP `nbox_get` kind `mac` / `nbox://mac/<addr>`, `nbox open mac/<addr>`). The input is normalized first (any common form → canonical `aa:bb:cc:dd:ee:ff`); a non-MAC is a usage error (exit 2) with no NetBox round-trip. MACs aren't globally unique, so several carrying interfaces surface as ambiguous (exit 5) with the candidate list, not a silent first-pick.

## Scope decisions
1. **Lookup-only, not browse/search.** MACs aren't substring-meaningful, so there's no Nav-rail browse and no search fan-out. `browse_filter_field` returns `None` for Mac (inert; never a rail kind). This keeps the surface to the Asn/RouteTarget template — no CIDR/inet-style "no usable filter" trap to design around.
2. **MAC normalization is the headline UX.** Operators paste MACs in every format (`aa:bb:…`, `AABB.CCDD.EEFF` Cisco, `aa-bb-…`, bare `aabbccddeeff`, even `/48`). `mac::normalize` accepts all and canonicalizes before the `mac_address=` filter — a miss here means a reverse-lookup that *should* hit returns nothing. Heavily tested.
3. **Ambiguous → exit 5, not silent first-pick.** MACs aren't enforced globally unique; >1 carrying interface returns the candidate list (each labeled `aa:…:ff → edge01 xe-0/0/1`), reusing the shared `resolve_unique` path every other multi-match lookup takes.
4. **Polymorphic assignment rendered as `"<parent> <interface>"`.** A MAC's `assigned_object` is a `dcim.interface` (carries `device`) or a `virtualization.vminterface` (carries `virtual_machine`). The view's `assigned_label` mirrors `ip_view`'s but extends it for the VM parent — `edge01 xe-0/0/1` vs `web-01 eth0`. The owning `device` name is pulled straight from the brief, no second fetch.
5. **No journal.** MACs aren't journalable in NetBox, so no `--journal` flag — cleaner than the journal-bearing kinds.

## Surface
- CLI: `nbox mac <addr>` (+ `--json`/`--fields`/`--envelope`).
- MCP: `nbox_get` kind `mac` + `nbox://mac/<addr>` resource (the kind set, the get dispatch, the resource-template/cli-kind maps).
- `nbox open mac/<addr>` (open resolver + `resolve_content_type_id`).
- Man page gains `nbox-mac(1)`; completions gain `mac`.

## API shape (verified against the NetBox demo OpenAPI schema)
`MACAddress` model: id/url/display/mac_address/assigned_object_type/assigned_object_id/assigned_object/description/owner/comments/tags/custom_fields. `mac_address` supports exact + `__ic` filters; endpoint `/api/dcim/mac-addresses/`. The `assigned_object` is polymorphic (readOnly, nullable) — exactly what `assigned_label` handles.

## Tests (+21)
- `mac::normalize`: every form (colon/dash/dot/bare/uppercase/`/48`/whitespace) + rejection (non-mac, too few/many digits, non-hex).
- `MacView::from_model`: device-interface, VM-interface, and unassigned assignments; `assigned_label` fallback to bare name.
- `to_key_values` rendering.
- `mac_candidates` query wiremock (exact filter + ambiguous-returns-both).
- Three binary-level `nbox mac` error contracts: invalid→2 (no round-trip), not-found→4 (input form normalized before the request), ambiguous→5 (carrying interfaces named in stderr).

## Gate
`scripts/smoke.sh` green: fmt, both pedantic clippies, both test modes (845 lib / 753 no-default-features), all integration, `cargo audit`, build smoke, man-page + completion generation.

## Docs
CHANGELOG `[Unreleased]`; ROADMAP MAC ☐→☑ + "18 object types"→19; README/AGENTS/FEATURES/MCP kind lists + command list.

## Open question
NetBox supports `mac_address__ic` substring matching. This PR keeps MAC exact-match per the reverse-resolve framing; a substring form could land as a follow-up if there's a use case for it.
