### PR TITLE
fix(browse): revert BROWSE_CAP 1000 → 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   layer, not the dcim/ipam domain layer. `BROWSE_CAP = 1000` (whole-kind browse,
   a different concept) is unchanged. A full `/24` still truncates at 200; closing
   that fully is a targeted `--all`/fetch-all toggle, not a cap bump.
+- **Browse cap reverted 1000 → 500.** A Nav-rail browse now pulls up to 500 rows
+  (0.11.0 raised it to 1000; reverted). 500 is still a single round trip (it's
+  below NetBox's per-request `MAX_PAGE_SIZE` ceiling of 1000), so the network
+  cost is identical — but the rows past a few hundred are essentially never
+  scrolled to (at that scale the filter narrows, not the cap), and 1000 doubled
+  the TUI's idle render work: the list `Vec<Row>` is rebuilt on every draw
+  (~5.5 Hz while the 180ms `PreviewTick` fires; see the ROADMAP `TUI render
+  dirty-flag` item) for rows no one reads. The filter is the escape hatch, not
+  a bigger cap. The list-count badge reads `500+` when capped. (The dirty-flag
+  fix would eliminate idle rebuilds for *all* list sizes — a separate, scheduled
+  win; it doesn't change that 500 is the right cap either way, since every
+  *change* still rebuilds the full list and 1000 stays 2× the cost at those
+  moments.)
 
 ## [0.12.0] - 2026-06-24
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -683,11 +683,11 @@ A batch of proposed perf wins, each verified against the code. Net: one quick wi
   filters need the resolved ids (`site_id`/`vrf_id`/scope content-type), so it can't start blind; a
   cancellation token doesn't help when the input is the missing value.
 - ☐ **TUI render dirty-flag (idle-CPU win, medium).** The event loop `terminal.draw`s on every event, and
-  the 180ms `PreviewTick` always arrives → a full widget rebuild ≥5.5 Hz even when idle (1000-row `Vec<Row>`
-  clones + `format!`). ratatui diffs the *buffer* (I/O minimal) but not the Rust-side rebuild. A render-dirty
-  flag would skip the redraw when nothing changed — a battery/SSH win, not latency. CARE: the tick also
-  advances the spinner, status-TTL expiry, and the browse/preview debounce flush, so the flag must key on
-  *state mutation* (and still mark dirty on spinner ticks, status changes, async results) — not on "no
+  the 180ms `PreviewTick` always arrives → a full widget rebuild ≥5.5 Hz even when idle (a cap-full `Vec<Row>`
+  clones + `format!`; 500 rows post-revert, was 1000). ratatui diffs the *buffer* (I/O minimal) but not the
+  Rust-side rebuild. A render-dirty flag would skip the redraw when nothing changed — a battery/SSH win, not
+  latency. CARE: the tick also advances the spinner, status-TTL expiry, and the browse/preview debounce flush,
+  so the flag must key on *state mutation* (and still mark dirty on spinner ticks, status changes, async results) — not on "no
   keypress," or it freezes the spinner / stalls TTL.
 - ☐ **HTTP/2 multiplexing — probe DONE (2026-06-21), promising; implement+verify next.** reqwest's `http2`
   feature is **off** (the `h2` in the lockfile is axum's MCP server, not the outbound client), so the client

--- a/src/netbox/browse.rs
+++ b/src/netbox/browse.rs
@@ -19,10 +19,16 @@ use crate::util::format::api_to_web_url;
 
 /// Upper bound on rows pulled for a single browse (keeps a large instance from
 /// dragging the whole table into memory; search is the tool for finding a needle).
-/// Sized to NetBox's per-request `MAX_PAGE_SIZE` ceiling (1000) so a cap-full
-/// browse lands in a single round trip — go higher and `list_all` pages a second
-/// request for the remainder.
-pub const BROWSE_CAP: usize = 1000;
+///
+/// Deliberately 500, not the `MAX_PAGE_SIZE` ceiling (1000): a cap-full list is
+/// still a single round trip (500 ≤ 1000), and the rows past a few hundred are
+/// essentially never scrolled to — at that scale the filter narrows, not the cap.
+/// The larger cap also doubles the TUI's idle render work (the list `Vec<Row>` is
+/// rebuilt on every draw, ~5.5 Hz while the 180ms `PreviewTick` is firing; see
+/// the ROADMAP `TUI render dirty-flag` item), for rows no one reads. The filter
+/// is the escape hatch, not a bigger cap. (0.11.0 briefly raised this 500 → 1000;
+/// reverted because the network-only "free" claim ignored the render side.)
+pub const BROWSE_CAP: usize = 500;
 
 /// The server-side filter a browse `filter` maps to for `kind`. Two shapes, both
 /// applied server-side so a browse narrows without pulling the whole table:


### PR DESCRIPTION
## What

Reverts the Nav-rail browse cap from 1000 back to 500 (0.11.0 raised it 500 → 1000).

## Why

The 0.11.0 bump's rationale was network-only: "1000 = NetBox's per-request `MAX_PAGE_SIZE` ceiling, so a cap-full browse is still one round trip." Correct, but one-sided — it ignored the render side:

- The TUI event loop calls `terminal.draw` at the top of every iteration; the 180ms `PreviewTick` is always arriving → `render` fires ~5.5 Hz **while idle**.
- `render_home_list` builds the full `Vec<Row>` via `.map(...).collect()` over the whole list up to the cap on **every draw** (not cached, not windowed).
- At 1000 that's 2× the 500 cost, always-on, for rows **no one reads** — past a few hundred, the filter narrows, not the cap.

500 is still a single round trip (500 ≤ `MAX_PAGE_SIZE` 1000), so the network cost is identical. The cap encodes the principle durably — **the filter is the escape hatch, not a bigger cap** — so it doesn't drift back up.

## Independent of the dirty-flag decision

The ROADMAP's `TUI render dirty-flag` fix would eliminate idle rebuilds for *all* list sizes — but it does **not** argue for keeping 1000. Every *actual change* (keypress, result arrival) still rebuilds the full list, and at 1000 that's 2× the 500 cost at those moments. So 500 is the right cap **regardless**; the dirty-flag is a separate, scheduled, additive win (ROADMAP: medium, battery/SSH not latency).

## Change

One-line const: `pub const BROWSE_CAP: usize = 1000` → `500`, with an expanded rationale comment. Downstream auto-adapts:
- The `1000+`/`500+` truncation cue reads the const (`ui.rs` `if n >= BROWSE_CAP { format!("{}+", BROWSE_CAP) }`) → badge now reads `500+`.
- `cap_sized_browse_is_one_round_trip` reads the const (`let n = BROWSE_CAP`) → now mocks `limit=500`, passes unchanged.

## Verification

- **Gate:** `fmt --check`, `clippy --all-targets --all-features -- -D warnings`, `test --all-features` (**1107 pass**), `test --no-default-features` (**1012 pass**) — all green, counts unchanged.
- **Targeted:** `cap_sized_browse_is_one_round_trip` adapted and passed.
- **Live:** search/browse paths return 200 against the 4.6.2 box.
- The literal-`1000` pagination tests call `list_all(.., 1000)` directly (testing the paging mechanism with an arbitrary `max`), not `browse`/`BROWSE_CAP` — untouched.

## Docs

- `CHANGELOG.md` `[Unreleased]` → `### Changed` entry (revert + rationale + dirty-flag independence note).
- `ROADMAP.md` perf-candidates section: `1000-row Vec<Row>` → `500 rows post-revert, was 1000`.
- The 0.11.0 release line is left immutable (historical fact; the revert is documented in `[Unreleased]`).

## Files

- `src/netbox/browse.rs` — const 1000 → 500 + rationale comment.
- `CHANGELOG.md`, `ROADMAP.md` — doc updates.