### PR TITLE
feat(tui): OSC 52 clipboard for SSH/headless terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the supplied arguments. Zero live dependency — a prompt is a plan, not data;
   the agent runs the plan against the tools. `enable_prompts()` capability
   advertised.
+- **TUI copy over SSH/headless terminals.** On non-macOS Unix with no graphical
+  display, the `y` copy action now emits OSC 52 so the local terminal can write
+  the local clipboard through the terminal stream. macOS, Windows, and desktop
+  sessions still try `arboard`'s native clipboard first, with OSC 52 as a
+  fallback if that call fails.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ serde = { version = "1", features = ["derive"] }
 # cycling follows the config file, not alphabetical). Already in the tree.
 indexmap = { version = "2", features = ["serde"] }
 serde_json = "1"
+# OSC 52 clipboard payloads are base64-encoded for terminal/SSH clipboard
+# integration.
+base64 = "0.22"
 # JSON Schema derivation for MCP tool output schemas. Pinned to the exact
 # version rmcp 1.7 depends on so `Json<T>` accepts our `JsonSchema` types
 # (the trait bound is satisfied only by that one schemars instance).
@@ -143,7 +146,6 @@ wiremock = "0.6"
 # `rand` 0.8 supplies the RNG for keygen (matches `rsa`'s `rand_core` 0.6).
 rsa = { version = "0.9", features = ["pem"] }
 rand = "0.8"
-base64 = "0.22"
 
 # Lints apply to every target of the package — lib, bin, AND the integration
 # test crates in tests/ (each its own crate). A `[lints]` table is the only way

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ are no feature-variant builds to choose between.
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `clipboard` | Yes | Copy values with `y` in the TUI (via `arboard`) |
+| `clipboard` | Yes | Copy values with `y` in the TUI (desktop clipboard via `arboard`; SSH/headless fallback via OSC 52) |
 | `http` | Yes | `nbox serve --http` loopback MCP transport (+ OIDC) |
 | `updates` | Yes | GitHub update notifications |
 
@@ -335,7 +335,7 @@ auth/permission (401/403), `4` not found, `5` ambiguous reference. See
 | `PgUp` / `PgDn` | page up / down |
 | `Enter` | open selected object |
 | `o` | open in browser |
-| `y` | copy current item label |
+| `y` | copy current item label (desktop clipboard, or OSC 52 over SSH/headless terminals) |
 | `R` | related objects (jump between connected objects) |
 | `D` | overview dashboard |
 | `T` | prefix tree (`Space` / `←` / `→` collapse/expand) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,14 +115,15 @@ Polish the read experience. No writes here.
   parent-prefix enrichment as a best-effort longest match, and name lookups resolving exact-then-contains
   — are **by design** (surfacing ambiguity over guessing), acknowledged here, not tracked for a fix._
 - ☐ **Demo recording** — an asciinema/VHS cast for the README.
-- ☐ **Headless/SSH clipboard (OSC 52).** `y`-copy uses `arboard`, which only speaks X11/Wayland — over
-  SSH with no display forwarding it waits out the X11 connection timeout, then fails with a cryptic error
-  (the copy runs on a spawned task, so the UI doesn't freeze, but nothing reaches a clipboard). Fix: when
-  no `$DISPLAY`/`$WAYLAND_DISPLAY` is set, skip `arboard` and emit an OSC 52 escape
-  (`ESC ]52;c;<base64>BEL`) so the *local* terminal writes the *local* clipboard over the SSH stream; keep
-  `arboard` when a display is present, and fall back to OSC 52 on an `arboard` error rather than surfacing
-  the X11 message. Document the caveats (tmux needs `set -g set-clipboard on`; some terminals disable OSC
-  52) and keep the status honest ("copied via terminal").
+- ☑ **Headless/SSH clipboard (OSC 52).** On Linux/Unix X11+Wayland sessions, `y`-copy uses `arboard`;
+  over SSH with no display forwarding it waits out the X11 connection timeout, then fails with a
+  cryptic error (the copy runs on a spawned task, so the UI doesn't freeze, but nothing reaches a
+  clipboard). Fix: on non-macOS Unix with no `$DISPLAY`/`$WAYLAND_DISPLAY`, skip `arboard` and emit an
+  OSC 52 escape (`ESC ]52;c;<base64>BEL`) so the *local* terminal writes the *local* clipboard over the
+  SSH stream. macOS and Windows still try `arboard`'s native desktop backends first; any `arboard` error
+  falls back to OSC 52 rather than surfacing the X11 message. Document the caveats (tmux needs
+  `set -g set-clipboard on`; some terminals disable OSC 52) and keep the status honest ("copied via
+  terminal").
 - ☑ **Interface journal + `nbox_get interface`.** Interfaces are now a
   first-class `GetKind::Interface` in both `nbox_get` (MCP + resource) and the
   journal resolver, so `nbox journal interface <device>/<name>` and `nbox_get`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -156,6 +156,18 @@ usage error (exit 2) instead of blocking, and call an explicit subcommand:
 nbox --no-tui device edge01       # never drops into the TUI
 ```
 
+### TUI copy over SSH does not reach the clipboard
+
+On non-macOS Unix, when no graphical display is available
+(`DISPLAY`/`WAYLAND_DISPLAY` are unset), the TUI `y` copy action uses OSC 52 so
+the local terminal can write the local clipboard through the SSH stream. macOS
+and Windows still try their native desktop clipboards first. Some terminals
+disable OSC 52, and tmux needs clipboard passthrough enabled, for example:
+
+```tmux
+set -g set-clipboard on
+```
+
 ### `… is ambiguous — matches: …` (exit 5)
 
 The reference matched several objects. Disambiguate with the right scope flag —

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,8 +1,11 @@
 //! TUI entry point and event loop.
 
 use anyhow::Result;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use ratatui::backend::Backend;
 use ratatui::{DefaultTerminal, Terminal};
+use std::io::Write;
 use tokio::sync::mpsc;
 
 use crate::cache::{Cache, CacheKey};
@@ -116,7 +119,13 @@ async fn event_loop(
         let Some(event) = rx.recv().await else { break };
         // Never await network here — dispatch each command on its own task,
         // which posts results back as AppEvents.
-        for command in app.handle_event(event) {
+        let commands = match event {
+            AppEvent::CopyViaTerminal(text) => {
+                app.handle_event(AppEvent::Status(copy_via_terminal_status(&text)))
+            }
+            event => app.handle_event(event),
+        };
+        for command in commands {
             // `ArmRefresh` re-arms the ticker in place (it owns no client/network):
             // abort the old task and spawn one at the new interval. Everything else
             // is side-effecting work spawned off the render thread.
@@ -362,13 +371,7 @@ fn dispatch(command: AppCommand, client: NetBoxClient, cache: Cache, tx: mpsc::S
             });
         }
         AppCommand::Copy(text) => {
-            tokio::spawn(async move {
-                let message = match copy_to_clipboard(&text) {
-                    Ok(()) => format!("copied: {text}"),
-                    Err(e) => format!("copy failed: {e}"),
-                };
-                let _ = tx.send(AppEvent::Status(message)).await;
-            });
+            dispatch_copy(text, tx);
         }
         AppCommand::SwitchProfile {
             id,
@@ -438,15 +441,136 @@ async fn reconnect(
 }
 
 #[cfg(feature = "clipboard")]
-fn copy_to_clipboard(text: &str) -> Result<()> {
-    let mut clipboard = arboard::Clipboard::new()?;
-    clipboard.set_text(text.to_string())?;
-    Ok(())
+fn dispatch_copy(text: String, tx: mpsc::Sender<AppEvent>) {
+    let env = ClipboardEnv::from_process();
+    if should_skip_desktop_clipboard(ClipboardPlatform::CURRENT, &env) {
+        send_status(&tx, copy_via_terminal_status(&text));
+        return;
+    }
+
+    tokio::spawn(async move {
+        let message = match copy_to_desktop_clipboard(&text) {
+            Ok(()) => CopyMethod::System.status_message(&text),
+            Err(e) => {
+                tracing::debug!("desktop clipboard failed; falling back to OSC 52: {e:#}");
+                let _ = tx.send(AppEvent::CopyViaTerminal(text)).await;
+                return;
+            }
+        };
+        let _ = tx.send(AppEvent::Status(message)).await;
+    });
 }
 
 #[cfg(not(feature = "clipboard"))]
-fn copy_to_clipboard(_text: &str) -> Result<()> {
-    anyhow::bail!("clipboard support was not built in (enable the `clipboard` feature)")
+fn dispatch_copy(text: String, tx: mpsc::Sender<AppEvent>) {
+    send_status(&tx, copy_via_terminal_status(&text));
+}
+
+#[cfg(feature = "clipboard")]
+fn copy_to_desktop_clipboard(text: &str) -> Result<()> {
+    arboard::Clipboard::new()
+        .and_then(|mut c| c.set_text(text.to_string()))
+        .map_err(Into::into)
+}
+
+fn send_status(tx: &mpsc::Sender<AppEvent>, message: String) {
+    if let Err(e) = tx.try_send(AppEvent::Status(message)) {
+        tracing::debug!("dropping clipboard status; event queue is full or closed: {e}");
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CopyMethod {
+    #[cfg(feature = "clipboard")]
+    System,
+    Terminal,
+}
+
+impl CopyMethod {
+    fn status_message(self, text: &str) -> String {
+        #[cfg(not(feature = "clipboard"))]
+        let _ = text;
+        match self {
+            #[cfg(feature = "clipboard")]
+            Self::System => format!("copied: {text}"),
+            Self::Terminal => format!("copied via terminal: {text}"),
+        }
+    }
+}
+
+#[cfg(any(feature = "clipboard", test))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ClipboardEnv {
+    display: Option<String>,
+    wayland_display: Option<String>,
+}
+
+#[cfg(any(feature = "clipboard", test))]
+impl ClipboardEnv {
+    #[cfg(feature = "clipboard")]
+    fn from_process() -> Self {
+        Self {
+            display: std::env::var("DISPLAY").ok().filter(|s| !s.is_empty()),
+            wayland_display: std::env::var("WAYLAND_DISPLAY")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        }
+    }
+
+    fn has_graphical_display(&self) -> bool {
+        self.display.is_some() || self.wayland_display.is_some()
+    }
+}
+
+#[cfg(any(feature = "clipboard", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClipboardPlatform {
+    /// arboard needs an X11/Wayland display on Linux and other non-macOS Unix
+    /// backends; without one, skip the X11 timeout and use OSC 52.
+    #[cfg(any(test, all(unix, not(target_os = "macos"))))]
+    X11WaylandUnix,
+    /// macOS and Windows use native pasteboards and do not depend on DISPLAY.
+    #[cfg(any(test, not(all(unix, not(target_os = "macos")))))]
+    NativeDesktop,
+}
+
+#[cfg(feature = "clipboard")]
+impl ClipboardPlatform {
+    #[cfg(all(unix, not(target_os = "macos")))]
+    const CURRENT: Self = Self::X11WaylandUnix;
+    #[cfg(not(all(unix, not(target_os = "macos"))))]
+    const CURRENT: Self = Self::NativeDesktop;
+}
+
+#[cfg(any(feature = "clipboard", test))]
+fn should_skip_desktop_clipboard(platform: ClipboardPlatform, env: &ClipboardEnv) -> bool {
+    match platform {
+        #[cfg(any(test, all(unix, not(target_os = "macos"))))]
+        ClipboardPlatform::X11WaylandUnix => !env.has_graphical_display(),
+        #[cfg(any(test, not(all(unix, not(target_os = "macos")))))]
+        ClipboardPlatform::NativeDesktop => false,
+    }
+}
+
+fn copy_via_terminal(text: &str) -> Result<CopyMethod> {
+    write_osc52(text, &mut std::io::stdout())?;
+    Ok(CopyMethod::Terminal)
+}
+
+fn copy_via_terminal_status(text: &str) -> String {
+    match copy_via_terminal(text) {
+        Ok(method) => method.status_message(text),
+        Err(e) => format!("copy failed: {e}"),
+    }
+}
+
+fn write_osc52(text: &str, out: &mut impl Write) -> std::io::Result<()> {
+    out.write_all(osc52_sequence(text).as_bytes())?;
+    out.flush()
+}
+
+fn osc52_sequence(text: &str) -> String {
+    format!("\x1b]52;c;{}\x07", BASE64_STANDARD.encode(text.as_bytes()))
 }
 
 #[cfg(test)]
@@ -659,5 +783,87 @@ mod tests {
 
         term.backend_mut().resize(100, 30);
         assert!(draw_if_dirty(&mut term, &mut app, &mut gate).unwrap());
+    }
+
+    #[test]
+    fn clipboard_env_detects_graphical_display() {
+        assert!(
+            !ClipboardEnv {
+                display: None,
+                wayland_display: None,
+            }
+            .has_graphical_display()
+        );
+        assert!(
+            ClipboardEnv {
+                display: Some(":0".into()),
+                wayland_display: None,
+            }
+            .has_graphical_display()
+        );
+        assert!(
+            ClipboardEnv {
+                display: None,
+                wayland_display: Some("wayland-0".into()),
+            }
+            .has_graphical_display()
+        );
+    }
+
+    #[test]
+    fn desktop_clipboard_skip_is_linux_x11_wayland_only() {
+        let headless = ClipboardEnv {
+            display: None,
+            wayland_display: None,
+        };
+        let x11 = ClipboardEnv {
+            display: Some(":0".into()),
+            wayland_display: None,
+        };
+        let wayland = ClipboardEnv {
+            display: None,
+            wayland_display: Some("wayland-0".into()),
+        };
+
+        assert!(should_skip_desktop_clipboard(
+            ClipboardPlatform::X11WaylandUnix,
+            &headless
+        ));
+        assert!(!should_skip_desktop_clipboard(
+            ClipboardPlatform::X11WaylandUnix,
+            &x11
+        ));
+        assert!(!should_skip_desktop_clipboard(
+            ClipboardPlatform::X11WaylandUnix,
+            &wayland
+        ));
+        assert!(!should_skip_desktop_clipboard(
+            ClipboardPlatform::NativeDesktop,
+            &headless
+        ));
+    }
+
+    #[test]
+    fn osc52_sequence_encodes_clipboard_payload() {
+        assert_eq!(osc52_sequence("edge01"), "\u{1b}]52;c;ZWRnZTAx\u{7}");
+        assert_eq!(
+            osc52_sequence("device edge99"),
+            "\u{1b}]52;c;ZGV2aWNlIGVkZ2U5OQ==\u{7}"
+        );
+    }
+
+    #[test]
+    fn write_osc52_writes_and_flushes_the_sequence() {
+        let mut out = Vec::new();
+        write_osc52("edge01", &mut out).unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), osc52_sequence("edge01"));
+    }
+
+    #[test]
+    fn terminal_copy_status_is_honest() {
+        assert_eq!(
+            CopyMethod::Terminal.status_message("edge01"),
+            "copied via terminal: edge01"
+        );
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -268,6 +268,9 @@ pub enum AppEvent {
     /// is available (drives the TUI banner), `None` when up to date or the check
     /// was skipped. Fired at most once per session.
     UpdateAvailable(Option<String>),
+    /// Internal event-loop request to write OSC 52 bytes on the same thread as
+    /// terminal draws, avoiding interleaved stdout writes from worker tasks.
+    CopyViaTerminal(String),
     Status(String),
 }
 
@@ -1439,6 +1442,7 @@ impl App {
                 self.nav_counts = counts.into_iter().collect();
                 Vec::new()
             }
+            AppEvent::CopyViaTerminal(_) => Vec::new(),
             AppEvent::Status(message) => {
                 // An async status push (e.g. "copied …"/"opened …"): classify it
                 // so confirmations and failures still get the right color.


### PR DESCRIPTION
## What

`y`-copy used `arboard`, which on Unix only speaks X11/Wayland. Over SSH with no display forwarding it waits out the X11 connection timeout and then fails with a cryptic error — nothing reaches a clipboard. This adds an OSC 52 path so copy works over SSH and on headless terminals.

## Behavior by platform

| Platform | Primary | Fallback |
|----------|---------|----------|
| Linux / non-macOS Unix, **with** `$DISPLAY`/`$WAYLAND_DISPLAY` | `arboard` (native) | OSC 52 on error |
| Linux / non-macOS Unix, **no** display (SSH/headless) | **OSC 52** (skips arboard + its X11 timeout) | — |
| macOS / Windows | `arboard` (native pasteboard; DISPLAY-agnostic) | OSC 52 on error |
| `--no-default-features` (no `clipboard`) | **OSC 52** | — |

OSC 52 (`ESC ]52;c;<base64>BEL`) is written to the terminal stream, so the *local* terminal — not a remote X server — writes the *local* clipboard.

## Correctness: no stdout race

OSC 52 bytes are written **only on the event-loop thread**, never from a spawned task:
- the headless skip writes synchronously inside `dispatch` (loop thread);
- the native-error fallback round-trips through a new internal `AppEvent::CopyViaTerminal`, intercepted in the loop *before* `handle_event`.

So the escape is serialized with `terminal.draw` and the two can't interleave on stdout (crossterm flushes the frame; `write_osc52` flushes after). OSC 52 doesn't move the cursor or draw cells, so ratatui's next diff is unaffected.

## Notes

- Status stays honest: `copied: <v>` (native) vs `copied via terminal: <v>` (OSC 52).
- **Known edge:** detection keys on `DISPLAY`/`WAYLAND_DISPLAY` (an X11/Wayland concept), so SSH-into-a-Mac can't be distinguished — arboard succeeds to the *remote* Mac's pasteboard rather than falling back to OSC 52. Deliberate (Terminal.app's OSC 52 is unreliable; SSH-into-Mac-TUI is rare); `SSH_CONNECTION` could close it later if wanted.
- `base64` moves dev-dep → runtime dep (now used in non-test code).

## Verification

- Platform-conditional logic is unit-tested **cross-platform** via a `cfg(any(feature = "clipboard", test))` gate: display detection, the skip decision, OSC 52 encoding, and the buffered write. 5 new tests, present in both feature modes.
- `fmt` clean; `clippy --all-targets` clean on `--all-features` **and** `--no-default-features`; **1139** all-features / **1044** no-default tests pass, 0 failed.

## Docs

README (feature table + keymap), CHANGELOG (`Added`), ROADMAP (item ☑), and a `docs/TROUBLESHOOTING.md` entry covering the tmux `set -g set-clipboard on` caveat.