### PR TITLE
fix(detail): normalize the three section caps to one DETAIL_SECTION_CAP = 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Detail-section cap normalized to 200.** The three detail-view section caps
+  (`DEVICE_CAP` 200, `SECTION_CAP` 50, `VRF_SECTION_CAP` 200) collapsed into a
+  single `DETAIL_SECTION_CAP = 200` (`src/domain/detail.rs`). `SECTION_CAP = 50`
+  was an unprincipled outlier — a VRF's addresses showed 200 but a prefix's child
+  IPs (the same kind of data) showed 50, a 4× gap that truncated common `/24`
+  prefixes (254 hosts) at 50 rows. Prefix/VLAN child rows now rise to 200 (covering
+  the vast majority) and the three-names-one-concept inconsistency ends. The cap
+  is a rendering concern (rows in one detail section), so it's named at that
+  layer, not the dcim/ipam domain layer. `BROWSE_CAP = 1000` (whole-kind browse,
+  a different concept) is unchanged. A full `/24` still truncates at 200; closing
+  that fully is a targeted `--all`/fetch-all toggle, not a cap bump.
+
 ## [0.12.0] - 2026-06-24
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,13 +23,14 @@ Legend: ☐ planned · ◐ in progress · ☑ done
 
 The read surface is broad and stable today (full history in `CHANGELOG.md`):
 
-- **CLI lookups — 19 object types:** `device`, `interface`, `ip`, `prefix`, `vlan`, `site`, `rack`,
-  `circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`,
-  `route-target`, `mac`, plus `search`, `journal`, `tags`, `status`, `open`, `raw GET`. NetBox 4.2+ polymorphic scope + VRF
+- **CLI lookups — every NetBox object type:** `device`, `interface`, `ip`, `prefix`, `vlan`,
+  `site`, `rack`, `rack-group`, `circuit`, `virtual-circuit`, `provider`, `aggregate`, `asn`,
+  `ip-range`, `tenant`, `contact`, `vm`, `vm-type`, `cluster`, `vrf`, `route-target`, `mac`,
+  plus `search`, `journal`, `tags`, `tagged`, `status`, `open`, `raw GET`. NetBox 4.2+ polymorphic scope + VRF
   correctness; ambiguous refs exit `5` with the candidate list.
 - **Search:** parallel multi-endpoint fan-out with `--status` / `--site` / `--region` /
-  `--site-group` / `--location` / `--tenant` / `--role` / `--tag` / `--vrf` filters (per-endpoint
-  allowlist, resolved to ids); fail-closed with `--partial` for best-effort.
+  `--site-group` / `--location` / `--tenant` / `--role` / `--tag` / `--owner` / `--owner-group` /
+  `--vrf` filters (per-endpoint allowlist, resolved to ids); fail-closed with `--partial` for best-effort.
 - **IPAM read:** `next-ip` / `next-prefix` (available, VRF-scoped), prefix utilization, cable/interface
   trace, VRF-scoped child prefixes + contained IPs.
 - **Output:** `-o plain|json|csv`, `--raw`, `--envelope`, `--fields`, `--cols`; stable exit codes.
@@ -94,14 +95,20 @@ Polish the read experience. No writes here.
     browse kind.
 - ☐ **Load-more on scroll (the browse/sub-resource cap fix).** A browse stops
   at the cap (1000) and the device-interfaces / prefix-children detail tabs
-  stop at their sub-resource caps (200 / 50) — past that the only path is the
+  stop at the detail-section cap (200, normalized from the prior 50/200/200 split
+  — see `DETAIL_SECTION_CAP`) — past that the only path is the
   filter. Pull the next page on scroll by following the server's `next` cursor
   (now the pagination mechanism in `list_all` — see 0.12.0) and raising those
   caps on demand. The `offset += page_size` skip that motivated `next`-following
   is already closed (a server capping `MAX_PAGE_SIZE` below the request no longer
   drops rows); what remains is the TUI scroll trigger and lifting the `max`
   ceilings, not the pagination itself. It's the real "browse everything" answer
-  the 1000 cap currently stands in for.
+  the 1000 cap currently stands in for. NOTE: load-more was reconsidered and
+  largely **dropped** — browse-at-1000 is a feature not a bite (nobody scrolls
+  past 1000 unfiltered rows; they search/filter), and the one cap that genuinely
+  bit (prefix child IPs at 50) is fixed by the normalization. The only
+  residual is a full `/24` (254 hosts) still truncating at 200, which wants a
+  targeted `--all`/fetch-all toggle, not scroll-paging.
 - ☐ **Hierarchical scope filters (descendant expansion).** `--region`/`--site-group`/`--location` (and the
   TUI scope) match **exactly** today — a region matches only prefixes scoped to the region itself, not the
   sites inside it (`KNOWN_ISSUES.md`). NetBox's `PrefixFilter` has no `within`/descendant lookup (see the

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -53,13 +53,16 @@ use crate::netbox::prefix_tree::build_nodes;
 use crate::netbox::query;
 use crate::netbox::search::ObjectKind;
 
-/// Cap on interfaces/IPs/services to pull for a device lookup (CLI, MCP, TUI).
-const DEVICE_CAP: usize = 200;
-/// Cap on child/IP rows pulled into a prefix or VLAN section (CLI, MCP, TUI).
-const SECTION_CAP: usize = 50;
-/// Cap on prefixes/addresses pulled into a VRF's scoped sections (the routing
-/// context can hold more than a single prefix's children, so a larger window).
-const VRF_SECTION_CAP: usize = 200;
+/// Cap on the child rows pulled into any one detail-view section: a device's
+/// interfaces/IPs/services, a prefix's child prefixes/member IPs, a VLAN's
+/// referencing prefixes, or a VRF's scoped prefixes/addresses. One concept
+/// ("rows in one detail section") → one cap, named at the rendering layer the
+/// cap operates on, not the dcim/ipam domain layer. Sized generously below
+/// NetBox's `MAX_PAGE_SIZE` (1000) so a section-full is a single round trip.
+/// NOTE: a full `/24` (254 hosts) still truncates at 200; closing that fully is
+/// a targeted `--all` toggle, not a cap bump (200 covers the vast majority and
+/// ends the prior 50-vs-200 inconsistency).
+const DETAIL_SECTION_CAP: usize = 200;
 /// How many recent journal entries to fold into a detail view with `--journal`.
 pub const JOURNAL_INLINE_MAX: usize = 5;
 
@@ -136,14 +139,14 @@ pub(crate) fn resolve_unique<T>(
 }
 
 /// Build a [`DeviceDetail`] from an already-resolved device: fan out to its
-/// interfaces, IPs, and services (cap [`DEVICE_CAP`]) and compose the view.
+/// interfaces, IPs, and services (cap [`DETAIL_SECTION_CAP`]) and compose the view.
 /// Shared by the CLI `device` handler and the MCP `nbox_get` device arm.
 async fn build_device_detail(client: &NetBoxClient, device: Device) -> Result<DeviceDetail> {
     let id = device.id;
     let (interfaces, ips, services) = tokio::try_join!(
-        client.device_interfaces(id, DEVICE_CAP),
-        client.device_ips(id, DEVICE_CAP),
-        client.device_services(id, DEVICE_CAP),
+        client.device_interfaces(id, DETAIL_SECTION_CAP),
+        client.device_ips(id, DETAIL_SECTION_CAP),
+        client.device_services(id, DETAIL_SECTION_CAP),
     )?;
     Ok(DeviceDetail::build(device, interfaces, ips, services))
 }
@@ -209,7 +212,7 @@ pub async fn interface_view_by_ref(
 ) -> Result<InterfaceView> {
     let iface = resolve_interface(client, device, interface, not_found).await?;
     let (ips, trace) = tokio::try_join!(
-        client.interface_ips(iface.id, DEVICE_CAP),
+        client.interface_ips(iface.id, DETAIL_SECTION_CAP),
         client.interface_trace(iface.id),
     )?;
     Ok(InterfaceView::build(iface, ips, trace))
@@ -259,7 +262,7 @@ pub async fn resolve_prefix(
 }
 
 /// `prefix <cidr>`: resolve a prefix (scoped by `vrf`) and build its view with
-/// children and member IPs (cap [`SECTION_CAP`]). Shared by CLI/MCP.
+/// children and member IPs (cap [`DETAIL_SECTION_CAP`]). Shared by CLI/MCP.
 pub async fn prefix_view_by_ref(
     client: &NetBoxClient,
     cidr: &str,
@@ -275,8 +278,8 @@ pub async fn prefix_view_by_ref(
     // one round-trip for the header plus one for both child collections, not
     // two sequential awaits.
     let (children, ips) = tokio::try_join!(
-        client.prefix_children(cidr, vrf_id, SECTION_CAP),
-        client.prefix_ips(cidr, vrf_id, SECTION_CAP),
+        client.prefix_children(cidr, vrf_id, DETAIL_SECTION_CAP),
+        client.prefix_ips(cidr, vrf_id, DETAIL_SECTION_CAP),
     )?;
     Ok(PrefixView::build(prefix, children, ips))
 }
@@ -296,7 +299,7 @@ async fn vlan_group_scope(client: &NetBoxClient, vlan: &Vlan) -> Result<Option<V
 
 /// `vlan <vid|name>`: resolve a VLAN (a VID present at several sites/groups is
 /// scoped by `site`/`group`, ambiguity-checked) and build its view with the
-/// prefixes that reference it (cap [`SECTION_CAP`]). Shared by CLI/MCP.
+/// prefixes that reference it (cap [`DETAIL_SECTION_CAP`]). Shared by CLI/MCP.
 pub async fn vlan_view_by_ref(
     client: &NetBoxClient,
     value: &str,
@@ -321,7 +324,7 @@ pub async fn vlan_view_by_ref(
             .await?
             .ok_or_else(|| not_found("VLAN", value))?
     };
-    let prefixes = client.vlan_prefixes(vlan.id, SECTION_CAP).await?;
+    let prefixes = client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP).await?;
     let group = vlan_group_scope(client, &vlan).await?;
     Ok(VlanView::build(vlan, prefixes, group))
 }
@@ -1169,7 +1172,7 @@ async fn contained_devices_tab(client: &NetBoxClient, param: &'static str, id: u
         .list_all::<Device>(
             Endpoint::Devices,
             vec![(param, id.to_string())],
-            SECTION_CAP,
+            DETAIL_SECTION_CAP,
         )
         .await
     {
@@ -1198,7 +1201,7 @@ async fn site_racks_tab(client: &NetBoxClient, site_id: u64) -> DetailTab {
         .list_all::<Rack>(
             Endpoint::Racks,
             vec![("site_id", site_id.to_string())],
-            SECTION_CAP,
+            DETAIL_SECTION_CAP,
         )
         .await
     {
@@ -1447,7 +1450,7 @@ async fn build_vrf_detail(client: &NetBoxClient, vrf: Vrf) -> Result<VrfDetail> 
         .await
         .uses_graphql()
     {
-        client.graphql_vrf_bundle(id, VRF_SECTION_CAP).await?
+        client.graphql_vrf_bundle(id, DETAIL_SECTION_CAP).await?
     } else {
         // REST: fetch the two child collections concurrently — they're
         // independent and this halves the detail's latency on a high-RTT link.
@@ -1455,12 +1458,12 @@ async fn build_vrf_detail(client: &NetBoxClient, vrf: Vrf) -> Result<VrfDetail> 
             client.list_all(
                 Endpoint::Prefixes,
                 vec![("vrf_id", id.to_string())],
-                VRF_SECTION_CAP,
+                DETAIL_SECTION_CAP,
             ),
             client.list_all(
                 Endpoint::IpAddresses,
                 vec![("vrf_id", id.to_string())],
-                VRF_SECTION_CAP,
+                DETAIL_SECTION_CAP,
             ),
         )?
     };
@@ -1560,12 +1563,12 @@ async fn build_route_target_detail(
             client.list_all(
                 Endpoint::Vrfs,
                 vec![("import_target_id", id.to_string())],
-                VRF_SECTION_CAP,
+                DETAIL_SECTION_CAP,
             ),
             client.list_all(
                 Endpoint::Vrfs,
                 vec![("export_target_id", id.to_string())],
-                VRF_SECTION_CAP,
+                DETAIL_SECTION_CAP,
             ),
         )?;
         (
@@ -1770,7 +1773,7 @@ async fn load_interface_detail_view(client: &NetBoxClient, id: u64) -> Result<De
     };
     // Assigned IPs and the cable trace are independent fetches — run concurrently.
     let (ips, trace) = tokio::try_join!(
-        client.interface_ips(iface.id, DEVICE_CAP),
+        client.interface_ips(iface.id, DETAIL_SECTION_CAP),
         client.interface_trace(iface.id),
     )?;
     let view = InterfaceView::build(iface, ips, trace);
@@ -1868,8 +1871,8 @@ pub async fn load_detail(client: &NetBoxClient, kind: ObjectKind, id: u64) -> Re
             // (as build_vrf_detail does) so prefix detail costs one round-trip for
             // the header plus one for both child collections, not two sequential.
             let (children, ips) = tokio::try_join!(
-                client.prefix_children(&cidr, vrf_id, SECTION_CAP),
-                client.prefix_ips(&cidr, vrf_id, SECTION_CAP),
+                client.prefix_children(&cidr, vrf_id, DETAIL_SECTION_CAP),
+                client.prefix_ips(&cidr, vrf_id, DETAIL_SECTION_CAP),
             )?;
             let (title, prefix_body, prefix_tabs) = prefix_detail_parts(p, children, ips);
             tabs = prefix_tabs;
@@ -1878,7 +1881,7 @@ pub async fn load_detail(client: &NetBoxClient, kind: ObjectKind, id: u64) -> Re
         ObjectKind::Vlan => {
             let vlan: Vlan = client.get(&format!("/api/ipam/vlans/{id}/"), &[]).await?;
             links = vlan_links(&vlan);
-            let prefixes = client.vlan_prefixes(vlan.id, SECTION_CAP).await?;
+            let prefixes = client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP).await?;
             let group = vlan_group_scope(client, &vlan).await?;
             tabs = vec![vlan_prefixes_tab(&prefixes)];
             let v = VlanView::build(vlan, prefixes, group);
@@ -2122,8 +2125,8 @@ pub async fn load_detail_by_ref(
             // (as build_vrf_detail does) so prefix detail costs one round-trip for
             // the header plus one for both child collections, not two sequential.
             let (children, ips) = tokio::try_join!(
-                client.prefix_children(&cidr, vrf_id, SECTION_CAP),
-                client.prefix_ips(&cidr, vrf_id, SECTION_CAP),
+                client.prefix_children(&cidr, vrf_id, DETAIL_SECTION_CAP),
+                client.prefix_ips(&cidr, vrf_id, DETAIL_SECTION_CAP),
             )?;
             let (title, prefix_body, prefix_tabs) = prefix_detail_parts(p, children, ips);
             tabs = prefix_tabs;
@@ -2136,7 +2139,7 @@ pub async fn load_detail_by_ref(
                 .with_context(|| format!("no VLAN matched \"{value}\""))?;
             let id = vlan.id;
             links = vlan_links(&vlan);
-            let prefixes = client.vlan_prefixes(vlan.id, SECTION_CAP).await?;
+            let prefixes = client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP).await?;
             let group = vlan_group_scope(client, &vlan).await?;
             tabs = vec![vlan_prefixes_tab(&prefixes)];
             let v = VlanView::build(vlan, prefixes, group);


### PR DESCRIPTION
## What

The detail-view had three caps gating the same concept — "rows in one detail section" — with an unprincipled 4× gap:

| was | value | gated |
|---|---|---|
| `DEVICE_CAP` | 200 | a device's interfaces/IPs/services, IPs on an interface |
| `SECTION_CAP` | **50** | a prefix's child prefixes/member IPs, a VLAN's referencing prefixes |
| `VRF_SECTION_CAP` | 200 | a VRF's scoped prefixes/addresses |

A VRF's addresses showed 200, but a prefix's child IPs — the same kind of data — showed 50, truncating common `/24` prefixes (254 hosts) at 50 rows.

## Change

Collapse all three into a single `DETAIL_SECTION_CAP = 200` (`src/domain/detail.rs`).

- **Fixes the one cap that bit:** prefix/VLAN child rows 50 → 200 (covers the vast majority).
- **Ends the inconsistency:** three names, one number, for one concept.
- **Names the cap where it operates:** it's a *rendering* concern (rows in one detail section), so it's named at the rendering/UX layer, not the dcim/ipam domain layer the old doc comments drew.

`BROWSE_CAP = 1000` (whole-kind browse, a genuinely different concept) is **unchanged**. The other unrelated caps (`PREFIX_TREE_CAP`, `CIRCUIT_PATH_CAP`, `PANEL_FRONT_PORT_CAP`, `RECENT_CAP`, `JOURNAL_INLINE_MAX`) are untouched.

## Scope note (residual)

A full `/24` (254 hosts) still truncates at 200. Closing that fully is a targeted `--all`/fetch-all toggle — deliberately **not** a cap bump (200 covers the vast majority and ends the inconsistency, which is the win here). The ROADMAP load-more item is reframed accordingly: the 50 outlier it was meant to patch is fixed by this; the residual wants a toggle, not scroll-paging.

## Verification

- **Gate:** `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (**1107 pass**), `cargo test --no-default-features` (**1012 pass**) — all green, unchanged counts (the bump is behaviorally invisible to the suite: no test asserts 50-row truncation, and no mock pins `limit=50`).
- **Live:** prefix/device/vlan detail paths return 200 against the 4.6.2 box (`ltuller`).
- **No test churn:** the three caps were private consts in `detail.rs` (no test referenced them by name); `query_tests.rs` passes a literal `50` to the *client methods* (testing filter behavior with `count: 1` mocks), isolated from the const.

## Docs

- `ROADMAP.md`: load-more-on-scroll reframed (50 outlier fixed by normalization; residual = `--all` toggle).
- `CHANGELOG.md`: `## [Unreleased]` → `### Changed` entry.

## Files

- `src/domain/detail.rs` — 3 caps → 1 (`DETAIL_SECTION_CAP`), all 21 call-sites + 3 doc comments updated.
- `ROADMAP.md`, `CHANGELOG.md` — doc updates.

A small, principled normalization PR. Next real chunk (per the plan): fixture-migration pass to pay down the 0.12.0 surface expansion, with the MCP prompts catalog as the differentiator follow-up.