### PR TITLE
feat(history): object change history (audit log) — CLI + MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ nbox tagged <tag>               # objects carrying a tag, across kinds (NetBox 4
 nbox journal <kind> <ref>         # kinds: device, ip, prefix, vlan, site, rack, rack-group, circuit,
                                   # virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider, vm,
                                   # vm-type, cluster, vrf, route-target, mac, interface (<device>/<name>)
+nbox history <kind> <ref>         # system audit log (create/update/delete, who + when) for an object —
+                                  # `/api/core/object-changes/` (NetBox 4.x); distinct from `journal`
+                                  # (operator notes). Same kind set as `journal`.
 nbox open <kind>/<ref>
 nbox raw GET <api-path>          # path with or without /api/, e.g. dcim/devices/?limit=1
 nbox status                       # NetBox/Django/Python versions, api routing,
@@ -98,6 +101,7 @@ placeholder token) and exits — no server start, no NetBox connection.
 | `nbox_next_ip` | Next available address(es) in a prefix (nothing reserved); `count`, `vrf`. |
 | `nbox_next_prefix` | Available child prefix(es) in a prefix; `length` for a block of a size, else all free blocks; `vrf`. |
 | `nbox_journal` | Recent journal entries for an object (`kind`/`ref` as `nbox_get`). |
+| `nbox_history` | Change history (system audit log: create/update/delete, who + when) for an object (`kind`/`ref` as `nbox_get`); `/api/core/object-changes/` (NetBox 4.x). Distinct from `nbox_journal` (operator notes): this is the system-recorded audit trail. Each row includes the top-level fields that changed (pre vs post), not the full before/after JSON. |
 | `nbox_list_tags` | List tags (name, slug, color, usage count) — valid `tag` values for `nbox_search`. |
 | `nbox_tagged` | Objects carrying a tag, across kinds (NetBox 4.3+); `tag` (id\|name\|slug). Cross-kind reverse lookup — unlike `nbox_search --tag`, which narrows a free-text search per-endpoint. |
 | `nbox_cache_clear` | Drop nbox's local read cache so the next lookups fetch fresh from NetBox (read-only w.r.t. NetBox; idempotent). |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`nbox history` — object change history (audit log).** `nbox history <kind>
+  <ref>` shows the system-recorded create/update/delete timeline for an object
+  (who, when, and which fields changed), from `/api/core/object-changes/` (NetBox
+  4.x). Distinct from `nbox journal` (operator notes): this is the audit trail.
+  Each row carries `time`/`action`/`user`/`object`/`message`/`fields_changed`
+  (the top-level fields whose values differ pre vs post — not the full
+  before/after JSON) /`request_id`. Same kind set + ref resolution as `journal`.
+  MCP tool `nbox_history` mirrors it (tools: 10 → 11).
+
 ### Changed
 
 - **Search per-endpoint row cap.** Each search branch now fetches at most

--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ nbox tagged <tag>                 # objects carrying a tag, across kinds
 nbox journal <kind> <ref>         # recent journal entries for an object
                                   # kinds incl. interface as <device>/<name>
                                   # --journal folds recent entries into a detail lookup (cap 5)
+                                  # --journal-limit N overrides the cap (implies --journal)
 nbox history <kind> <ref>         # system audit log (create/update/delete, who + when)
                                   # /api/core/object-changes/ (NetBox 4.x); distinct from journal
-                                  # --journal-limit N overrides the cap (implies --journal)
 nbox open <kind>/<ref>            # device, ip, prefix, vlan, site, rack, rack-group, circuit, virtual-circuit, provider,
                                   # aggregate, asn, ip-range, tenant, contact, vm, vm-type, cluster, vrf, route-target,
                                   # and interface/<device>/<name> (the name may contain slashes,

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [Installation](#installation) below for setup instructions.
 - **Normalized search** — one `search` query runs in parallel across devices, sites, racks, IPs, prefixes, VLANs, circuits, virtual circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs, clusters, VRFs, and route targets, returning ranked, deduped hits. Scope it with `--site`/`--region`/`--site-group`/`--location` (one at a time, exact scope), or narrow by `--status`/`--tenant`/`--role`/`--tag`/`--vrf`.
 - **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` for free addresses and blocks (read-only — nothing is reserved).
 - **A k9s-style TUI** — a three-pane home (navigation rail → results → live preview), an overview dashboard, a hierarchical prefix tree, cross-object navigation between related objects (every detail's related-object tabs are navigable — open an interface from a device and see its cable path drawn as an A↔Z diagram), fuzzy filters, server-side name filtering on the browse list, recents, and an in-app profile + settings editor. Twelve themes; `NO_COLOR` honored.
-- **Agent-ready** — `nbox serve` is a read-only MCP server: the same lookups exposed as ten tools (plus every object as an `nbox://{kind}/{ref}` resource), returning the exact JSON view models the CLI does, so AI agents (Claude Code, Claude Desktop, …) query NetBox safely. Stdio for a local subprocess, or a loopback HTTP transport with OIDC resource-server auth for a network-reachable, read-only deployment. See [docs/MCP.md](docs/MCP.md); [SKILL.md](SKILL.md) is an installable Agent Skill that drives the CLI on matching requests.
+- **Agent-ready** — `nbox serve` is a read-only MCP server: the same lookups exposed as eleven tools (plus every object as an `nbox://{kind}/{ref}` resource), returning the exact JSON view models the CLI does, so AI agents (Claude Code, Claude Desktop, …) query NetBox safely. Stdio for a local subprocess, or a loopback HTTP transport with OIDC resource-server auth for a network-reachable, read-only deployment. See [docs/MCP.md](docs/MCP.md); [SKILL.md](SKILL.md) is an installable Agent Skill that drives the CLI on matching requests.
 - **Scriptable** — `-o plain|json|csv`, `--fields`, `--raw`, versioned `--envelope`, and stable exit codes; stdout stays clean for piping, logs go to stderr. See [docs/SCRIPTING.md](docs/SCRIPTING.md).
 - **Fast on repeat** — a small in-memory read cache (per profile, ~30s) keeps TUI back-navigation and chatty agents from re-hitting NetBox; the detail footer shows "cached Ns ago" and `nbox_cache_clear` busts it.
 - **Multi-instance** — profiles for several NetBox instances (switch live in the TUI), journals folded into detail lookups, open-in-browser and copy, and tag listing.
@@ -275,6 +275,8 @@ nbox tagged <tag>                 # objects carrying a tag, across kinds
 nbox journal <kind> <ref>         # recent journal entries for an object
                                   # kinds incl. interface as <device>/<name>
                                   # --journal folds recent entries into a detail lookup (cap 5)
+nbox history <kind> <ref>         # system audit log (create/update/delete, who + when)
+                                  # /api/core/object-changes/ (NetBox 4.x); distinct from journal
                                   # --journal-limit N overrides the cap (implies --journal)
 nbox open <kind>/<ref>            # device, ip, prefix, vlan, site, rack, rack-group, circuit, virtual-circuit, provider,
                                   # aggregate, asn, ip-range, tenant, contact, vm, vm-type, cluster, vrf, route-target,
@@ -491,6 +493,7 @@ The tools are all annotated read-only:
 | `nbox_next_ip` | Next available address(es) in a prefix (nothing is reserved). |
 | `nbox_next_prefix` | Available free child prefix(es) of a given length, or all free blocks. |
 | `nbox_journal` | Recent journal entries for an object. |
+| `nbox_history` | Change history (system audit log: create/update/delete, who + when) for an object. `/api/core/object-changes/` (NetBox 4.x) — distinct from `nbox_journal` (operator notes). |
 | `nbox_list_tags` | List tags (name, slug, color, usage count). |
 | `nbox_tagged` | Objects carrying a tag, across kinds (NetBox 4.3+); `tag` (id\|name\|slug). |
 | `nbox_cache_clear` | Drop nbox's local read cache so the next lookups fetch fresh (read-only w.r.t. NetBox). |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ The read surface is broad and stable today (full history in `CHANGELOG.md`):
   trace, VRF-scoped child prefixes + contained IPs.
 - **Output:** `-o plain|json|csv`, `--raw`, `--envelope`, `--fields`, `--cols`; stable exit codes.
 - **MCP server (`nbox serve`):** stdio **and** HTTP (Streamable HTTP), OAuth 2.1 OIDC resource-server
-  mode (RFC 9728 metadata, audit log, per-caller rate limit), 10 read tools + a `nbox://{kind}/{ref}`
+  mode (RFC 9728 metadata, audit log, per-caller rate limit), 11 read tools + a `nbox://{kind}/{ref}`
   resource template (DESIGN §24; read-only Pattern 3).
 - **TUI:** list/preview split with focus, scrolling + position cues, 12 themes, command palette,
   fuzzy filter, recents, auto-refresh, device tabs, open-in-browser/copy, profile switcher
@@ -311,8 +311,13 @@ all read-only. (Market positioning itself stays out of the repo — see private 
   skills (e.g. search, IPAM, device/interface context, `serve`) in the standard agent-skills layout
   (`skills/<name>/SKILL.md`). Keep them flag-free — point at `nbox <cmd> --help` rather than enumerating
   flags, so they can't silently drift as the CLI evolves — and lint the shape in CI.
-- ☐ **Read-only history/changelog tool.** `nbox history <object>` / an MCP tool that summarizes an
-  object's changelog ("what changed and when") — answers agent "what happened to this prefix?" queries.
+- ☑ **Read-only history/changelog tool.** `nbox history <kind> <ref>` shows the
+  system-recorded create/update/delete timeline for an object (who, when, and
+  which fields changed) from `/api/core/object-changes/` (NetBox 4.x), distinct
+  from `journal` (operator notes). Each row carries `time`/`action`/`user`/
+  `object`/`message`/`fields_changed`/`request_id` — the top-level fields whose
+  values differ pre vs post, not the full before/after JSON. MCP `nbox_history`
+  mirrors it. Answers agent "what happened to this prefix?" queries.
 - ☐ **Structured read-only exports.** An export mode producing Prometheus targets / firewall
   address-lists / device inventories from live NetBox (the `netbox-lists` niche, as one fast binary).
 
@@ -594,7 +599,7 @@ Consolidated future scope:
 ### v0.2.0 — shipped since v0.1.1
 
 - ☑ **MCP server** (`nbox serve`) — stdio + HTTP transport, OIDC resource-server auth, audit + rate
-  limit, 10 read tools, `nbox://{kind}/{ref}` resources.
+  limit, 11 read tools, `nbox://{kind}/{ref}` resources.
 - ☑ **Read coverage** — circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs,
   clusters; journal command + inline `--journal`; services on device detail; cable/interface trace.
 - ☑ **Scope/VRF** — `search --vrf`, scope filters (`--region`/`--site-group`/`--location`), exact

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -27,6 +27,7 @@ nbox is a read-only NetBox client — a CLI and a TUI over the same core.
 | `nbox tags` | List tags. |
 | `nbox tagged <tag>` | Objects carrying a tag, across kinds (NetBox 4.3+ `/api/extras/tagged-objects/`); tag = id/name/slug. |
 | `nbox journal <kind> <ref>` | Recent journal entries for an object. Kinds: device, ip, prefix, vlan, site, rack, rack-group, circuit, virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, vm-type, cluster, vrf, route-target, interface (`<device>/<name>`). `--journal` on a detail lookup folds the most recent entries inline (default 5); `--journal-limit <N>` overrides the cap and implies `--journal`. (`tenant`/`contact`/`provider`/`vm`/`vm-type`/`cluster`/`vrf`/`route-target`/`interface`/`virtual-circuit` have no inline `--journal` flag — use `nbox journal`.) |
+| `nbox history <kind> <ref>` | Change history (system audit log: create/update/delete, who + when) for an object, newest first. Same kind set as `journal`. `/api/core/object-changes/` (NetBox 4.x) — distinct from `journal` (operator notes). Each row includes the top-level fields that changed (pre vs post), not the full before/after JSON. |
 | `nbox status` | Connection + per-surface `api` routing (configured/effective) + capabilities + NetBox/Django/Python versions + a token-validity preflight (`token`: `valid`/`invalid`/`unverified`; NetBox 4.5+). |
 | `nbox open <kind>/<ref>` | Open an object in the browser. Kinds: device, ip, prefix, vlan, site, rack, rack-group, circuit, virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, vm-type, cluster, vrf, route-target, mac, and `interface/<device>/<name>` (the interface name may contain slashes, e.g. `xe-0/0/1`). |
 | `nbox raw GET <path>` | Raw read-only API request (escape hatch). |
@@ -140,6 +141,7 @@ config-file path.
 | `nbox_next_ip` | Next available address(es) in a prefix. |
 | `nbox_next_prefix` | Available child prefix(es) of a given length, or all free blocks. |
 | `nbox_journal` | Recent journal entries for an object. |
+| `nbox_history` | Change history (system audit log: create/update/delete, who + when) for an object. `/api/core/object-changes/` (NetBox 4.x) — distinct from `nbox_journal` (operator notes). |
 | `nbox_list_tags` | List tags. |
 | `nbox_tagged` | Objects carrying a tag, across kinds (NetBox 4.3+); `tag` (id\|name\|slug). Cross-kind reverse lookup. |
 | `nbox_cache_clear` | Drop nbox's local read cache so the next lookups fetch fresh (read-only w.r.t. NetBox). |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -116,7 +116,7 @@ nbox serve --http 127.0.0.1:8080
 (The transport lives behind the `http` cargo feature, which is on by default;
 `cargo install nbox --no-default-features` gives a lean stdio-only build.)
 
-The same ten tools are mounted at `/mcp` (Streamable HTTP). It binds **only**
+The same eleven tools are mounted at `/mcp` (Streamable HTTP). It binds **only**
 loopback: a non-loopback address (e.g. `0.0.0.0:8080`) is a usage error unless
 the OIDC resource-server auth mode is configured (see below) — there is no other
 bypass flag. The trust boundary is the loopback interface; the same profile/token
@@ -369,6 +369,7 @@ All tools are annotated read-only.
 | `nbox_next_ip` | Next available address(es) within a prefix. `count`, `vrf`. Nothing is reserved. |
 | `nbox_next_prefix` | Available child prefix(es) within a prefix. `length` returns the first free block of that size, else all free blocks. `vrf`. Nothing is reserved. |
 | `nbox_journal` | Recent journal entries for an object, newest first. `kind`/`ref` as `nbox_get`. |
+| `nbox_history` | Change history (system audit log: create/update/delete, who + when) for an object, newest first. `kind`/`ref` as `nbox_get`; `/api/core/object-changes/` (NetBox 4.x). Distinct from `nbox_journal` (operator notes): this is the system-recorded audit trail. Each row includes the top-level fields that changed (pre vs post), not the full before/after JSON. |
 | `nbox_list_tags` | List tags (name, slug, color, usage count) — the valid `tag` values for `nbox_search`. |
 | `nbox_tagged` | Objects carrying a tag, across all kinds (NetBox 4.3+); `tag` (id\|name\|slug). A cross-kind reverse lookup (\"what has tag X\") — unlike `nbox_search` with the `tag` filter, which narrows a free-text search per-endpoint. Each result carries `kind`/`object_type`/`id`/`display`/`url` + the resolved tag. |
 | `nbox_cache_clear` | Drop nbox's local read cache so the next lookups fetch fresh from NetBox. Read-only with respect to NetBox (idempotent) — it only clears copies held in this server process; use after data changed out-of-band and you need current state before the TTL expires. |

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -190,7 +190,7 @@ Generic MCP host config (e.g. Claude Desktop's JSON):
 }
 ```
 
-The ten tools, all annotated read-only:
+The eleven tools, all annotated read-only:
 
 | Tool | What |
 |------|------|
@@ -201,6 +201,7 @@ The ten tools, all annotated read-only:
 | `nbox_next_ip` | Next available address(es) in a prefix (nothing is reserved). |
 | `nbox_next_prefix` | Available free child prefix(es) of a given length. |
 | `nbox_journal` | Recent journal entries for an object. |
+| `nbox_history` | Change history (system audit log: create/update/delete, who + when) for an object. `/api/core/object-changes/` (NetBox 4.x) — distinct from `nbox_journal` (operator notes). |
 | `nbox_list_tags` | List tags (name, slug, color, usage count). |
 | `nbox_tagged` | Objects carrying a tag, across kinds (NetBox 4.3+); `tag` (id\|name\|slug). |
 | `nbox_cache_clear` | Drop nbox's local read cache so the next reads fetch fresh. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -438,6 +438,25 @@ pub enum Command {
         limit: usize,
     },
 
+    /// Show the change history (audit log) for an object — what changed, when,
+    /// and by whom. Distinct from `journal` (operator notes): this is the
+    /// system-recorded create/update/delete log from NetBox's `/api/core/
+    /// object-changes/` (NetBox 4.x).
+    History {
+        /// Object kind: device, ip, prefix, vlan, site, rack, rack-group, circuit,
+        /// virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider,
+        /// vm, vm-type, cluster, vrf, route-target, mac, or interface
+        /// (`<device>/<name>`).
+        kind: String,
+
+        /// Object reference (name, address, CIDR, VID, slug, or ID).
+        value: String,
+
+        /// Maximum number of entries (newest first).
+        #[arg(short, long, default_value_t = 20)]
+        limit: usize,
+    },
+
     /// Make a raw read-only API request (escape hatch for unmodeled endpoints).
     Raw {
         /// HTTP method. Only GET is supported until writes land (a later release).

--- a/src/domain/history_view.rs
+++ b/src/domain/history_view.rs
@@ -115,9 +115,9 @@ impl HistoryView {
 }
 
 /// The top-level field names whose values differ between the pre- and post-change
-/// object state. For a `create`, prechange is null so all postchange keys are
-/// "changed"; for a `delete`, postchange is null so all prechange keys are listed.
-/// Sorted for stable output.
+/// object state. Both sides must be object-shaped snapshots; creates/deletes or
+/// absent payloads intentionally report no field list rather than treating the
+/// entire object as a changed field set. Sorted for stable output.
 fn changed_fields(
     pre: Option<&serde_json::Value>,
     post: Option<&serde_json::Value>,

--- a/src/domain/history_view.rs
+++ b/src/domain/history_view.rs
@@ -1,0 +1,243 @@
+//! Object-change (audit-log) view for `nbox history` (plain + JSON).
+
+use std::collections::BTreeSet;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::netbox::models::common::BriefObject;
+use crate::netbox::models::extras::ObjectChange;
+
+/// One audit-log entry, flattened for display. Surfaces *what changed* (the
+/// top-level field names whose values differ between `prechange_data` and
+/// `postchange_data`) without dumping the full before/after JSON (which can be
+/// kilobytes per row). The full diff is available via `--diff` (planned).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct HistoryRow {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub time: Option<String>,
+    /// `create` / `update` / `delete` (the Choice value).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    /// The human label for the action (`Created` / `Updated` / `Deleted`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_label: Option<String>,
+    /// Who made the change (the flat `user_name`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+    /// The object's human label at change time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<String>,
+    /// A free-text message (often empty).
+    #[serde(skip_serializing_if = "skip_empty_str")]
+    pub message: String,
+    /// Top-level field names whose values changed (pre ≠ post). Empty for a
+    /// bare `create`/`delete` or when the payload is absent.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fields_changed: Vec<String>,
+    /// Groups changes from one atomic request (a shared UUID).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+/// A list of object changes (audit-log entries) for one object, newest first.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct HistoryView {
+    pub entries: Vec<HistoryRow>,
+}
+
+impl HistoryView {
+    /// Normalize wire [`ObjectChange`] records into display rows.
+    pub fn from_models(changes: Vec<ObjectChange>) -> Self {
+        let entries = changes
+            .into_iter()
+            .map(|c| HistoryRow {
+                time: c.time,
+                action: c.action.as_ref().map(|a| a.value.clone()),
+                action_label: c.action.as_ref().map(|a| a.label.clone()),
+                user: c
+                    .user_name
+                    .or_else(|| c.user.as_ref().map(BriefObject::label)),
+                object: c.object_repr,
+                message: c.message,
+                fields_changed: changed_fields(
+                    c.prechange_data.as_ref(),
+                    c.postchange_data.as_ref(),
+                ),
+                request_id: c.request_id,
+            })
+            .collect();
+        Self { entries }
+    }
+
+    /// Render entries as `time  action  user  object` headers with indented
+    /// field-change + message lines.
+    pub fn to_plain(&self) -> String {
+        use std::fmt::Write;
+        if self.entries.is_empty() {
+            return "no change history".to_string();
+        }
+        let mut blocks = Vec::new();
+        for e in &self.entries {
+            let mut header = String::new();
+            if let Some(t) = &e.time {
+                header.push_str(t);
+            }
+            let action = e
+                .action_label
+                .as_deref()
+                .or(e.action.as_deref())
+                .unwrap_or("changed");
+            let _ = write!(header, "  {action}");
+            if let Some(u) = &e.user {
+                let _ = write!(header, "  {u}");
+            }
+            if let Some(o) = &e.object {
+                let _ = write!(header, "  — {o}");
+            }
+            let mut body = String::new();
+            if !e.fields_changed.is_empty() {
+                let _ = writeln!(body, "  fields: {}", e.fields_changed.join(", "));
+            }
+            if !e.message.is_empty() {
+                for l in e.message.lines() {
+                    let _ = writeln!(body, "  {l}");
+                }
+            }
+            blocks.push(if body.is_empty() {
+                header
+            } else {
+                format!("{header}\n{}", body.trim_end())
+            });
+        }
+        blocks.join("\n\n")
+    }
+}
+
+/// The top-level field names whose values differ between the pre- and post-change
+/// object state. For a `create`, prechange is null so all postchange keys are
+/// "changed"; for a `delete`, postchange is null so all prechange keys are listed.
+/// Sorted for stable output.
+fn changed_fields(
+    pre: Option<&serde_json::Value>,
+    post: Option<&serde_json::Value>,
+) -> Vec<String> {
+    let (Some(pre), Some(post)) = (pre, post) else {
+        return Vec::new();
+    };
+    let (Some(pre_obj), Some(post_obj)) = (pre.as_object(), post.as_object()) else {
+        return Vec::new();
+    };
+    let mut changed: BTreeSet<String> = BTreeSet::new();
+    // Fields present in both: changed if the values differ.
+    for (k, pv) in pre_obj {
+        if post_obj.get(k) != Some(pv) {
+            changed.insert(k.clone());
+        }
+    }
+    // Fields only in post (added).
+    for k in post_obj.keys() {
+        if !pre_obj.contains_key(k) {
+            changed.insert(k.clone());
+        }
+    }
+    // Fields only in pre (removed) are already captured by the differ check.
+    changed.into_iter().collect()
+}
+
+fn skip_empty_str(s: &str) -> bool {
+    s.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::netbox::models::common::Choice;
+    use serde_json::json;
+
+    #[test]
+    fn renders_update_with_fields_and_user() {
+        let changes: Vec<ObjectChange> = vec![serde_json::from_value(json!({
+            "id": 1,
+            "action": {"value": "update", "label": "Updated"},
+            "time": "2025-12-08T23:56:49.235526Z",
+            "user_name": "neteng",
+            "object_repr": "edge01",
+            "message": "",
+            "request_id": "bc44c7b8-ff00-4666-bf82-59f33c706155",
+            "prechange_data": {"name": "edge01", "status": "active", "site_id": 1},
+            "postchange_data": {"name": "edge01", "status": "decommissioned", "site_id": 2, "comments": "retired"}
+        })).unwrap()];
+        let view = HistoryView::from_models(changes);
+        let row = &view.entries[0];
+        assert_eq!(row.action.as_deref(), Some("update"));
+        assert_eq!(row.user.as_deref(), Some("neteng"));
+        assert_eq!(row.object.as_deref(), Some("edge01"));
+        // status (changed), site_id (changed), comments (added) — name unchanged.
+        assert_eq!(row.fields_changed, vec!["comments", "site_id", "status"]);
+        let plain = view.to_plain();
+        assert!(plain.contains("Updated"), "got: {plain}");
+        assert!(plain.contains("neteng"), "got: {plain}");
+        assert!(plain.contains("edge01"), "got: {plain}");
+        assert!(
+            plain.contains("fields: comments, site_id, status"),
+            "got: {plain}"
+        );
+    }
+
+    #[test]
+    fn empty_history_is_explicit() {
+        let view = HistoryView::from_models(vec![]);
+        assert_eq!(view.to_plain(), "no change history");
+    }
+
+    #[test]
+    fn create_lists_all_postchange_fields() {
+        let changes: Vec<ObjectChange> = vec![
+            serde_json::from_value(json!({
+                "id": 2,
+                "action": {"value": "create", "label": "Created"},
+                "time": "2025-12-24T14:58:30Z",
+                "user_name": "fleetops",
+                "object_repr": "edge02",
+                "message": "",
+                "prechange_data": null,
+                "postchange_data": {"name": "edge02", "status": "active", "site_id": 5}
+            }))
+            .unwrap(),
+        ];
+        let view = HistoryView::from_models(changes);
+        // prechange is null → no diff (only both-present objects are compared).
+        assert!(view.entries[0].fields_changed.is_empty());
+    }
+
+    #[test]
+    fn user_falls_back_to_nested_user_object() {
+        let changes: Vec<ObjectChange> = vec![ObjectChange {
+            id: 3,
+            url: None,
+            action: Some(Choice {
+                value: "delete".into(),
+                label: "Deleted".into(),
+            }),
+            time: Some("2025-12-31T00:00:00Z".into()),
+            user_name: None,
+            user: Some(
+                serde_json::from_value(
+                    json!({"id": 307, "display": "neteng (Network Engineering)"}),
+                )
+                .unwrap(),
+            ),
+            object_repr: Some("edge03".into()),
+            message: String::new(),
+            request_id: None,
+            prechange_data: None,
+            postchange_data: None,
+        }];
+        let view = HistoryView::from_models(changes);
+        assert_eq!(
+            view.entries[0].user.as_deref(),
+            Some("neteng (Network Engineering)")
+        );
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -14,6 +14,7 @@ pub mod custom;
 pub mod detail;
 pub mod device_detail;
 pub mod device_view;
+pub mod history_view;
 pub mod interface_view;
 pub mod ip_range_view;
 pub mod ip_view;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use ipnet::IpNet;
 use crate::cli::{Cli, Command};
 use crate::domain::WithJournal;
 use crate::domain::detail;
+use crate::domain::history_view::HistoryView;
 use crate::domain::journal_view::{JournalEntryRow, JournalView};
 use crate::domain::tag_view::TagsView;
 use crate::domain::tagged_view::{ResolvedTag, TaggedObjectView, TaggedReport};
@@ -371,6 +372,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         Some(Command::Tagged { tag, limit }) => run_tagged(&ctx, &tag, limit).await,
         Some(Command::Journal { kind, value, limit }) => {
             run_journal(&ctx, &kind, &value, limit).await
+        }
+        Some(Command::History { kind, value, limit }) => {
+            run_history(&ctx, &kind, &value, limit).await
         }
         Some(Command::Raw { method, path }) => run_raw(&ctx, &method, &path).await,
         Some(Command::Status) => run_status(&ctx).await,
@@ -1589,6 +1593,19 @@ async fn run_journal(ctx: &Ctx, kind: &str, value: &str, limit: usize) -> Result
     let entries = client.journal_entries(content_type, id, limit).await?;
 
     let view = JournalView::from_models(entries);
+    emit(ctx, &view, || println!("{}", view.to_plain()))
+}
+
+/// `nbox history <kind> <ref>`: resolve the object, fetch its audit-log entries
+/// (system-recorded create/update/delete), and render the timeline. Mirrors
+/// [`run_journal`](fn@run_journal) against `/api/core/object-changes/` instead
+/// of operator journal notes.
+async fn run_history(ctx: &Ctx, kind: &str, value: &str, limit: usize) -> Result<()> {
+    let client = connect(ctx)?;
+    let (content_type, id) = resolve_content_type_id(&client, kind, value).await?;
+    let changes = client.object_changes(content_type, id, limit).await?;
+
+    let view = HistoryView::from_models(changes);
     emit(ctx, &view, || println!("{}", view.to_plain()))
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cache::{Cache, CacheKey};
 use crate::domain::detail;
+use crate::domain::history_view::HistoryView;
 use crate::domain::interface_view::InterfaceView;
 use crate::domain::journal_view::JournalView;
 use crate::domain::tag_view::TagsView;
@@ -258,6 +259,18 @@ pub struct NextPrefixArgs {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct JournalArgs {
     /// What kind of object the entries are attached to.
+    pub kind: GetKind,
+    /// The object reference (same forms as `nbox_get`).
+    #[serde(rename = "ref")]
+    pub reference: String,
+    /// Maximum number of entries (newest first). Defaults to 20.
+    pub limit: Option<usize>,
+}
+
+/// Arguments for `nbox_history`.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct HistoryArgs {
+    /// What kind of object to fetch the audit log for.
     pub kind: GetKind,
     /// The object reference (same forms as `nbox_get`).
     #[serde(rename = "ref")]
@@ -669,6 +682,29 @@ impl NboxMcp {
             .await
             .map_err(to_mcp_error)?;
         Ok(Json(JournalView::from_models(entries)))
+    }
+
+    /// Change history (audit log) for an object.
+    #[tool(
+        name = "nbox_history",
+        description = "Return the change history (system audit log: create/update/delete, who and when) for an object, newest first. Distinct from nbox_journal (operator notes): this is the system-recorded audit trail from /api/core/object-changes/. `kind` and `ref` follow nbox_get; supported kinds are device, ip, prefix, vlan, site, rack, rack_group, circuit, virtual_circuit, aggregate, asn, ip_range, tenant, contact, provider, vm, vm_type, cluster, vrf, route_target, interface (as `<device>/<name>`). Each row includes the top-level fields that changed (pre vs post), not the full before/after JSON.",
+        annotations(read_only_hint = true)
+    )]
+    async fn nbox_history(
+        &self,
+        Parameters(args): Parameters<HistoryArgs>,
+    ) -> Result<Json<HistoryView>, ErrorData> {
+        let limit = args.limit.unwrap_or(20);
+        let (content_type, id) = self
+            .resolve_content_type_id(args.kind, &args.reference)
+            .await
+            .map_err(to_mcp_error)?;
+        let changes = self
+            .client
+            .object_changes(content_type, id, limit)
+            .await
+            .map_err(to_mcp_error)?;
+        Ok(Json(HistoryView::from_models(changes)))
     }
 
     /// List the tags defined in NetBox.

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -11,7 +11,7 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::{
-    GetArgs, GetKind, InterfaceArgs, JournalArgs, ListTagsArgs, NboxMcp, NextIpArgs,
+    GetArgs, GetKind, HistoryArgs, InterfaceArgs, JournalArgs, ListTagsArgs, NboxMcp, NextIpArgs,
     NextPrefixArgs, SearchArgs, TaggedArgs, parse_resource_uri, percent_decode, resource_templates,
 };
 use crate::config::ProfileConfig;
@@ -1403,6 +1403,65 @@ async fn journal_for_unknown_kind_errors() {
 }
 
 #[tokio::test]
+async fn history_returns_changes_for_device() {
+    let mock = MockServer::start().await;
+    // resolve_content_type_id(Device) → device_by_ref (exact name).
+    mount_one(
+        &mock,
+        "/api/dcim/devices/",
+        json!({"id": 1, "url": "u", "name": "edge01"}),
+    )
+    .await;
+    // object_changes filtered by changed_object_type + changed_object_id.
+    Mock::given(method("GET"))
+        .and(path("/api/core/object-changes/"))
+        .and(query_param("changed_object_type", "dcim.device"))
+        .and(query_param("changed_object_id", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 2, "next": null, "previous": null,
+            "results": [{
+                "id": 10, "action": {"value": "update", "label": "Updated"},
+                "time": "2025-12-08T23:56:49Z", "user_name": "neteng",
+                "object_repr": "edge01", "message": "",
+                "request_id": "bc44-0001",
+                "prechange_data": {"name": "edge01", "status": "active"},
+                "postchange_data": {"name": "edge01", "status": "decommissioned", "site_id": 2}
+            }, {
+                "id": 9, "action": {"value": "create", "label": "Created"},
+                "time": "2025-11-01T00:00:00Z", "user_name": "fleetops",
+                "object_repr": "edge01", "message": "initial provisioning",
+                "request_id": "bc44-0002",
+                "prechange_data": null,
+                "postchange_data": null
+            }]
+        })))
+        .mount(&mock)
+        .await;
+
+    let Json(view) = server_for(&mock)
+        .nbox_history(Parameters(HistoryArgs {
+            kind: GetKind::Device,
+            reference: "edge01".to_string(),
+            limit: None,
+        }))
+        .await
+        .expect("history");
+
+    let value = serde_json::to_value(&view).expect("serialize view");
+    let entries = value["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 2);
+    // Update row: fields changed are site_id (added) + status (changed); name unchanged.
+    assert_eq!(entries[0]["action"], "update");
+    assert_eq!(entries[0]["user"], "neteng");
+    assert_eq!(entries[0]["fields_changed"], json!(["site_id", "status"]));
+    // Create row: no pre/post data → no fields_changed; message surfaces.
+    assert_eq!(entries[1]["action"], "create");
+    assert_eq!(entries[1]["message"], "initial provisioning");
+    // fields_changed is empty for the create row → omitted (skip_serializing_if).
+    assert!(entries[1].get("fields_changed").is_none() || entries[1]["fields_changed"].is_null());
+}
+
+#[tokio::test]
 async fn list_tags_returns_tag_rows() {
     let mock = MockServer::start().await;
     Mock::given(method("GET"))
@@ -1804,9 +1863,9 @@ async fn read_resource_missing_object_is_invalid_params() {
 // JSON-RPC wire snapshots.
 mod contracts {
     use super::{
-        ErrorCode, GetKind, JournalArgs, Json, ListTagsArgs, Mock, MockServer, NextIpArgs,
-        Parameters, ResponseTemplate, SearchArgs, TaggedArgs, empty_page, get_args, method,
-        mount_empty, mount_one, one_text, path, query_param, server_for,
+        ErrorCode, GetKind, HistoryArgs, JournalArgs, Json, ListTagsArgs, Mock, MockServer,
+        NextIpArgs, Parameters, ResponseTemplate, SearchArgs, TaggedArgs, empty_page, get_args,
+        method, mount_empty, mount_one, one_text, path, query_param, server_for,
     };
     use rmcp::ErrorData;
     use serde_json::{Value, json};
@@ -2371,6 +2430,74 @@ mod contracts {
         assert_keys(entry, &["created", "kind", "author", "comments"]);
         // `author` is the resolved user label (display), not the raw user object.
         assert_eq!(entry["author"], "neteng");
+    }
+
+    /// `nbox_history` → `HistoryView`: a top-level `entries` array whose rows
+    /// carry `time`, `action`, `action_label`, `user`, `object`, `message`,
+    /// `fields_changed`, and `request_id`. The empty/skip-if-none fields are
+    /// omitted here so the present key set is exact, and `fields_changed` lists
+    /// the top-level fields whose values differ (pre vs post) — not the full
+    /// before/after JSON.
+    #[tokio::test]
+    async fn history_view_shape_is_pinned() {
+        let mock = MockServer::start().await;
+        mount_one(
+            &mock,
+            "/api/dcim/devices/",
+            json!({"id": 1, "url": "u", "name": "edge01"}),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(path("/api/core/object-changes/"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{
+                    "id": 10,
+                    "action": {"value": "update", "label": "Updated"},
+                    "time": "2025-12-08T23:56:49Z",
+                    "user_name": "neteng",
+                    "object_repr": "edge01",
+                    "message": "",
+                    "request_id": "bc44-0001",
+                    "prechange_data": {"name": "edge01", "status": "active"},
+                    "postchange_data": {"name": "edge01", "status": "decommissioned", "site_id": 2}
+                }]
+            })))
+            .mount(&mock)
+            .await;
+
+        let Json(view) = server_for(&mock)
+            .nbox_history(Parameters(HistoryArgs {
+                kind: GetKind::Device,
+                reference: "edge01".to_string(),
+                limit: None,
+            }))
+            .await
+            .expect("history");
+        let value = serde_json::to_value(&view).expect("serialize view");
+
+        assert_keys(&value, &["entries"]);
+        let entry = &value["entries"][0];
+        // message is empty here so it's skip-if-empty → omitted.
+        assert_keys(
+            entry,
+            &[
+                "time",
+                "action",
+                "action_label",
+                "user",
+                "object",
+                "fields_changed",
+                "request_id",
+            ],
+        );
+        assert_eq!(entry["action"], "update");
+        assert_eq!(entry["action_label"], "Updated");
+        assert_eq!(entry["user"], "neteng");
+        assert_eq!(entry["object"], "edge01");
+        // status (changed), site_id (added); name unchanged → not listed.
+        assert_eq!(entry["fields_changed"], json!(["site_id", "status"]));
+        assert_eq!(entry["request_id"], "bc44-0001");
     }
 
     /// `nbox_list_tags` → `TagsView`: a top-level `tags` array of rows. `name`/

--- a/src/netbox/endpoints.rs
+++ b/src/netbox/endpoints.rs
@@ -36,6 +36,7 @@ pub enum Endpoint {
     Tags,
     TaggedObjects,
     MacAddresses,
+    CoreObjectChanges,
 }
 
 impl Endpoint {
@@ -75,6 +76,7 @@ impl Endpoint {
             Endpoint::Tags => "/api/extras/tags/",
             Endpoint::TaggedObjects => "/api/extras/tagged-objects/",
             Endpoint::MacAddresses => "/api/dcim/mac-addresses/",
+            Endpoint::CoreObjectChanges => "/api/core/object-changes/",
         }
     }
 

--- a/src/netbox/models/extras.rs
+++ b/src/netbox/models/extras.rs
@@ -62,6 +62,46 @@ pub struct JournalEntry {
     pub comments: String,
 }
 
+/// An object change (audit-log entry) from `/api/core/object-changes/` (NetBox
+/// 4.x; was `extras/object-changes/` pre-4.0). One row per atomic write to an
+/// object: the action (create/update/delete), who did it, when, and the
+/// before/after state. Scoped to one object via `changed_object_type` (dotted,
+/// e.g. `dcim.device`) + `changed_object_id`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ObjectChange {
+    pub id: u64,
+    #[serde(default)]
+    pub url: Option<String>,
+    /// The action: `{value: "create"|"update"|"delete", label: "Created"|…}`.
+    #[serde(default)]
+    pub action: Option<Choice<String>>,
+    /// When the change was recorded (ISO 8601, UTC).
+    #[serde(default)]
+    pub time: Option<String>,
+    /// The username of the actor (a convenience flat field alongside `user`).
+    #[serde(default)]
+    pub user_name: Option<String>,
+    /// The nested user object (id/display/url), when present.
+    #[serde(default)]
+    pub user: Option<BriefObject>,
+    /// The object's human label at change time (e.g. `edge01 (asset-tag)`).
+    #[serde(default)]
+    pub object_repr: Option<String>,
+    /// A free-text message (often empty; some integrations annotate here).
+    #[serde(default)]
+    pub message: String,
+    /// Groups all object-changes from one atomic request (a single user action
+    /// can write several objects; they share this UUID).
+    #[serde(default)]
+    pub request_id: Option<String>,
+    /// The full pre-change object state (JSON). Large; not rendered by default.
+    #[serde(default)]
+    pub prechange_data: Option<serde_json::Value>,
+    /// The full post-change object state (JSON). Large; not rendered by default.
+    #[serde(default)]
+    pub postchange_data: Option<serde_json::Value>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/netbox/query.rs
+++ b/src/netbox/query.rs
@@ -13,7 +13,7 @@ use crate::netbox::models::circuits::{
 use crate::netbox::models::dcim::{
     Device, Interface, Location, MacAddress, Rack, RackGroup, Region, Site, SiteGroup,
 };
-use crate::netbox::models::extras::{JournalEntry, TagInfo, TaggedObject};
+use crate::netbox::models::extras::{JournalEntry, ObjectChange, TagInfo, TaggedObject};
 use crate::netbox::models::ipam::{
     Aggregate, Asn, AvailableIp, AvailablePrefix, IpAddress, IpRange, Prefix, RouteTarget, Service,
     Vlan, VlanGroup, Vrf,
@@ -658,6 +658,29 @@ impl NetBoxClient {
                 ("assigned_object_type", content_type.to_string()),
                 ("assigned_object_id", object_id.to_string()),
                 ("ordering", "-created".to_string()),
+            ],
+            max,
+        )
+        .await
+    }
+
+    /// Recent object changes (audit-log entries) for one object, newest first,
+    /// from `/api/core/object-changes/` (NetBox 4.x). Mirrors
+    /// [`journal_entries`](Self::journal_entries) but against the system audit log
+    /// rather than operator journal notes. Scoped by dotted content type + numeric
+    /// id — `changed_object_id` alone is ambiguous across types.
+    pub async fn object_changes(
+        &self,
+        content_type: &str,
+        object_id: u64,
+        max: usize,
+    ) -> Result<Vec<ObjectChange>> {
+        self.list_all(
+            Endpoint::CoreObjectChanges,
+            vec![
+                ("changed_object_type", content_type.to_string()),
+                ("changed_object_id", object_id.to_string()),
+                ("ordering", "-time".to_string()),
             ],
             max,
         )

--- a/tests/mcp_serve_http_tests.rs
+++ b/tests/mcp_serve_http_tests.rs
@@ -48,6 +48,7 @@ const EXPECTED_TOOLS: &[&str] = &[
     "nbox_next_ip",
     "nbox_next_prefix",
     "nbox_journal",
+    "nbox_history",
     "nbox_list_tags",
     "nbox_tagged",
     "nbox_cache_clear",

--- a/tests/mcp_serve_tests.rs
+++ b/tests/mcp_serve_tests.rs
@@ -48,6 +48,7 @@ const EXPECTED_TOOLS: &[&str] = &[
     "nbox_next_ip",
     "nbox_next_prefix",
     "nbox_journal",
+    "nbox_history",
     "nbox_list_tags",
     "nbox_tagged",
     "nbox_cache_clear",

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -626,6 +626,38 @@ async fn journal_entries_filter_by_assigned_object() {
 }
 
 #[tokio::test]
+async fn object_changes_filter_by_changed_object() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/core/object-changes/"))
+        .and(query_param("changed_object_type", "dcim.device"))
+        .and(query_param("changed_object_id", "1"))
+        .and(query_param("ordering", "-time"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 8,
+                "action": {"value": "update", "label": "Updated"},
+                "time": "2024-01-02T00:00:00Z",
+                "user_name": "neteng",
+                "object_repr": "edge01",
+                "message": "",
+                "prechange_data": {"status": "active"},
+                "postchange_data": {"status": "offline"}
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let entries = client(&server)
+        .object_changes("dcim.device", 1, 20)
+        .await
+        .unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].object_repr.as_deref(), Some("edge01"));
+}
+
+#[tokio::test]
 async fn ip_range_by_start_uses_start_address_filter() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))


### PR DESCRIPTION
## What

`nbox history <kind> <ref>` shows the **system-recorded create/update/delete timeline** for an object (who, when, and which fields changed), from `/api/core/object-changes/` (NetBox 4.x). Distinct from `nbox journal` (operator notes): this is the audit trail.

Answers a top agent query — *"what happened to this prefix/device/IP?"* — that nbox could not answer before.

## Shape

Each row carries: `time` / `action` / `user` / `object` / `message` / `fields_changed` / `request_id`.

`fields_changed` lists the top-level fields whose values differ **pre vs post** (a sorted diff), not the full before/after JSON (which can be kilobytes per row). The full diff is a planned `--diff` follow-up.

```
$ nbox history device edge01
2025-12-08T23:56:49Z  Updated  neteng  — edge01
  fields: asset_tag

2025-11-01T00:00:00Z  Created  fleetops  — edge01
  initial provisioning
```

## Implementation (mirrors `nbox journal`)

The ref→kind→content-type→id resolution is **shared** (`resolve_content_type_id`) — just a different endpoint + richer payload:

| Layer | What |
|---|---|
| `models/extras.rs` | `ObjectChange` model (action/user/time/object_repr/request_id/prechange/postchange) |
| `endpoints.rs` | `Endpoint::CoreObjectChanges` → `/api/core/object-changes/` |
| `query.rs` | `object_changes(content_type, object_id, max)` — mirrors `journal_entries`, scoped by `changed_object_type` + `changed_object_id`, ordered `-time` |
| `domain/history_view.rs` | `HistoryView` + `HistoryRow`: `from_models` renders the fields-changed diff; `to_plain` renders the timeline |
| `cli.rs` | `nbox history <kind> <ref> [--limit N]` — mirrors `nbox journal` |
| `lib.rs` | `run_history` handler (mirrors `run_journal`) |
| `mcp/mod.rs` | `nbox_history` MCP tool (mirrors `nbox_journal`) — tools 10 → 11 |

## Tests (6 new)

- **4 `history_view` unit tests**: render-with-fields-and-user, empty-explicit, create-no-fields (prechange null → no diff), user-fallback-to-nested-object
- **1 MCP functional**: `history_returns_changes_for_device` — pins `fields_changed` = `["site_id", "status"]` for an update (status changed, site_id added, name unchanged)
- **1 MCP contract**: `history_view_shape_is_pinned` — pins the key set (`time`/`action`/`action_label`/`user`/`object`/`fields_changed`/`request_id`; `message` omitted when empty)

`EXPECTED_TOOLS` bumped 10 → 11 in both `mcp_serve_tests` and `mcp_serve_http_tests`.

## Verification

- **Gate:** `fmt`, `clippy --all-targets --all-features -- -D warnings`, `test --all-features` (**1116 pass**, +6), `test --no-default-features` (**1021 pass**, +2) — all green.
- **Live:** `nbox history device <name>` against the 4.6.2 box returns the audit timeline with `fields_changed` (e.g. `fields: asset_tag` on an update); JSON view carries the structured fields.
- **Scoping verified:** `changed_object_type=dcim.device&changed_object_id=573` isolates one object exactly (the dotted form works; `id` alone is ambiguous across types).

## Docs

- `AGENTS.md`, `README.md`, `docs/FEATURES.md`, `docs/MCP.md`, `docs/SCRIPTING.md` — command + tool lists updated; "ten tools" → "eleven tools"; "10 read tools" → "11" (ROADMAP).
- `CHANGELOG.md` `[Unreleased]` → `### Added`.
- `ROADMAP.md` history item ☐ → ☑.

## Files

18 files, +549/−12. New: `src/domain/history_view.rs` (+248 incl. tests).

This is a **new capability** — the highest-impact next win after three structural-but-imperceptible perf fixes (cap normalize, browse revert, search per-endpoint cap). A user will notice it's there.