### PR TITLE
ci: split PR gate into parallel named checks + scheduled supply-chain

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,13 @@
 ## Checklist
 
 - [ ] `cargo fmt --all -- --check`
-- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (and `--no-default-features`)
-- [ ] `cargo test --all-features`
+- [ ] `cargo clippy --all-targets --all-features --locked -- -D warnings`
+- [ ] `cargo clippy --all-targets --no-default-features --locked -- -D warnings`
+- [ ] `cargo test --all-features --locked`
+- [ ] `cargo test --no-default-features --locked`
+- [ ] Generated man pages / shell completions still work if CLI flags changed
+- [ ] Live NetBox impact considered if API/query/detail behavior changed
+- [ ] `cargo audit` / dependency policy considered if dependencies changed
 - [ ] Docs updated, and the kind / tool / keybinding lists kept in sync (if the surface changed)
 - [ ] `CHANGELOG.md` `[Unreleased]` updated (user-facing or breaking changes)
 - [ ] No secrets or internal-only references included

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,17 @@ on:
     paths-ignore:
       - '**.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  check:
-    name: fmt · clippy · build · test
+  fmt:
+    name: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -25,34 +29,77 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy-all-features:
+    name: clippy-all-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
 
-      - name: Format
-        run: cargo fmt --all -- --check
+      - name: Clippy (all features)
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+  clippy-no-default-features:
+    name: clippy-no-default-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Clippy (no default features)
-        run: cargo clippy --all-targets --no-default-features -- -D warnings
+        run: cargo clippy --all-targets --no-default-features --locked -- -D warnings
 
-      - name: Build
-        run: cargo build --all-features --verbose
+  test-all-features:
+    name: test-all-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
 
-      - name: Build (no default features)
-        run: cargo build --no-default-features --verbose
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Test
-        run: cargo test --all-features --verbose
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Test (all features)
+        run: cargo test --all-features --locked --verbose
+
+  test-no-default-features:
+    name: test-no-default-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
 
       - name: Test (no default features)
-        run: cargo test --no-default-features --verbose
+        run: cargo test --no-default-features --locked --verbose
 
-  msrv:
-    name: MSRV (1.88)
+  msrv-check:
+    name: msrv-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -67,3 +114,92 @@ jobs:
 
       - name: Check (all features, locked)
         run: cargo check --all-features --locked
+
+  generated-artifacts:
+    name: generated-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build nbox
+        run: cargo build --all-features --locked --verbose
+
+      - name: Generate man pages and shell completions
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/generated"
+          mkdir -p "$out/completions" "$out/man"
+          ./target/debug/nbox man "$out/man"
+          ./target/debug/nbox completions bash > "$out/completions/nbox.bash"
+          ./target/debug/nbox completions zsh > "$out/completions/_nbox"
+          ./target/debug/nbox completions fish > "$out/completions/nbox.fish"
+          ./target/debug/nbox completions powershell > "$out/completions/_nbox.ps1"
+          ./target/debug/nbox completions elvish > "$out/completions/nbox.elv"
+          test -s "$out/man/nbox.1"
+          test -s "$out/completions/nbox.bash"
+
+  security-audit:
+    name: security-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-audit
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-0.21
+
+      - name: Install cargo-audit
+        run: command -v cargo-audit || cargo install cargo-audit --locked
+
+      - name: Run security audit
+        run: cargo audit
+
+  platform-build:
+    name: platform-build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            install_musl: true
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            install_musl: false
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            install_musl: false
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            install_musl: false
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install musl tools
+        if: matrix.install_musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build target
+        run: cargo build --all-features --locked --target ${{ matrix.target }} --verbose

--- a/.github/workflows/netbox-integration.yml
+++ b/.github/workflows/netbox-integration.yml
@@ -19,6 +19,14 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  schedule:
+    # Nightly compatibility drift check for the pinned NetBox lines below.
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -60,14 +68,26 @@ jobs:
       # Always surface NetBox logs on failure to debug a flaky boot/seed.
       - name: Dump NetBox logs on failure
         if: failure()
-        run: docker compose -f tests/integration/docker-compose.yml logs --no-color netbox
+        shell: bash
+        run: |
+          mkdir -p .ci-logs
+          docker compose -f tests/integration/docker-compose.yml logs --no-color netbox \
+            | tee .ci-logs/netbox-4.2.log
+
+      - name: Upload NetBox logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: netbox-4.2-logs
+          path: .ci-logs/*.log
+          if-no-files-found: ignore
 
       - name: Tear down
         if: always()
         run: docker compose -f tests/integration/docker-compose.yml down -v
 
   netbox-45-graphql:
-    name: live NetBox 4.5 GraphQL search
+    name: live NetBox 4.5 GraphQL backend
     runs-on: ubuntu-latest
     env:
       NETBOX_IMAGE: netboxcommunity/netbox:v4.5.10-4.0.2
@@ -103,7 +123,75 @@ jobs:
 
       - name: Dump NetBox logs on failure
         if: failure()
-        run: docker compose -f tests/integration/docker-compose.yml logs --no-color netbox
+        shell: bash
+        run: |
+          mkdir -p .ci-logs
+          docker compose -f tests/integration/docker-compose.yml logs --no-color netbox \
+            | tee .ci-logs/netbox-4.5.log
+
+      - name: Upload NetBox logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: netbox-4.5-logs
+          path: .ci-logs/*.log
+          if-no-files-found: ignore
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f tests/integration/docker-compose.yml down -v
+
+  netbox-46-compat:
+    name: live NetBox 4.6 compatibility
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      NETBOX_IMAGE: netboxcommunity/netbox:v4.6.2
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build nbox
+        run: cargo build --all-features --verbose
+
+      - name: Boot NetBox 4.6 fixture
+        run: docker compose -f tests/integration/docker-compose.yml up -d
+
+      - name: Wait for NetBox 4.6 to finish first boot
+        run: NETBOX_READY_HTTP_CODES=200,403 ./tests/integration/wait-for-ready.sh 420
+
+      - name: Resolve NetBox 4.6 API token
+        run: echo "NETBOX_TOKEN=$(./tests/integration/resolve-token.sh)" >> "$GITHUB_ENV"
+
+      - name: Wait for NetBox to be ready
+        run: ./tests/integration/wait-for-ready.sh 60
+
+      - name: Seed the fixture
+        run: ./tests/integration/seed.py
+
+      - name: Run gated compatibility tests
+        run: cargo test --test it_netbox -- --ignored --test-threads=1 --skip status_reports_netbox_4_2
+
+      - name: Dump NetBox logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          mkdir -p .ci-logs
+          docker compose -f tests/integration/docker-compose.yml logs --no-color netbox \
+            | tee .ci-logs/netbox-4.6.log
+
+      - name: Upload NetBox logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: netbox-4.6-logs
+          path: .ci-logs/*.log
+          if-no-files-found: ignore
 
       - name: Tear down
         if: always()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,47 @@
+name: Security
+
+on:
+  schedule:
+    - cron: "43 10 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  supply-chain:
+    name: supply-chain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-audit
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-0.21
+
+      - name: Install cargo-audit
+        run: command -v cargo-audit || cargo install cargo-audit --locked
+
+      - name: Cache cargo-deny
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-deny
+          key: cargo-deny-0.19
+
+      - name: Install cargo-deny
+        run: command -v cargo-deny || cargo install cargo-deny --locked
+
+      - name: Run security audit
+        run: cargo audit
+
+      - name: Run cargo-deny
+        run: cargo deny check advisories bans sources licenses

--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Full list with copy-paste fixes: [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.
 - [Compatibility](docs/COMPATIBILITY.md) — NetBox 4.2 / 4.3 / 4.5+ matrix and how nbox adapts
 - [Comparison](docs/COMPARISON.md) — nbox vs the NetBox web UI / raw API, and when to use each
 - [Scripting & automation](docs/SCRIPTING.md) — JSON/CSV/envelope schemas, exit codes, jq recipes, CI
+- [Continuous Integration](docs/CI.md) — required checks, scheduled gates, local smoke
 - [MCP server](docs/MCP.md) — agent setup, tools, HTTP/OIDC
 - [Architecture](docs/ARCHITECTURE.md) — internal design and module structure
 - [Agents](AGENTS.md) — machine-readable surface, output formats, exit codes

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,63 @@
+# cargo-deny policy for scheduled supply-chain checks.
+#
+# PRs run `cargo audit` for advisories. This broader scheduled gate also checks
+# licenses, duplicate-version pressure, and dependency sources. Keep exceptions
+# documented here so dependency drift is reviewable.
+
+[graph]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+
+[advisories]
+version = 2
+yanked = "warn"
+ignore = [
+    # RUSTSEC-2023-0071 — same rationale as `.cargo/audit.toml`: reaches the
+    # shipped binary through jsonwebtoken's RSA verification path only; no RSA
+    # private-key oracle is exposed by nbox. Revisit when upstream fixes `rsa`
+    # or we can move to a release-safe non-vulnerable backend.
+    "RUSTSEC-2023-0071",
+]
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[licenses.private]
+ignore = false
+
+[bans]
+# The current graph intentionally carries several transitive duplicate stacks
+# (notably crypto and Windows crates). Keep this quiet until a focused dependency
+# cleanup can make duplicate-version pressure actionable.
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,49 @@
+# Continuous Integration
+
+nbox uses a balanced PR gate: deterministic Rust checks run in parallel, live
+NetBox checks cover the real API paths, and broader compatibility/security checks
+run on schedules before releases.
+
+## Pull request checks
+
+PRs run these checks:
+
+- `fmt`
+- `clippy-all-features`
+- `clippy-no-default-features`
+- `test-all-features`
+- `test-no-default-features`
+- `msrv-check`
+- `generated-artifacts`
+- `security-audit`
+- `platform-build (x86_64-unknown-linux-musl)`
+- `platform-build (aarch64-apple-darwin)`
+- `platform-build (x86_64-apple-darwin)`
+- `platform-build (x86_64-pc-windows-msvc)`
+- `live NetBox 4.2 end-to-end`
+- `live NetBox 4.5 GraphQL backend`
+
+The platform lanes are build-only on PRs. Linux remains the full test platform so
+PR feedback stays close to the current wall time while still catching platform
+compile failures before release.
+
+## Scheduled checks
+
+- `NetBox Integration` runs nightly and adds `live NetBox 4.6 compatibility` to
+  catch supported-version drift against the pinned 4.6 fixture.
+- `Security` runs weekly and executes `cargo audit` plus `cargo deny check
+  advisories bans sources licenses` against `deny.toml`.
+
+Scheduled failures should be treated as release blockers even when they do not
+block an individual PR.
+
+## Local pre-tag smoke
+
+Run the local gate before tagging:
+
+```bash
+scripts/smoke.sh
+```
+
+It mirrors the host-local PR gates plus supply-chain checks. GitHub Actions still
+owns macOS/Windows platform builds and live NetBox fixtures.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Release smoke: run the full pre-tag gate locally, in one shot, so a tag never
-# moves on a tree that would fail CI or the release build. Mirrors the CI `check`
-# + `audit` jobs — format, both clippy modes (pedantic), both test modes, and
-# `cargo audit` — then adds a build smoke and man-page / shell-completion
-# generation. The cross-compiled release matrix (musl/darwin/windows) is the
-# release workflow's job, not this script's.
+# moves on a tree that would fail CI or the release build. Mirrors the PR gates
+# that are practical on one local host — format, both clippy modes (pedantic),
+# both test modes, generated artifacts, and security/supply-chain checks. The
+# macOS/Windows platform build matrix and live NetBox jobs stay in GitHub Actions.
 #
 # Usage:  scripts/smoke.sh    (run from anywhere; it cd's to the repo root)
 set -euo pipefail
@@ -12,39 +11,48 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "$1 not installed — run: cargo install $2 --locked" >&2
+        exit 1
+    fi
+}
 
 step "Format check"
 cargo fmt --all -- --check
 
 step "Clippy — all features (pedantic gate)"
-cargo clippy --all-targets --all-features -- -D warnings
+cargo clippy --all-targets --all-features --locked -- -D warnings
 
 step "Clippy — no default features"
-cargo clippy --all-targets --no-default-features -- -D warnings
+cargo clippy --all-targets --no-default-features --locked -- -D warnings
 
 step "Tests — all features"
-cargo test --all-features
+cargo test --all-features --locked
 
 step "Tests — no default features"
-cargo test --no-default-features
+cargo test --no-default-features --locked
 
 step "Security audit"
-if ! command -v cargo-audit >/dev/null 2>&1; then
-    echo "cargo-audit not installed — run: cargo install cargo-audit --locked" >&2
-    exit 1
-fi
+require_cmd cargo-audit cargo-audit
 cargo audit
 
+step "Supply-chain policy"
+require_cmd cargo-deny cargo-deny
+cargo deny check advisories bans sources licenses
+
 step "Build smoke — all features + no default features"
-cargo build --all-features
-cargo build --no-default-features
+cargo build --all-features --locked
+cargo build --no-default-features --locked
 
 step "Man pages + shell completions generate"
 smoke_dir="$(mktemp -d)"
 trap 'rm -rf "$smoke_dir"' EXIT
-cargo run --quiet --all-features -- man "$smoke_dir/man" >/dev/null
+cargo build --quiet --all-features --locked
+./target/debug/nbox man "$smoke_dir/man" >/dev/null
 for sh in bash zsh fish powershell elvish; do
-    cargo run --quiet --all-features -- completions "$sh" >/dev/null
+    ./target/debug/nbox completions "$sh" >/dev/null
 done
+test -s "$smoke_dir/man/nbox.1"
 
 printf '\n\033[1;32m✓ smoke passed — gate is green; safe to tag.\033[0m\n'

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -562,6 +562,7 @@ impl ClipboardEnv {
         }
     }
 
+    #[cfg(any(test, all(unix, not(target_os = "macos"))))]
     fn has_graphical_display(&self) -> bool {
         self.display.is_some() || self.wayland_display.is_some()
     }
@@ -593,7 +594,10 @@ fn should_skip_desktop_clipboard(platform: ClipboardPlatform, env: &ClipboardEnv
         #[cfg(any(test, all(unix, not(target_os = "macos"))))]
         ClipboardPlatform::X11WaylandUnix => !env.has_graphical_display(),
         #[cfg(any(test, not(all(unix, not(target_os = "macos")))))]
-        ClipboardPlatform::NativeDesktop => false,
+        ClipboardPlatform::NativeDesktop => {
+            let _ = env;
+            false
+        }
     }
 }
 

--- a/tests/it_netbox.rs
+++ b/tests/it_netbox.rs
@@ -45,9 +45,10 @@ fn netbox_token() -> String {
 
 /// A throwaway config file holding one profile that points at the live NetBox.
 /// `page_size` is configurable so the pagination test can force multiple pages.
-/// REST is the canonical backend, so no `[profiles.ci.api]` table is needed.
-/// The `NamedTempFile` is returned so it lives as long as the test needs it.
-fn temp_config(page_size: usize) -> NamedTempFile {
+/// REST is the canonical backend; tests that need GraphQL pass an optional
+/// `[profiles.ci.api]` table. The `NamedTempFile` is returned so it lives as
+/// long as the test needs it.
+fn temp_config_with_api(page_size: usize, api_table: Option<&str>) -> NamedTempFile {
     let mut config = NamedTempFile::new().expect("create temp config");
     write!(
         config,
@@ -57,19 +58,24 @@ fn temp_config(page_size: usize) -> NamedTempFile {
          url = \"{url}\"\n\
          token_env = \"NETBOX_TOKEN_UNUSED\"\n\
          page_size = {page_size}\n\
-         verify_tls = false\n",
+         verify_tls = false\n\
+         {api_table}",
         url = netbox_url(),
+        api_table = api_table.unwrap_or(""),
     )
     .expect("write temp config");
     config.flush().expect("flush temp config");
     config
 }
 
+fn temp_config(page_size: usize) -> NamedTempFile {
+    temp_config_with_api(page_size, None)
+}
+
 /// Run `nbox <args>` against the live instance with the given page size, using a
 /// throwaway profile and `NBOX_TOKEN` for auth. Returns the captured output.
-fn run_nbox_with_page_size(page_size: usize, args: &[&str]) -> Output {
-    let config = temp_config(page_size);
-    let output = Command::new(env!("CARGO_BIN_EXE_nbox"))
+fn run_nbox_with_config(config: &NamedTempFile, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_nbox"))
         .arg("--config")
         .arg(config.path())
         .args(args)
@@ -80,7 +86,12 @@ fn run_nbox_with_page_size(page_size: usize, args: &[&str]) -> Output {
         .env_remove("NBOX_LOG")
         .env_remove("RUST_LOG")
         .output()
-        .expect("spawn nbox");
+        .expect("spawn nbox")
+}
+
+fn run_nbox_with_page_size(page_size: usize, args: &[&str]) -> Output {
+    let config = temp_config(page_size);
+    let output = run_nbox_with_config(&config, args);
     // `config` (the temp file) drops here, after the child has fully run.
     output
 }
@@ -145,6 +156,38 @@ fn status_reports_netbox_4_2() {
         version.starts_with("4.2"),
         "expected NetBox 4.2.x, got {version:?}"
     );
+}
+
+/// Opting the VRF surface into GraphQL should both report an effective GraphQL
+/// backend and successfully render a real seeded VRF detail. The search surface
+/// remains REST by design even if a legacy config asks for GraphQL.
+#[test]
+#[ignore = "requires a live NetBox 4.5+ with GraphQL (netbox-integration workflow)"]
+fn graphql_backend_status_and_vrf_detail_work() {
+    let config = temp_config_with_api(
+        100,
+        Some(
+            "\n[profiles.ci.api]\n\
+             search = \"graphql\"\n\
+             vrf = \"graphql\"\n\
+             route_target = \"graphql\"\n",
+        ),
+    );
+
+    let status = run_nbox_with_config(&config, &["-o", "json", "status"]);
+    assert_ok(&status, "status");
+    let v = json_of(&status);
+    assert_eq!(v["api"]["vrf"]["configured"], "graphql", "got: {v}");
+    assert_eq!(v["api"]["vrf"]["effective"], "graphql", "got: {v}");
+    assert_eq!(
+        v["api"]["search"]["effective"], "rest",
+        "search must stay REST: {v}"
+    );
+
+    let vrf = run_nbox_with_config(&config, &["-o", "json", "vrf", "ci-vrf"]);
+    assert_ok(&vrf, "vrf ci-vrf");
+    let v = json_of(&vrf);
+    assert_eq!(v["summary"]["name"], "ci-vrf", "got: {v}");
 }
 
 // --- search ----------------------------------------------------------------


### PR DESCRIPTION
## What

Hardens the CI gate. The single `fmt · clippy · build · test` job becomes parallel **named** checks so a red lane points straight at the cause, plus a build-only platform matrix and scheduled supply-chain coverage.

**PR checks now (see `docs/CI.md`):** `fmt`, `clippy-all-features`, `clippy-no-default-features`, `test-all-features`, `test-no-default-features`, `msrv-check`, `generated-artifacts`, `security-audit`, `platform-build (x86_64-unknown-linux-musl | aarch64-apple-darwin | x86_64-apple-darwin | x86_64-pc-windows-msvc)`, `live NetBox 4.2 end-to-end`, `live NetBox 4.5 GraphQL backend`. All jobs run `--locked`; every workflow gets concurrency + cancel-in-progress.

- **Security workflow** (weekly + manual): `cargo audit` + `cargo deny check advisories bans sources licenses`, governed by a new `deny.toml` (RUSTSEC-2023-0071 ignored, matching `.cargo/audit.toml`).
- **NetBox Integration**: concurrency, failure-log artifacts, and a nightly/manual **4.6 compatibility** lane (gated to schedule/dispatch, not a PR check).
- **Fixes a vacuous lane**: the old `live NetBox 4.5 GraphQL search` ran a filter that matched **zero** tests. Renamed to `…GraphQL backend` and added `graphql_backend_status_and_vrf_detail_work`, which opts the VRF surface into GraphQL and asserts a real seeded `ci-vrf` detail renders (search stays REST by design). Fixture confirmed in `seed.py`.
- `smoke.sh` mirrors the host-practical PR gates (+ `cargo deny`, + `--locked`); `docs/CI.md` enumerates the check names; PR checklist + README refreshed.

## Branch protection

`master` currently has **no branch protection**, so the renamed/split check names require **no coordination** — nothing is a required status check today, and this merges cleanly. `docs/CI.md` lists the check names as the ready-made set to plug in **if/when** branch protection is enabled later.

Two notes that only become relevant **once required checks exist** (not today):
- `paths-ignore: '**.md'` means a doc-only PR skips the gated jobs — fine while advisory, but it would deadlock a *required*-check PR. A sentinel "all-green" job would close that.
- `security-audit` as a *required* PR check would let a daily RustSec drop fail unrelated PRs; the weekly `Security` workflow already covers it, so required-on-every-PR vs scheduled-only is a future call.

## Validation

- All three workflows parse as YAML; `deny.toml` is valid; the new integration test compiles and its `ci-vrf` fixture is seeded.
- fmt + clippy clean locally. (The live-NetBox lanes can only be exercised by the workflow itself — this PR's run is their first real test.)