### PR TITLE
fix(search): swallow 404 on version-gated endpoints (regression from #1)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,18 @@ pub fn is_broken_pipe(err: &anyhow::Error) -> bool {
     })
 }
 
+/// True if `err`'s chain contains a [`NboxError::NotFound`] — i.e. the request
+/// hit an HTTP 404. Used by version-gated search fan-out branches (kinds added
+/// in a later NetBox release, like rack-groups/vm-types in 4.6) to treat a
+/// missing endpoint as an empty result on older releases rather than fail the
+/// whole search. A 404 on a *list* endpoint means "this kind doesn't exist on
+/// this version" — never a per-object miss — so swallowing it is safe there.
+pub fn is_not_found(err: &anyhow::Error) -> bool {
+    err.chain()
+        .find_map(|e| e.downcast_ref::<NboxError>())
+        .is_some_and(|ne| matches!(ne, NboxError::NotFound(_)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -1141,8 +1141,16 @@ impl NetBoxClient {
         let Some(params) = endpoint_params(q, f, &["tenant", "tag", "owner", "owner_group"]) else {
             return Ok(Vec::new());
         };
+        // `virtual-machine-types/` is a NetBox 4.6+ endpoint. On an older
+        // release it 404s — treat that as "this kind isn't available here" and
+        // return empty, so the search fan-out stays green on 4.2–4.5 instead
+        // of failing closed on a version-gated endpoint miss.
         let page: Page<VirtualMachineType> =
-            self.list(Endpoint::VirtualMachineTypes, params).await?;
+            match self.list(Endpoint::VirtualMachineTypes, params).await {
+                Ok(page) => page,
+                Err(e) if crate::error::is_not_found(&e) => return Ok(Vec::new()),
+                Err(e) => return Err(e),
+            };
         Ok(page
             .results
             .into_iter()
@@ -1268,7 +1276,15 @@ impl NetBoxClient {
         let Some(params) = endpoint_params(q, f, &["tenant", "tag", "owner", "owner_group"]) else {
             return Ok(Vec::new());
         };
-        let page: Page<RackGroup> = self.list(Endpoint::RackGroups, params).await?;
+        // `rack-groups/` is a NetBox 4.6+ endpoint; on an older release it 404s.
+        // Swallow that as an empty result so the search fan-out stays green on
+        // 4.2–4.5 (the kind is simply absent), rather than fail closed on a
+        // version-gated endpoint miss.
+        let page: Page<RackGroup> = match self.list(Endpoint::RackGroups, params).await {
+            Ok(page) => page,
+            Err(e) if crate::error::is_not_found(&e) => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
         Ok(page
             .results
             .into_iter()

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -1863,3 +1863,79 @@ async fn search_with_region_filters_devices_by_region_id() {
         .expect("region-scoped device filtered by region_id");
     assert_eq!(device.display, "edge01");
 }
+
+/// Regression: the 4.6 kinds (`vm-types`, `rack-groups`) are version-gated search
+/// fan-out branches. On a pre-4.6 NetBox those endpoints 404 — the branches must
+/// swallow the 404 and return empty, NOT fail the whole search closed. Before the
+/// fix, a 404 on either branch made every `nbox search` exit 1 with "search
+/// incomplete", breaking search entirely on 4.2–4.5.
+#[tokio::test]
+async fn search_swallows_404_on_version_gated_endpoints() {
+    let server = MockServer::start().await;
+
+    // The device hit is what we assert survives; everything else is empty.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 1, "url": "http://nb/api/dcim/devices/1/", "name": "edge01"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    // The always-present endpoints: empty pages keep the fan-out clean.
+    for ep in [
+        "/api/dcim/sites/",
+        "/api/ipam/ip-addresses/",
+        "/api/ipam/prefixes/",
+        "/api/ipam/vlans/",
+        "/api/circuits/circuits/",
+        "/api/circuits/virtual-circuits/",
+        "/api/ipam/aggregates/",
+        "/api/ipam/asns/",
+        "/api/ipam/ip-ranges/",
+        "/api/tenancy/tenants/",
+        "/api/tenancy/contacts/",
+        "/api/circuits/providers/",
+        "/api/virtualization/virtual-machines/",
+        "/api/virtualization/clusters/",
+        "/api/dcim/racks/",
+        "/api/ipam/vrfs/",
+        "/api/ipam/route-targets/",
+    ] {
+        mount_empty(&server, ep).await;
+    }
+
+    // The 4.6-only endpoints return 404 — the NetBox 4.2 reality.
+    for ep in [
+        "/api/virtualization/virtual-machine-types/",
+        "/api/dcim/rack-groups/",
+    ] {
+        Mock::given(method("GET"))
+            .and(path(ep))
+            .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+            .mount(&server)
+            .await;
+    }
+
+    let outcome = client(&server)
+        .search(SearchRequest {
+            query: "edge01".into(),
+            limit: 25,
+            filters: SearchFilters::default(),
+        })
+        .await
+        .expect("search must not fail closed when a version-gated endpoint 404s");
+
+    // No errors surfaced: the 404s are absorbed, not reported as partial failures.
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    // The device hit still comes through — search is fully usable on 4.2.
+    let device = outcome
+        .results
+        .iter()
+        .find(|r| r.kind == ObjectKind::Device)
+        .expect("device hit survives the 404s on version-gated branches");
+    assert_eq!(device.display, "edge01");
+}


### PR DESCRIPTION
## Problem

PR #1 (kinds+owner) added `rack-group` and `vm-type` to the `nbox search` fan-out. Those endpoints (`/api/dcim/rack-groups/`, `/api/virtualization/virtual-machine-types/`) only exist on **NetBox 4.6+**. On a pre-4.6 NetBox they 404 — and search is **fail-closed**, so a 404 on either branch failed the *whole* search (exit 1, `"search incomplete"`).

This broke `nbox search` entirely on the 4.2 integration fixture:
```
test search_finds_seeded_device ... FAILED
search branch 'vm-types' failed: not found (HTTP 404)
search branch 'rack-groups' failed: not found (HTTP 404)
error: search incomplete — 2 endpoint(s) failed
```

## Fix

The two **version-gated** search branches swallow a 404 (`NboxError::NotFound`) and return an empty result, so the fan-out stays green on 4.2–4.5: the kinds are simply absent, not a hard failure.

- The **always-present** endpoints keep fail-closed — a 404 there is genuinely unexpected and worth surfacing.
- **Detail lookups** and **browse** for the new kinds already 404 → exit 4 (documented "kind doesn't exist on this version"), so only the fan-out needed this.

## Test

Adds `crate::error::is_not_found` (mirrors `is_broken_pipe`) and a wiremock regression test (`search_swallows_404_on_version_gated_endpoints`) that mounts 404s on the two endpoints and asserts the device hit still comes through with no errors. **Verified the test fails without the fix and passes with it.**

## Gate

`cargo fmt` · `cargo clippy --all-targets --all-features -D warnings` · `cargo test --all-features` — all green (1100 tests).

This is a hotfix for the master regression; (c) schema-canary + (d) install-recipes continue on a separate PR.