### PR TITLE
perf(tui): render-signature redraw gate + concurrent VLAN detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **TUI idle redraw gate.** The 180ms preview tick still drives debounce, status
+  expiry, and the loading spinner, but the event loop now skips `terminal.draw`
+  when a conservative render signature has not changed. Idle ticks no longer
+  rebuild the Results table; spinner/status/async results/keypresses/resize still
+  redraw normally.
+- **VLAN detail fan-out.** VLAN detail now fetches referencing prefixes and the
+  VLAN group's scope concurrently, preserving the same JSON/plain view shape while
+  saving one round trip when a VLAN has both.
 - **Search per-endpoint row cap.** Each search branch now fetches at most
   `min(page_size, max(req.limit, SEARCH_BRANCH_FLOOR))` rows (floor 25), not the
   full `page_size` (100 by default). The merge truncates to `req.limit` anyway,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -705,7 +705,7 @@ escape hatch, and GraphQL still cannot replace canonical REST `q` search.
   dropped as stale. Options, in order: summary-only preview; longer idle delay before warm-prefetch; abort
   handles for superseded preview/search/browse generations. Opening a row should still use the full detail
   cache and preserve the "preview warms open" behavior where possible.
-- ☐ **TUI render dirty-signature (idle CPU/SSH win).** The event loop redraws on the 180ms preview tick even
+- ☑ **TUI render dirty-signature (idle CPU/SSH win).** The event loop redraws on the 180ms preview tick even
   when nothing visible changed; `render_home_list` rebuilds/clones the full row set each draw. Use a
   render-signature diff rather than hand-threading a fragile dirty bool. Signature should include visible
   state (`screen`, `mode`, focus, selections, result/detail ids, status+TTL, spinner frame when loading,
@@ -729,7 +729,7 @@ escape hatch, and GraphQL still cannot replace canonical REST `q` search.
     ~88 for a 42U rack, not 1000) are two round-trips today. They return *different shapes* (full `Device`
     objects vs unit-oriented elevation rows), so "share them" is conditional — only worth it when the elevation
     data suffices for the devices tab and that tab isn't rendered from fields the elevation endpoint lacks;
-  - VLAN detail: `vlan_prefixes` and `vlan_group_scope` are independent — `try_join!`;
+  - ☑ VLAN detail: `vlan_prefixes` and `vlan_group_scope` are independent — `try_join!`;
   - circuit path: memo a panel device's front-port list per detail load so A/Z walks or repeated hops through
     the same patch panel do not page the same 1000 front ports more than once.
 - ☐ **Resolver fallback concurrency.** For non-numeric refs, run exact alternatives concurrently where the

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -324,8 +324,10 @@ pub async fn vlan_view_by_ref(
             .await?
             .ok_or_else(|| not_found("VLAN", value))?
     };
-    let prefixes = client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP).await?;
-    let group = vlan_group_scope(client, &vlan).await?;
+    let (prefixes, group) = tokio::try_join!(
+        client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP),
+        vlan_group_scope(client, &vlan),
+    )?;
     Ok(VlanView::build(vlan, prefixes, group))
 }
 
@@ -1881,8 +1883,10 @@ pub async fn load_detail(client: &NetBoxClient, kind: ObjectKind, id: u64) -> Re
         ObjectKind::Vlan => {
             let vlan: Vlan = client.get(&format!("/api/ipam/vlans/{id}/"), &[]).await?;
             links = vlan_links(&vlan);
-            let prefixes = client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP).await?;
-            let group = vlan_group_scope(client, &vlan).await?;
+            let (prefixes, group) = tokio::try_join!(
+                client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP),
+                vlan_group_scope(client, &vlan),
+            )?;
             tabs = vec![vlan_prefixes_tab(&prefixes)];
             let v = VlanView::build(vlan, prefixes, group);
             (format!("vlan {}", v.vid), v.to_detail_header())
@@ -2139,8 +2143,10 @@ pub async fn load_detail_by_ref(
                 .with_context(|| format!("no VLAN matched \"{value}\""))?;
             let id = vlan.id;
             links = vlan_links(&vlan);
-            let prefixes = client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP).await?;
-            let group = vlan_group_scope(client, &vlan).await?;
+            let (prefixes, group) = tokio::try_join!(
+                client.vlan_prefixes(vlan.id, DETAIL_SECTION_CAP),
+                vlan_group_scope(client, &vlan),
+            )?;
             tabs = vec![vlan_prefixes_tab(&prefixes)];
             let v = VlanView::build(vlan, prefixes, group);
             (id, format!("vlan {}", v.vid), v.to_detail_header())

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -482,7 +482,8 @@ async fn get_vlan_by_vid_returns_vlan_view_with_prefixes() {
             "results": [{
                 "id": 3, "url": "u", "vid": 208, "name": "users",
                 "status": {"value": "active", "label": "Active"},
-                "site": {"id": 1, "display": "iad1"}
+                "site": {"id": 1, "display": "iad1"},
+                "group": {"id": 9, "display": "campus"}
             }]
         })))
         .mount(&mock)
@@ -494,6 +495,16 @@ async fn get_vlan_by_vid_returns_vlan_view_with_prefixes() {
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "count": 1, "next": null, "previous": null,
             "results": [{"id": 9, "url": "u", "prefix": "10.44.208.0/24"}]
+        })))
+        .mount(&mock)
+        .await;
+    // vlan_group_scope: the independent follow-up that enriches group_scope.
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/vlan-groups/9/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 9, "name": "campus", "slug": "campus",
+            "scope_type": "dcim.region",
+            "scope": {"id": 5, "display": "us-east"}
         })))
         .mount(&mock)
         .await;
@@ -513,6 +524,8 @@ async fn get_vlan_by_vid_returns_vlan_view_with_prefixes() {
         "vlan view has no site key: {value}"
     );
     assert_eq!(value["prefixes"][0], "10.44.208.0/24");
+    assert_eq!(value["group_scope"], "us-east");
+    assert_eq!(value["group_scope_type"], "region");
 }
 
 #[tokio::test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,8 @@
 //! TUI entry point and event loop.
 
 use anyhow::Result;
-use ratatui::DefaultTerminal;
+use ratatui::backend::Backend;
+use ratatui::{DefaultTerminal, Terminal};
 use tokio::sync::mpsc;
 
 use crate::cache::{Cache, CacheKey};
@@ -108,8 +109,9 @@ async fn event_loop(
         );
     }
 
+    let mut render_gate = RenderGate::default();
     while !app.should_quit {
-        terminal.draw(|frame| ui::render(frame, app))?;
+        draw_if_dirty(terminal, app, &mut render_gate)?;
 
         let Some(event) = rx.recv().await else { break };
         // Never await network here — dispatch each command on its own task,
@@ -129,6 +131,53 @@ async fn event_loop(
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RenderSignature {
+    digest: u64,
+}
+
+impl RenderSignature {
+    fn new(app: &App, size: (u16, u16)) -> Self {
+        Self {
+            digest: app.render_digest(size),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RenderGate {
+    last_drawn: Option<RenderSignature>,
+}
+
+impl RenderGate {
+    fn needs_draw(&self, app: &App, size: (u16, u16)) -> bool {
+        self.last_drawn != Some(RenderSignature::new(app, size))
+    }
+
+    fn record_drawn(&mut self, app: &App, size: (u16, u16)) {
+        self.last_drawn = Some(RenderSignature::new(app, size));
+    }
+}
+
+fn draw_if_dirty<B>(
+    terminal: &mut Terminal<B>,
+    app: &mut App,
+    gate: &mut RenderGate,
+) -> Result<bool>
+where
+    B: Backend,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    let size = terminal.size()?;
+    let size = (size.width, size.height);
+    if !gate.needs_draw(app, size) {
+        return Ok(false);
+    }
+    terminal.draw(|frame| ui::render(frame, app))?;
+    gate.record_drawn(app, size);
+    Ok(true)
 }
 
 /// Spawn the auto-refresh ticker at `secs` (skipping `None`/`0` = off), returning
@@ -398,4 +447,211 @@ fn copy_to_clipboard(text: &str) -> Result<()> {
 #[cfg(not(feature = "clipboard"))]
 fn copy_to_clipboard(_text: &str) -> Result<()> {
     anyhow::bail!("clipboard support was not built in (enable the `clipboard` feature)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProfileConfig;
+    use crate::netbox::search::{ObjectKind, SearchOutcome, SearchResult};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::backend::TestBackend;
+
+    fn app() -> App {
+        let profile = ProfileConfig {
+            url: "http://localhost".into(),
+            ..Default::default()
+        };
+        let client = NetBoxClient::new(&profile, None).unwrap();
+        App::new(
+            client,
+            "default",
+            "test".into(),
+            "http://localhost".into(),
+            "4.6.0".into(),
+            None,
+        )
+    }
+
+    fn terminal() -> Terminal<TestBackend> {
+        Terminal::new(TestBackend::new(80, 24)).unwrap()
+    }
+
+    fn buffer_text(term: &Terminal<TestBackend>) -> String {
+        term.backend()
+            .buffer()
+            .content
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect()
+    }
+
+    fn result() -> SearchResult {
+        SearchResult {
+            kind: ObjectKind::Device,
+            id: 42,
+            display: "edge01".into(),
+            subtitle: Some("dc1".into()),
+            url: "http://localhost/dcim/devices/42/".into(),
+            score: 100,
+        }
+    }
+
+    fn press(code: KeyCode) -> AppEvent {
+        AppEvent::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn render_gate_initial_draw_happens() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        assert!(buffer_text(&term).contains("profile:"));
+    }
+
+    #[test]
+    fn render_gate_idle_preview_tick_after_stable_frame_skips_draw() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        let before = buffer_text(&term);
+        assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
+
+        assert!(!draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        assert_eq!(buffer_text(&term), before);
+    }
+
+    #[test]
+    fn render_gate_spinner_draws_while_loading_and_stops_after_settle() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        app.pending = 1;
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+
+        assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
+        assert!(
+            draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
+            "spinner frame change redraws"
+        );
+
+        app.handle_event(AppEvent::SearchComplete {
+            req: 0,
+            result: Ok(SearchOutcome {
+                results: Vec::new(),
+                errors: Vec::new(),
+            }),
+        });
+        assert!(
+            draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
+            "settle redraws to clear spinner"
+        );
+        assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
+        assert!(
+            !draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
+            "idle ticks stop drawing after settle"
+        );
+    }
+
+    #[test]
+    fn render_gate_transient_status_draws_until_it_clears() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        app.handle_event(AppEvent::Status("copied: edge01".into()));
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        assert!(buffer_text(&term).contains("copied: edge01"));
+
+        for _ in 0..9 {
+            assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
+            assert!(
+                draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
+                "ttl countdown redraws"
+            );
+        }
+
+        assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
+        assert!(
+            draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
+            "ttl expiry redraws once to clear"
+        );
+        assert!(!buffer_text(&term).contains("copied: edge01"));
+
+        assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
+        assert!(!draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+    }
+
+    #[test]
+    fn render_gate_preview_debounce_command_alone_does_not_redraw() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+        app.results = vec![result()];
+        app.view = vec![0];
+        app.selected = 0;
+        app.preview_dirty = true;
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        let commands = app.handle_event(AppEvent::PreviewTick);
+        assert!(matches!(
+            commands.as_slice(),
+            [AppCommand::LoadPreview {
+                kind: ObjectKind::Device,
+                id: 42
+            }]
+        ));
+        assert!(!draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+    }
+
+    #[test]
+    fn render_gate_async_result_events_redraw() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        app.handle_event(AppEvent::SearchComplete {
+            req: 0,
+            result: Ok(SearchOutcome {
+                results: vec![result()],
+                errors: Vec::new(),
+            }),
+        });
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        assert!(buffer_text(&term).contains("edge01"));
+    }
+
+    #[test]
+    fn render_gate_keypress_visible_change_redraws() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        assert!(app.handle_event(press(KeyCode::Tab)).is_empty());
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+    }
+
+    #[test]
+    fn render_gate_terminal_resize_redraws() {
+        let mut app = app();
+        let mut term = terminal();
+        let mut gate = RenderGate::default();
+
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+        assert!(!draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+
+        term.backend_mut().resize(100, 30);
+        assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -570,14 +570,20 @@ mod tests {
         assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
         assert!(buffer_text(&term).contains("copied: edge01"));
 
+        // Intermediate TTL ticks only decrement the (unrendered) countdown — the
+        // status text is unchanged, so the gate must NOT redraw, yet the status
+        // stays on screen (the last drawn frame still holds it).
         for _ in 0..9 {
             assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
             assert!(
-                draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
-                "ttl countdown redraws"
+                !draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),
+                "intermediate ttl ticks do not redraw"
             );
+            assert!(buffer_text(&term).contains("copied: edge01"));
         }
 
+        // The expiry tick clears the status: `self.status` empties (which IS
+        // hashed), so this redraws exactly once to wipe the message.
         assert!(app.handle_event(AppEvent::PreviewTick).is_empty());
         assert!(
             draw_if_dirty(&mut term, &mut app, &mut gate).unwrap(),

--- a/src/tui/cheese.rs
+++ b/src/tui/cheese.rs
@@ -20,6 +20,7 @@ use ratatui::widgets::Paragraph;
 use ratatui_cheese::input::{Input, InputState};
 use ratatui_cheese::spinner::{SpinnerState, SpinnerType};
 use ratatui_cheese::theme::Palette;
+use std::hash::{Hash, Hasher};
 
 use crate::tui::theme::Theme;
 
@@ -170,6 +171,15 @@ impl TextInput {
         } else {
             self.state.value().to_string()
         }
+    }
+
+    /// Feed the on-screen input state into a render signature. Masked fields hash
+    /// only their rendered bullets, never the secret value.
+    pub(crate) fn hash_render_state<H: Hasher>(&self, h: &mut H) {
+        self.rendered_text().hash(h);
+        self.placeholder.hash(h);
+        self.cursor_pos().hash(h);
+        self.masked.hash(h);
     }
 
     /// Apply a key to the input, mutating its text/cursor. PURE: no I/O, just a
@@ -511,6 +521,16 @@ impl FormInput {
             .iter()
             .map(|(label, input)| (label.clone(), input.rendered_text()))
             .collect()
+    }
+
+    /// Feed the visible form state into a render signature. Masked fields hash
+    /// their rendered text through [`TextInput::hash_render_state`].
+    pub(crate) fn hash_render_state<H: Hasher>(&self, h: &mut H) {
+        self.focus.hash(h);
+        for (label, input) in &self.fields {
+            label.hash(h);
+            input.hash_render_state(h);
+        }
     }
 
     /// Render the form into `area`, one labelled row per field, returning the

--- a/src/tui/config_modal.rs
+++ b/src/tui/config_modal.rs
@@ -21,6 +21,7 @@
 //! the modal unit-testable without a terminal or a network.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::hash::{Hash, Hasher};
 
 use crate::config::BackendPreference;
 use crate::netbox::auth::AuthScheme;
@@ -29,7 +30,7 @@ use crate::tui::theme::Theme;
 
 /// Which section of the Config modal is active. `Tab` switches sections at the
 /// Profiles list level and from the Settings form.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConfigSection {
     Profiles,
     Settings,
@@ -47,7 +48,7 @@ pub mod field {
 }
 
 /// The result of a test-connect attempt, shown in the form before committing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TestState {
     /// No test run yet for the current form contents.
     Idle,
@@ -394,6 +395,26 @@ impl ProfileForm {
         }
         Ok(())
     }
+
+    /// Feed the visible form state into a render signature. The token field is
+    /// masked by [`FormInput::hash_render_state`], so the raw token is not hashed.
+    fn hash_render_state<H: Hasher>(&self, h: &mut H) {
+        self.inputs.hash_render_state(h);
+        match self.auth_scheme {
+            AuthScheme::Auto => "auto",
+            AuthScheme::Bearer => "bearer",
+            AuthScheme::Token => "token",
+        }
+        .hash(h);
+        self.verify_tls.hash(h);
+        self.exclude_config_context.hash(h);
+        self.api_vrf.as_str().hash(h);
+        self.api_route_target.as_str().hash(h);
+        self.editing.hash(h);
+        self.test.hash(h);
+        self.message.hash(h);
+        self.clear_token.hash(h);
+    }
 }
 
 /// What the Profiles section is currently showing: the list, or an add/edit form,
@@ -430,7 +451,7 @@ impl ProfilesPane {
 }
 
 /// A single setting field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SettingId {
     /// `[ui].theme` — a cycle (Left/Right/Space), hot-applied live.
     Theme,
@@ -503,7 +524,7 @@ pub const SETTINGS_CATEGORIES: &[(&str, &[SettingId])] = &[
 ];
 
 /// Which pane of the two-pane Settings section holds focus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SettingsFocus {
     /// The left category list: `↑/↓` select, `→` enters the fields.
     Categories,
@@ -731,6 +752,27 @@ impl SettingsPane {
         self.api_route_target
     }
 
+    /// Feed the visible settings state into a render signature.
+    fn hash_render_state<H: Hasher>(&self, h: &mut H) {
+        self.focus.hash(h);
+        self.category.hash(h);
+        self.field.hash(h);
+        self.theme_index.hash(h);
+        self.theme_name().hash(h);
+        self.refresh.hash_render_state(h);
+        self.browser.hash_render_state(h);
+        self.log_level.hash_render_state(h);
+        self.log_file.hash_render_state(h);
+        self.cache_enabled.hash(h);
+        self.cache_ttl.hash_render_state(h);
+        self.page_size.hash_render_state(h);
+        self.timeout.hash_render_state(h);
+        self.exclude_config_context.hash(h);
+        self.api_vrf.as_str().hash(h);
+        self.api_route_target.as_str().hash(h);
+        self.message.hash(h);
+    }
+
     /// Cycle an api backend between `rest` and `graphql` (Left/Right/Space on its
     /// row). Two values, so any cycle key flips it.
     fn cycle_api(&mut self, id: SettingId) {
@@ -880,6 +922,29 @@ impl ConfigModal {
                 connection,
             ),
         }
+    }
+
+    /// Feed the on-screen modal state into a render signature.
+    pub(crate) fn hash_render_state<H: Hasher>(&self, h: &mut H) {
+        self.section.hash(h);
+        match &self.profiles.mode {
+            ProfilesMode::List { selected } => {
+                "profiles-list".hash(h);
+                selected.hash(h);
+            }
+            ProfilesMode::Form(form) => {
+                "profiles-form".hash(h);
+                form.hash_render_state(h);
+            }
+            ProfilesMode::ConfirmDelete { name, selected } => {
+                "profiles-confirm-delete".hash(h);
+                name.hash(h);
+                selected.hash(h);
+            }
+        }
+        self.profiles.message.hash(h);
+        self.profiles.last_selected.hash(h);
+        self.settings.hash_render_state(h);
     }
 }
 

--- a/src/tui/filter_modal.rs
+++ b/src/tui/filter_modal.rs
@@ -7,6 +7,7 @@
 //! "one scope at a time" is a UI invariant rather than a post-hoc error.
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::hash::{Hash, Hasher};
 
 use crate::netbox::search::SearchFilters;
 use crate::tui::cheese::TextInput;
@@ -133,6 +134,19 @@ impl FilterModal {
             }
         }
         f
+    }
+
+    /// Feed the on-screen modal state into a render signature.
+    pub(crate) fn hash_render_state<H: Hasher>(&self, h: &mut H) {
+        self.focus.hash(h);
+        self.scope_type.hash(h);
+        self.scope_type_label().hash(h);
+        self.status.hash_render_state(h);
+        self.scope_value.hash_render_state(h);
+        self.tenant.hash_render_state(h);
+        self.role.hash_render_state(h);
+        self.tag.hash_render_state(h);
+        self.vrf.hash_render_state(h);
     }
 
     fn focus_next(&mut self) {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -4,6 +4,8 @@
 //! they perform no I/O, so they're unit-testable without a terminal. Network
 //! work happens in spawned tasks (see `tui::app`), never in the render loop.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -78,7 +80,7 @@ impl RelatedModal {
 }
 
 /// Which screen is in the body area.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Screen {
     Home,
     Detail,
@@ -90,7 +92,7 @@ pub enum Screen {
 }
 
 /// Input mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Mode {
     Normal,
     Search,
@@ -104,7 +106,7 @@ pub enum Mode {
 /// Which pane of the three-pane home screen has focus. Movement keys route to it:
 /// Nav moves the section cursor, the list moves the selection, the preview scrolls
 /// its body. `Tab`/`Shift+Tab` cycle left→right (Nav → List → Preview).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Focus {
     Nav,
     List,
@@ -114,7 +116,7 @@ pub enum Focus {
 /// A section in the home Navigation pane: a browse-by-kind entry, or `Recent`.
 /// Selecting a kind lists all of it into the Results pane; `Recent` shows the
 /// recently-opened items. Search stays on `/` (not a nav entry).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NavSection {
     Devices,
     Prefixes,
@@ -953,6 +955,109 @@ impl App {
     /// Install the live read cache (called once by `run_tui` after connecting).
     pub fn set_cache(&mut self, cache: Cache) {
         self.cache = cache;
+    }
+
+    /// Conservative digest of everything the renderer can put on screen, plus the
+    /// terminal size. The event loop uses this as a redraw gate; over-inclusion is
+    /// intentional because an unnecessary redraw is harmless, while omitting a
+    /// visible field could freeze stale pixels.
+    pub(crate) fn render_digest(&self, terminal_size: (u16, u16)) -> u64 {
+        let mut h = DefaultHasher::new();
+        terminal_size.hash(&mut h);
+        self.theme.name().hash(&mut h);
+        self.theme.is_no_color().hash(&mut h);
+        self.profile_name.hash(&mut h);
+        self.base_url.hash(&mut h);
+        self.netbox_version.hash(&mut h);
+        self.pending_profile.hash(&mut h);
+        self.refresh_secs.hash(&mut h);
+        self.open_browser_command.hash(&mut h);
+        self.log_level.hash(&mut h);
+        self.log_file.hash(&mut h);
+        for profile in &self.profiles {
+            profile.name.hash(&mut h);
+            profile.config.url.hash(&mut h);
+        }
+        self.profile_index.hash(&mut h);
+
+        self.mode.hash(&mut h);
+        self.screen.hash(&mut h);
+        self.focus.hash(&mut h);
+        self.nav_selected.hash(&mut h);
+        self.browse_kind.hash(&mut h);
+        self.last_browsed.hash(&mut h);
+        self.last_query.hash(&mut h);
+        self.browse_filter.hash(&mut h);
+        hash_filters(&self.filters, &mut h);
+        self.search_input.hash_render_state(&mut h);
+        self.command_input.hash_render_state(&mut h);
+        self.filter_input.hash_render_state(&mut h);
+
+        self.status.hash(&mut h);
+        severity_key(self.status_severity).hash(&mut h);
+        self.status_ttl.hash(&mut h);
+        self.pending.hash(&mut h);
+        if self.loading() {
+            self.spinner.frame().hash(&mut h);
+        }
+        if let Some(f) = self.detail_freshness {
+            freshness_source_key(f.source).hash(&mut h);
+            f.age.hash(&mut h);
+        }
+        self.update_available.hash(&mut h);
+        self.update_command.hash(&mut h);
+
+        hash_nav_counts(&self.nav_counts, &mut h);
+        hash_results(&self.results, &mut h);
+        self.view.hash(&mut h);
+        self.selected.hash(&mut h);
+        hash_recents(&self.recent, &mut h);
+        self.pending_reselect.hash(&mut h);
+
+        hash_detail(self.detail.as_ref(), &mut h);
+        self.detail_tab.hash(&mut h);
+        self.detail_row.hash(&mut h);
+        self.detail_scroll.hash(&mut h);
+        self.detail_nav.hash(&mut h);
+        hash_detail(self.preview.as_ref(), &mut h);
+        self.preview_for.hash(&mut h);
+        self.preview_scroll.hash(&mut h);
+
+        hash_dashboard(self.dashboard.as_ref(), &mut h);
+        self.dashboard_error.hash(&mut h);
+        hash_prefix_tree(
+            self.prefix_tree.as_ref(),
+            &self.prefix_tree_collapsed,
+            &mut h,
+        );
+        self.prefix_tree_error.hash(&mut h);
+        self.prefix_tree_selected.hash(&mut h);
+
+        match &self.modal {
+            Some(Modal::Help) => "modal-help".hash(&mut h),
+            Some(Modal::Config(modal)) => {
+                "modal-config".hash(&mut h);
+                modal.hash_render_state(&mut h);
+            }
+            Some(Modal::Filter(modal)) => {
+                "modal-filter".hash(&mut h);
+                modal.hash_render_state(&mut h);
+            }
+            Some(Modal::Related(modal)) => {
+                "modal-related".hash(&mut h);
+                modal.selected.hash(&mut h);
+                for link in &modal.links {
+                    link.kind.hash(&mut h);
+                    link.id.hash(&mut h);
+                    link.relation.hash(&mut h);
+                    link.label.hash(&mut h);
+                }
+            }
+            None => "modal-none".hash(&mut h),
+        }
+
+        self.should_quit.hash(&mut h);
+        h.finish()
     }
 
     /// Apply an event, returning any commands to dispatch. The commands handed
@@ -4007,6 +4112,138 @@ fn object_web_url(base_url: &str, kind: ObjectKind, id: u64) -> String {
             |_| format!("{}/{path}", base_url.trim_end_matches('/')),
             |url| url.to_string(),
         )
+}
+
+fn severity_key(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Info => "info",
+        Severity::Success => "success",
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+    }
+}
+
+fn freshness_source_key(source: crate::cache::Source) -> &'static str {
+    match source {
+        crate::cache::Source::Origin => "origin",
+        crate::cache::Source::Cache => "cache",
+    }
+}
+
+fn hash_filters<H: Hasher>(filters: &SearchFilters, h: &mut H) {
+    filters.status.hash(h);
+    filters.site.hash(h);
+    filters.region.hash(h);
+    filters.site_group.hash(h);
+    filters.location.hash(h);
+    filters.tenant.hash(h);
+    filters.role.hash(h);
+    filters.tag.hash(h);
+    filters.vrf.hash(h);
+}
+
+fn hash_nav_counts<H: Hasher>(counts: &std::collections::HashMap<ObjectKind, u32>, h: &mut H) {
+    let mut pairs: Vec<_> = counts.iter().collect();
+    pairs.sort_by_key(|(kind, _)| kind.as_str());
+    for (kind, count) in pairs {
+        kind.hash(h);
+        count.hash(h);
+    }
+}
+
+fn hash_results<H: Hasher>(results: &[SearchResult], h: &mut H) {
+    results.len().hash(h);
+    for result in results {
+        result.kind.hash(h);
+        result.id.hash(h);
+        result.display.hash(h);
+        result.subtitle.hash(h);
+        result.url.hash(h);
+        result.score.hash(h);
+    }
+}
+
+fn hash_recents<H: Hasher>(recent: &[RecentItem], h: &mut H) {
+    recent.len().hash(h);
+    for item in recent {
+        item.kind.hash(h);
+        item.id.hash(h);
+        item.title.hash(h);
+    }
+}
+
+fn hash_detail<H: Hasher>(detail: Option<&DetailView>, h: &mut H) {
+    let Some(detail) = detail else {
+        "detail-none".hash(h);
+        return;
+    };
+    detail.kind.hash(h);
+    detail.id.hash(h);
+    detail.title.hash(h);
+    detail.body.hash(h);
+    detail.header.hash(h);
+    detail.summary_label.hash(h);
+    hash_detail_rows(&detail.summary_rows, h);
+    for tab in &detail.tabs {
+        tab.key.hash(h);
+        tab.label.hash(h);
+        tab.body.hash(h);
+        hash_detail_rows(&tab.rows, h);
+    }
+    for link in &detail.links {
+        link.kind.hash(h);
+        link.id.hash(h);
+        link.relation.hash(h);
+        link.label.hash(h);
+    }
+}
+
+fn hash_detail_rows<H: Hasher>(rows: &[DetailRow], h: &mut H) {
+    rows.len().hash(h);
+    for row in rows {
+        row.text.hash(h);
+        row.target.hash(h);
+    }
+}
+
+fn hash_dashboard<H: Hasher>(dashboard: Option<&DashboardData>, h: &mut H) {
+    let Some(dashboard) = dashboard else {
+        "dashboard-none".hash(h);
+        return;
+    };
+    dashboard.device_total.hash(h);
+    dashboard.device_status_counts.hash(h);
+    dashboard.top_prefixes.hash(h);
+    for row in &dashboard.recent {
+        row.created.hash(h);
+        row.kind.hash(h);
+        row.summary.hash(h);
+    }
+}
+
+fn hash_prefix_tree<H: Hasher>(
+    tree: Option<&PrefixTreeData>,
+    collapsed: &std::collections::HashSet<u64>,
+    h: &mut H,
+) {
+    let Some(tree) = tree else {
+        "prefix-tree-none".hash(h);
+        return;
+    };
+    tree.total.hash(h);
+    for node in &tree.nodes {
+        node.id.hash(h);
+        node.prefix.hash(h);
+        node.vrf.hash(h);
+        node.status.hash(h);
+        node.depth.hash(h);
+        node.children.hash(h);
+        node.utilization.hash(h);
+        node.description.hash(h);
+    }
+    let mut collapsed: Vec<_> = collapsed.iter().copied().collect();
+    collapsed.sort_unstable();
+    collapsed.hash(h);
 }
 
 /// Classify a free-form status message (typically pushed from an async task,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -995,7 +995,12 @@ impl App {
 
         self.status.hash(&mut h);
         severity_key(self.status_severity).hash(&mut h);
-        self.status_ttl.hash(&mut h);
+        // `status_ttl` is deliberately NOT hashed: it counts a transient status
+        // down but is never rendered (no on-screen countdown), so hashing it would
+        // force a redraw every tick of the status window with no visible change.
+        // The expiry redraw still fires — clearing the TTL empties `self.status`,
+        // which IS hashed above. If a future UI shows a TTL-derived value (a fade
+        // or countdown), hash that derived visible value here instead.
         self.pending.hash(&mut h);
         if self.loading() {
             self.spinner.frame().hash(&mut h);


### PR DESCRIPTION
## What

Two independent perf wins from the ROADMAP perf-candidates list, verified together.

### 1. TUI render-signature redraw gate

The event loop drew on every iteration — and the always-on 180ms `PreviewTick` (~5.5 Hz) meant a full `render_home_list` rebuild (`Vec<Row>` clone + `format!`) **even when nothing visible changed**. The loop now skips `terminal.draw` when a conservative render signature is unchanged.

- **`App::render_digest((w,h))`** hashes everything the renderer can put on screen plus the terminal size. **Over-inclusion is deliberate**: an extra redraw is harmless, while omitting a visible field would freeze stale pixels. The two hashed collections (`nav_counts`, prefix-tree collapsed set) are **sorted first** for a stable digest.
- **`RenderGate`** in `app.rs` stores the last drawn signature; `draw_if_dirty` is generic over `B: Backend` so tests drive it with `TestBackend`. `record_drawn` runs **post-draw**, so the stored signature matches an actually-clamped frame.
- **No render loop**: `ui::render` mutates only viewports + idempotent clamps (`x.min(bound)`), so it settles in one frame and never oscillates.
- **No secret leak**: masked input fields hash their rendered bullets (`rendered_text()`), never the raw token; `cursor_pos()` is hashed so arrow-key moves still redraw. Config/Filter modals feed the digest through their own `hash_render_state`.
- **Signature = "can pixels change", not "did state change"**: `status_ttl` is *not* hashed. It counts a transient status down but is never rendered, so hashing it would redraw every tick of the ~1.8s status window with no visible change. The expiry redraw still fires — clearing the TTL empties `self.status`, which *is* hashed. (If a future UI shows a TTL-derived value — countdown/fade — hash that derived visible value instead.)

The tick still drives debounce, status expiry, and the spinner — those paths still redraw. 8 `TestBackend` tests cover: idle-skip, spinner-while-loading-then-settle, transient-status (intermediate ticks don't redraw, status stays visible, expiry redraws once to clear), debounce-emits-command-no-redraw, async-result, keypress, resize, initial draw.

### 2. VLAN detail fan-out

`vlan_prefixes` and the VLAN group's scope are independent, so they now run under `tokio::try_join!` across all three paths (shared `vlan_view_by_ref`, TUI `load_detail` by-id, `load_detail_by_ref` by-ref) — one fewer round trip when a VLAN has both, same view shape. Mirrors the prefix-detail fix. The MCP vlan test now mocks the `vlan-groups/{id}/` follow-up and asserts `group_scope`/`group_scope_type`, pinning that the concurrency doesn't drop the enrichment.

## Verification

- **Gate (local):** `fmt` clean; `clippy --all-targets` clean on `--all-features` *and* `--no-default-features`; **1134** all-features / **1039** no-default tests pass, 0 failed.
- `VlanView::build(...)` is unchanged → VLAN output is byte-identical; the gate only changes *when* the existing render runs, not *what* it produces.