### PR TITLE
fix(graphql): harden accelerator fallback and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **GraphQL accelerator fallback is more resilient.** If an effective GraphQL
+  `vrf` or `route_target` bundle fails at runtime (for example, a low NetBox
+  `GRAPHQL_MAX_QUERY_DEPTH`), nbox now warns and retries the same detail over
+  REST. Schema/probe fallback remains visible in `nbox status`, and stdout output
+  remains the same REST-shaped view.
 - **`nbox history --diff`.** The audit-log view now has a `--diff` flag (MCP
   `diff=true`) that includes the full `before`/`after` change payloads per row —
   the full JSON for a single change (CLI `--diff` implies `--limit 1`). The
@@ -596,7 +601,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Documented the in-memory read cache (`[cache]`) and the `nbox_cache_clear` MCP
   tool. Corrected the MSRV (1.88), the MCP tool count (nine), the searchable-kind
   lists (racks, VRFs, route targets), and the GraphQL/REST split (search is always
-  REST; GraphQL backs the VRF view only) across every doc. Expanded `SECURITY.md`
+  REST; at that point GraphQL only backed the VRF detail accelerator) across every
+  doc. Expanded `SECURITY.md`
   (the `nbox serve` network surface, supported-versions) and `CONTRIBUTING.md`
   (module map, an "adding a feature" recipe), and added GitHub issue/PR templates.
 
@@ -619,8 +625,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full-text `q` quick-search (filtering moved to per-field Strawberry lookups in
   4.3), so GraphQL can't reproduce canonical NetBox search. `nbox search` now
   always runs over REST; a `search = "graphql"` preference is accepted but
-  transparently falls back to REST, with the reason in `nbox status`. The VRF view
-  is currently the only GraphQL-capable surface. (The per-kind GraphQL search
+  transparently falls back to REST, with the reason in `nbox status`. At 0.4.0 the
+  VRF view was the only GraphQL-capable surface. (The per-kind GraphQL search
   fan-out — which silently returned unfiltered results on 4.3+ — was removed.)
 
 ### Fixed
@@ -666,7 +672,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full routing context (summary + prefix tree + addresses), and MCP `nbox_get vrf`
   returns the same bundle.
 - **VRFs are now a first-class object.** A VRF can be looked up (`nbox vrf <name|rd|id>`),
-  found in search (`nbox search` / TUI `/` / MCP `nbox_search`, REST and GraphQL —
+  found in search (`nbox search` / TUI `/` / MCP `nbox_search`; search is REST-canonical —
   subtitle = its RD, falling back to the tenant), browsed from the TUI Nav rail
   (a **VRFs** section with a live count), opened from the palette (`vrf <ref>`),
   resolved by `nbox open vrf/<ref>`, journalled (`nbox journal vrf/<ref>`), and

--- a/README.md
+++ b/README.md
@@ -575,13 +575,15 @@ raw escape-hatch tool come later.
 - Auto-detects **v2 API tokens** (NetBox 4.5+, `Authorization: Bearer nbt_…`) and
   legacy **v1 tokens** (`Authorization: Token …`); force one with `auth_scheme`.
 - Optional, read-only **GraphQL** (`/graphql/`) as a **per-surface accelerator**
-  for the VRF and route-target views (`[profiles.<name>.api]` `vrf`/`route_target = "graphql"`). nbox probes the
-  schema so NetBox 4.2, 4.3, and 4.5+ filter/pagination differences are handled
-  without hard-coding a version, and **falls back to REST** (with the reason in
-  `status`) when a surface isn't supported. **Search is always REST** — NetBox's
-  GraphQL API has no equivalent to REST's full-text `q`, so GraphQL never backs
-  the search surface. REST stays canonical and powers search, identity resolution,
-  detail lookups, raw, journals, and available-IP/prefix operations.
+  for the VRF and route-target views (`[profiles.<name>.api]`
+  `vrf`/`route_target = "graphql"`). nbox probes the schema so NetBox 4.2, 4.3,
+  and 4.5+ filter/pagination differences are handled without hard-coding a
+  version, and **falls back to REST** (with the reason in `status`) when a surface
+  isn't supported. If an effective GraphQL bundle fails at runtime, nbox warns and
+  retries the same detail over REST. **Search is always REST** — NetBox's GraphQL
+  API has no equivalent to REST's full-text `q`, so GraphQL never backs the search
+  surface. REST stays canonical and powers search, identity resolution, detail
+  lookups, raw, journals, and available-IP/prefix operations.
 
 ## Troubleshooting
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -280,12 +280,12 @@ cover. All of these stay within the read-only product and the explicit non-goals
   non-NAT IPs). The device IP tab picks it up for free.
 - ☐ **Cable-profile / bundle-aware cable-path visualizer** _(4.5 cable profiles, 4.6 CableBundle)_.
   Breakout/lane cables otherwise trace inaccurately — keep the 0.9.0 visualizer correct on new NetBox.
-- ☐ **4.7 compatibility watch + GraphQL depth-cap defense.** Re-verify the matrix against 4.7
-  when it lands (~Aug 2026). 4.6's `GRAPHQL_MAX_QUERY_DEPTH` can fail nbox's GraphQL accelerators
-  on a low cap — already falls back to REST; surface the reason clearly. Docs: `docs/COMPATIBILITY.md`.
-- ☐ **4.6 pagination primitives (infra).** Optional, version-gated: evaluate the `start` cursor
-  param for constant-time deep pagination on large fan-outs, with clean fallback to the
-  REST `next` link. Do **not** plan HTTP cache revalidation until NetBox exposes a
+- ☐ **4.7 compatibility watch.** Re-verify the matrix against 4.7 when it lands (~Aug 2026).
+  GraphQL depth-cap defense for 4.6's `GRAPHQL_MAX_QUERY_DEPTH` is shipped: effective GraphQL
+  bundle failures warn and retry REST. Docs: `docs/COMPATIBILITY.md`.
+- ☐ **4.6 pagination primitives (infra).** Optional, version-gated: evaluate REST/GraphQL cursor
+  pagination (`start`/`limit`) for future large fan-outs, with clean fallback to the REST `next`
+  link or today's bounded GraphQL first page. Do **not** plan HTTP cache revalidation until NetBox exposes a
   read-validator path; nbox's current cache deliberately lives at the assembled
   view-model layer because NetBox's `ETag` is not a useful `304` read-cache signal.
 - ☑ **Credential preflight via `/api/authentication-check/` (4.5).** A dedicated token-validity probe
@@ -441,7 +441,7 @@ Consolidated future scope:
   interface`. Scoped to a **single connection's path**, NOT full network topology maps (those stay an
   explicit non-goal). Raised 2026-06-20.
 - ☑ **Full rack integration** — racks are now a first-class **searchable** `ObjectKind`: they appear in
-  the global search fan-out (REST + GraphQL), `/` + `nbox search`, MCP `nbox_search`, and a `rack`
+  the REST-canonical global search fan-out, `/` + `nbox search`, MCP `nbox_search`, and a `rack`
   palette lookup, honoring the site/region/site-group/location scope (like devices, via `*_id`). They
   were already openable + a cross-nav target in the TUI (`nbox rack <ref>`, device→rack). ☑ **Rack
   elevation** — the rack detail has an `e` (elevation) tab: a framed, U-by-U front view from NetBox's
@@ -468,16 +468,18 @@ Consolidated future scope:
   generic `KIND/DISPLAY/SITE` layout. (A richer multi-column layout — e.g. device name/site/role/status —
   would need `SearchResult` enriched with those fields; deferred.)
 - ☑ **VRF-pivoted navigation (a dedicated VRF view).** VRF is now a first-class `ObjectKind`:
-  searchable (REST + GraphQL), browsable from the Nav rail with a live count, `nbox vrf <name|rd|id>`,
+  searchable via REST-canonical search, browsable from the Nav rail with a live count, `nbox vrf <name|rd|id>`,
   palette `vrf`, `open`/`journal` resolvers, and MCP `nbox_get`/`nbox://vrf/<ref>`. The TUI detail is a
   routing context — a fixed header card (RD/tenant/RT/enforce) over the VRF's prefix tree (navigable
   summary slot) with navigable `addresses` and a `targets` tab. Built on the new navigable-detail-row
   mechanism (a `DetailRow { text, target }`; `Enter` opens, `b`/`Esc` returns).
-- ☑ **Per-surface API backends.** Replaced the coarse `backend` profile key with `[profiles.<name>.api]`
-  (`search`/`vrf` = `rest`|`graphql`). REST is canonical; a GraphQL surface is an opt-in accelerator
-  resolved against the live schema probe (`EffectiveBackend`, REST-fallback with reason). Surface-aware
-  capabilities + a per-surface `api` block in `nbox status`/MCP. VRF GraphQL fetches its prefix/address
-  bundle in one query; REST and GraphQL produce a byte-identical `VrfDetail`.
+- ☑ **Per-surface API backends.** Replaced the coarse `backend` profile key with
+  `[profiles.<name>.api]` (`vrf`/`route_target` = `rest`|`graphql`; `search` is accepted
+  but REST-canonical). REST is canonical; a GraphQL surface is an opt-in accelerator
+  resolved against the live schema probe (`EffectiveBackend`, REST-fallback with reason).
+  Surface-aware capabilities + a per-surface `api` block in `nbox status`/MCP. VRF GraphQL
+  fetches its prefix/address bundle in one query; route-target GraphQL fetches importing/exporting
+  VRFs in one query; REST and GraphQL produce byte-identical detail views.
 - ☑ **Search stays REST — GraphQL search dropped (decided 2026-06-19).** Investigated collapsing the
   per-kind GraphQL search fan-out into one bundled POST. NetBox 4.3+ GraphQL has **no `q` full-text
   filter** (filtering moved to per-field Strawberry lookups), so it can't reproduce canonical NetBox
@@ -547,9 +549,9 @@ Consolidated future scope:
   the `from_value(json!{})` row reshape (`Default` on the `Prefix`/`IpAddress` wire models lets the
   conversion set only the VRF-relevant fields). All GraphQL — capabilities probe + VRF bundle + helpers
   + tests — now lives in `netbox/graphql.rs`; `search.rs` is REST-only (2657 → ~1.2k lines).
-- ☐ GraphQL capability probing v2 if schema churn demands it: dynamic `*Filter` discovery and/or a
-  short TTL cache keyed by instance/profile to avoid re-probing when users bounce between profiles
-  pointing at the same NetBox.
+- ☐ GraphQL capability probing v2 if schema churn demands it: dynamic `*Filter` discovery, a
+  short TTL cache keyed by instance/profile, and `/graphql/v2` / `GRAPHQL_DEFAULT_VERSION`
+  handling if NetBox changes the default GraphQL API version.
 - ☑ **Local cache (2026-06-19).** A small, bounded **in-memory** view-model cache (keyed by
   profile+kind+ref) so a burst of identical reads doesn't re-hit NetBox. Single short TTL (default 30s,
   a *de-dupe* window, not a freshness window — nothing is served past TTL); `r`/auto-refresh/profile-

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -27,7 +27,7 @@ flag, and the per-surface backend routing.
 
 ¹ In the official NetBox release notes — the `4.2.0` scope change (Jan 2025) and the `4.5` v2 tokens (HMAC, `nbt_` prefix, `Bearer`). v1 tokens are **deprecated but retained through the 4.x line; removal is planned for v5.0** (4.6 pushed this out from the originally-announced 4.7). nbox auto-detects the scheme, so the timeline doesn't affect it.
 
-⁴ NetBox 4.6 adds `GRAPHQL_MAX_QUERY_DEPTH`. nbox's GraphQL accelerators (the VRF and route-target bundles) issue nested queries; against an instance with a low cap they fail closed and fall back to REST (the reason surfaces in `nbox status`). Search is REST regardless, so it's unaffected.
+⁴ NetBox 4.6 adds `GRAPHQL_MAX_QUERY_DEPTH`. nbox's GraphQL accelerators (the VRF and route-target bundles) issue nested queries; unsupported schemas resolve to REST in `nbox status`, and a runtime bundle failure (including a low depth cap) retries the same detail over REST with a warning. Search is REST regardless, so it's unaffected.
 ² NetBox [#7598](https://github.com/netbox-community/netbox/issues/7598), "adopt advanced query filtering in GraphQL." GraphQL never had a REST-style full-text `q`; this rework is why a per-kind GraphQL search can't stand in for REST search.
 ³ **Observed** against live instances (4.2 vs 4.5.10), **not called out in the release notes** — so treat as empirical, not a documented contract. `/api/status/` auth may reflect instance `LOGIN_REQUIRED`-style config rather than a strict version change; either way nbox authenticates **every** request (including the version probe), so it is unaffected.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -131,7 +131,9 @@ Rules:
   values are config errors.
 - A `graphql` preference is honored only when the live schema probe confirms the
   surface is supported; otherwise nbox **falls back to REST** and `nbox status`
-  shows the reason. The output shape is identical either way.
+  shows the reason. If a supported GraphQL bundle fails at runtime, nbox retries
+  the same detail over REST and warns on stderr/logs. The output shape is
+  identical either way.
 - GraphQL posts to `/graphql/`, probes the schema, and shapes filters from the
   advertised input types, handling NetBox 4.2 (unpaginated lists), 4.3+ (offset
   pagination), and 4.5+ (equality lookups like `status: { exact: STATUS_ACTIVE }`).
@@ -139,7 +141,9 @@ Rules:
 > The coarse `backend = "rest"|"graphql"` profile key was **removed**. A config
 > that still sets it is rejected with a pointer to `[profiles.<name>.api]`.
 
-`nbox status` reports the configured vs effective backend per surface:
+Plain `nbox status` shows each surface's effective backend and any fallback
+reason. Use `nbox status --json` for `api.<surface>.configured`,
+`effective`, and `reason` fields:
 
 ```
 api search        rest (NetBox GraphQL exposes no REST-equivalent full-text (q) search)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -74,19 +74,19 @@ group), so the two are separate filters; both are passed straight through as
 server matches by name). On releases that carry no owner data the filters are
 silently ignored (queried unfiltered, not dropped).
 
-Profiles opt the **VRF view** into NetBox GraphQL under `[profiles.<name>.api]` —
-`vrf` (the VRF view's prefix/address bundle) is `rest` (default) or `graphql`. A
-GraphQL surface returns the same normalized shape and keeps the same fail-closed/
-`--partial` behavior, and **falls back to REST** (with the reason shown by `nbox
-status`) when the live schema can't support it. nbox probes `/graphql/` at
-runtime and adapts to the schema: NetBox 4.2's unpaginated list fields, NetBox
-4.3+'s offset pagination, and NetBox 4.5+'s lookup-wrapper filters are all shaped
-from introspection rather than version strings. **Search is always REST** —
-NetBox's GraphQL API has no equivalent to REST's full-text `q`, so a `search =
-"graphql"` preference transparently falls back. REST stays canonical and powers
-search, identity resolution, detail lookups, raw reads, journals, and
-available-IP/prefix commands. (The old coarse `backend = …` profile key was
-removed.)
+Profiles opt GraphQL-capable views into NetBox GraphQL under
+`[profiles.<name>.api]`: `vrf = "graphql"` bundles the VRF prefix/address section,
+and `route_target = "graphql"` bundles importing/exporting VRFs. A GraphQL surface
+returns the same normalized shape, falls back to REST when the live schema can't
+support it, and retries REST if the runtime bundle fails (for example, a low
+GraphQL query-depth cap). nbox probes `/graphql/` at runtime and adapts to the
+schema: NetBox 4.2's unpaginated list fields, NetBox 4.3+'s offset pagination, and
+NetBox 4.5+'s lookup-wrapper filters are all shaped from introspection rather than
+version strings. **Search is always REST** — NetBox's GraphQL API has no equivalent
+to REST's full-text `q`, so a `search = "graphql"` preference transparently falls
+back. REST stays canonical and powers search, identity resolution, raw reads,
+journals, and available-IP/prefix commands. (The old coarse `backend = …` profile
+key was removed.)
 
 ## Output
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -21,6 +21,11 @@ nbox status
 
 If that connects, the MCP server will too — it uses the same path.
 
+Backend routing is identical to the CLI. `nbox_search` always uses REST.
+`nbox_get vrf` and `nbox_get route_target` may use GraphQL for their
+child/relation bundles when `nbox_status.api` reports an effective `graphql`
+backend; identity/header resolution remains REST.
+
 ## Connecting it to a host
 
 The host launches `nbox serve` and provides the NetBox token in the

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,7 +409,8 @@ pub fn load(path: &Path) -> Result<Config> {
         if profile.backend.is_some() {
             anyhow::bail!(
                 "profile `{name}`: the `backend` key was removed — set the backend per surface under \
-                 `[profiles.{name}.api]` instead, e.g. `search = \"graphql\"` (and/or `vrf = \"graphql\"`)"
+                 `[profiles.{name}.api]` instead, e.g. `vrf = \"graphql\"` and/or \
+                 `route_target = \"graphql\"`"
             );
         }
     }

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -1437,12 +1437,30 @@ fn prefix_sort_key(cidr: &str) -> (u8, u128, u8) {
     }
 }
 
+async fn rest_vrf_children(
+    client: &NetBoxClient,
+    vrf_id: u64,
+) -> Result<(Vec<Prefix>, Vec<IpAddress>)> {
+    // REST: fetch the two child collections concurrently - they're independent
+    // and this halves the detail's latency on a high-RTT link.
+    Ok(tokio::try_join!(
+        client.list_all(
+            Endpoint::Prefixes,
+            vec![("vrf_id", vrf_id.to_string())],
+            DETAIL_SECTION_CAP,
+        ),
+        client.list_all(
+            Endpoint::IpAddresses,
+            vec![("vrf_id", vrf_id.to_string())],
+            DETAIL_SECTION_CAP,
+        ),
+    )?)
+}
+
 /// Build the backend-neutral [`VrfDetail`]: the VRF summary plus its scoped
 /// prefixes (as a tree) and addresses. Children come from a single bundled
-/// GraphQL query when the VRF surface resolves to GraphQL, else canonical REST.
-/// A real GraphQL/transport error propagates (fail closed) rather than degrading
-/// to empty data — only a capability mismatch (handled by `effective_backend`)
-/// routes to REST.
+/// GraphQL query when the VRF surface resolves to GraphQL; unsupported schemas
+/// route to REST before runtime, and runtime GraphQL bundle failures retry REST.
 async fn build_vrf_detail(client: &NetBoxClient, vrf: Vrf) -> Result<VrfDetail> {
     let id = vrf.id;
     let summary = VrfView::from_model(vrf);
@@ -1452,22 +1470,24 @@ async fn build_vrf_detail(client: &NetBoxClient, vrf: Vrf) -> Result<VrfDetail> 
         .await
         .uses_graphql()
     {
-        client.graphql_vrf_bundle(id, DETAIL_SECTION_CAP).await?
+        match client.graphql_vrf_bundle(id, DETAIL_SECTION_CAP).await {
+            Ok(bundle) => bundle,
+            Err(err) => {
+                let graphql_error = format!("{err:#}");
+                tracing::warn!(
+                    vrf_id = id,
+                    error = %graphql_error,
+                    "GraphQL VRF bundle failed; retrying REST"
+                );
+                rest_vrf_children(client, id).await.with_context(|| {
+                    format!(
+                        "GraphQL VRF bundle failed ({graphql_error}); REST fallback also failed"
+                    )
+                })?
+            }
+        }
     } else {
-        // REST: fetch the two child collections concurrently — they're
-        // independent and this halves the detail's latency on a high-RTT link.
-        tokio::try_join!(
-            client.list_all(
-                Endpoint::Prefixes,
-                vec![("vrf_id", id.to_string())],
-                DETAIL_SECTION_CAP,
-            ),
-            client.list_all(
-                Endpoint::IpAddresses,
-                vec![("vrf_id", id.to_string())],
-                DETAIL_SECTION_CAP,
-            ),
-        )?
+        rest_vrf_children(client, id).await?
     };
 
     let prefix_total = summary.prefix_count.unwrap_or(prefixes.len() as u64);
@@ -1536,15 +1556,38 @@ fn sort_vrf_refs(refs: &mut [VrfRef]) {
     refs.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.rd.cmp(&b.rd)));
 }
 
+async fn rest_route_target_relations(
+    client: &NetBoxClient,
+    route_target_id: u64,
+) -> Result<(Vec<VrfRef>, Vec<VrfRef>)> {
+    // REST: fetch the two VRF collections concurrently - they're independent and
+    // this halves the detail's latency on a high-RTT link.
+    let (importing, exporting): (Vec<Vrf>, Vec<Vrf>) = tokio::try_join!(
+        client.list_all(
+            Endpoint::Vrfs,
+            vec![("import_target_id", route_target_id.to_string())],
+            DETAIL_SECTION_CAP,
+        ),
+        client.list_all(
+            Endpoint::Vrfs,
+            vec![("export_target_id", route_target_id.to_string())],
+            DETAIL_SECTION_CAP,
+        ),
+    )?;
+    Ok((
+        importing.iter().map(VrfRef::from_model).collect(),
+        exporting.iter().map(VrfRef::from_model).collect(),
+    ))
+}
+
 /// Build a route target's relation graph: the target's header plus the VRFs that
 /// import and export it. A route target carries the relation on the VRF side, so
 /// when the route-target surface resolves to GraphQL one filtered
 /// `route_target_list` query returns both directions; otherwise canonical REST
-/// fans out two `/api/ipam/vrfs/` list calls concurrently (independent, so they
-/// run together). The resulting [`RouteTargetDetail`] is byte-identical between
-/// the two paths. A real GraphQL/transport error propagates (fail closed) rather
-/// than degrading to empty data — only a capability mismatch (handled by
-/// `effective_backend`) routes to REST.
+/// fans out two `/api/ipam/vrfs/` list calls concurrently. The resulting
+/// [`RouteTargetDetail`] is byte-identical between the two paths. Unsupported
+/// schemas route to REST before runtime, and runtime GraphQL bundle failures
+/// retry REST.
 async fn build_route_target_detail(
     client: &NetBoxClient,
     rt: RouteTarget,
@@ -1557,26 +1600,26 @@ async fn build_route_target_detail(
         .await
         .uses_graphql()
     {
-        client.graphql_route_target_bundle(id).await?
+        match client.graphql_route_target_bundle(id).await {
+            Ok(bundle) => bundle,
+            Err(err) => {
+                let graphql_error = format!("{err:#}");
+                tracing::warn!(
+                    route_target_id = id,
+                    error = %graphql_error,
+                    "GraphQL route-target bundle failed; retrying REST"
+                );
+                rest_route_target_relations(client, id)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "GraphQL route-target bundle failed ({graphql_error}); REST fallback also failed"
+                        )
+                    })?
+            }
+        }
     } else {
-        // REST: fetch the two VRF collections concurrently — they're independent
-        // and this halves the detail's latency on a high-RTT link.
-        let (importing, exporting): (Vec<Vrf>, Vec<Vrf>) = tokio::try_join!(
-            client.list_all(
-                Endpoint::Vrfs,
-                vec![("import_target_id", id.to_string())],
-                DETAIL_SECTION_CAP,
-            ),
-            client.list_all(
-                Endpoint::Vrfs,
-                vec![("export_target_id", id.to_string())],
-                DETAIL_SECTION_CAP,
-            ),
-        )?;
-        (
-            importing.iter().map(VrfRef::from_model).collect(),
-            exporting.iter().map(VrfRef::from_model).collect(),
-        )
+        rest_route_target_relations(client, id).await?
     };
 
     sort_vrf_refs(&mut importing_vrfs);
@@ -2774,6 +2817,320 @@ mod tests {
         assert_eq!(back.links[0].kind, ObjectKind::Site);
     }
 
+    // --- VRF detail: GraphQL accelerator vs REST ---
+
+    mod vrf_backends {
+        use super::super::*;
+        use crate::config::{ApiConfig, BackendPreference, ProfileConfig};
+        use serde_json::json;
+        use wiremock::matchers::{body_string_contains, method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn not_found(noun: &str, value: &str) -> anyhow::Error {
+            NboxError::NotFound(format!("no {noun} matched \"{value}\"")).into()
+        }
+
+        async fn mount_vrf_identity(server: &MockServer) {
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/42/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "id": 42, "url": "http://nb/api/ipam/vrfs/42/",
+                    "name": "customer-prod", "rd": "65000:42",
+                    "tenant": {"id": 1, "display": "Acme"},
+                    "prefix_count": 2,
+                    "ipaddress_count": 1
+                })))
+                .mount(server)
+                .await;
+        }
+
+        async fn mount_rest_children(server: &MockServer) {
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/prefixes/"))
+                .and(query_param("vrf_id", "42"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 2, "next": null, "previous": null,
+                    "results": [
+                        {
+                            "id": 1, "url": "u", "prefix": "10.50.0.0/16",
+                            "_depth": 0,
+                            "status": {"value": "container", "label": "container"},
+                            "description": "supernet"
+                        },
+                        {
+                            "id": 2, "url": "u", "prefix": "10.50.1.0/24",
+                            "_depth": 1,
+                            "status": {"value": "active", "label": "active"},
+                            "description": ""
+                        }
+                    ]
+                })))
+                .mount(server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/ip-addresses/"))
+                .and(query_param("vrf_id", "42"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 1, "next": null, "previous": null,
+                    "results": [
+                        {
+                            "id": 9, "url": "u", "address": "10.50.1.1/24",
+                            "status": {"value": "active", "label": "active"},
+                            "dns_name": "gw.customer",
+                            "description": ""
+                        }
+                    ]
+                })))
+                .mount(server)
+                .await;
+        }
+
+        fn rest_client(server: &MockServer) -> NetBoxClient {
+            NetBoxClient::new(
+                &ProfileConfig {
+                    url: server.uri(),
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap()
+        }
+
+        fn graphql_client(server: &MockServer) -> NetBoxClient {
+            NetBoxClient::new(
+                &ProfileConfig {
+                    url: server.uri(),
+                    api: Some(ApiConfig {
+                        search: None,
+                        vrf: Some(BackendPreference::Graphql),
+                        route_target: None,
+                    }),
+                    ..Default::default()
+                },
+                None,
+            )
+            .unwrap()
+        }
+
+        async fn mount_graphql_probe(server: &MockServer) {
+            let list_field = |name: &str, filter: &str| {
+                json!({
+                    "name": name,
+                    "args": [
+                        {"name": "filters", "type": {"kind": "INPUT_OBJECT", "name": filter}},
+                        {"name": "pagination", "type": {"kind": "INPUT_OBJECT", "name": "PaginationInput"}}
+                    ]
+                })
+            };
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("__schema"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"__schema": {"queryType": {"fields": [
+                        list_field("prefix_list", "PrefixFilter"),
+                        list_field("ip_address_list", "IPAddressFilter"),
+                    ]}}}
+                })))
+                .mount(server)
+                .await;
+            let vrf_id_field = json!({"name": "vrf_id", "type": {"kind": "INPUT_OBJECT", "name": "IntegerLookup"}});
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("DeviceFilter"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {
+                        "prefix": {"inputFields": [vrf_id_field.clone()]},
+                        "ip": {"inputFields": [vrf_id_field]}
+                    }
+                })))
+                .mount(server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("ASNFilter"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": {}})))
+                .mount(server)
+                .await;
+        }
+
+        async fn mount_graphql_bundle(server: &MockServer, response: ResponseTemplate) {
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("ip_address_list(filters"))
+                .respond_with(response)
+                .mount(server)
+                .await;
+        }
+
+        fn graphql_bundle_body() -> serde_json::Value {
+            json!({
+                "data": {
+                    "prefix_list": [
+                        {"id": "1", "prefix": "10.50.0.0/16", "_depth": 0, "status": "container", "description": "supernet"},
+                        {"id": "2", "prefix": "10.50.1.0/24", "_depth": 1, "status": "active", "description": ""}
+                    ],
+                    "ip_address_list": [
+                        {"id": "9", "address": "10.50.1.1/24", "status": "active", "dns_name": "gw.customer", "description": ""}
+                    ]
+                }
+            })
+        }
+
+        #[tokio::test]
+        async fn rest_and_graphql_vrf_detail_are_byte_identical() {
+            let rest = MockServer::start().await;
+            mount_vrf_identity(&rest).await;
+            mount_rest_children(&rest).await;
+
+            let gql = MockServer::start().await;
+            mount_vrf_identity(&gql).await;
+            mount_graphql_probe(&gql).await;
+            mount_graphql_bundle(
+                &gql,
+                ResponseTemplate::new(200).set_body_json(graphql_bundle_body()),
+            )
+            .await;
+
+            let rest_detail = vrf_detail_by_ref(&rest_client(&rest), "42", &not_found)
+                .await
+                .expect("rest detail");
+            let gql_detail = vrf_detail_by_ref(&graphql_client(&gql), "42", &not_found)
+                .await
+                .expect("graphql detail");
+
+            assert_eq!(
+                rest_detail.to_plain(),
+                gql_detail.to_plain(),
+                "plain output must be byte-identical across backends"
+            );
+            assert_eq!(
+                serde_json::to_string(&rest_detail).unwrap(),
+                serde_json::to_string(&gql_detail).unwrap(),
+                "serialized JSON must be byte-identical across backends"
+            );
+        }
+
+        #[tokio::test]
+        async fn graphql_preference_with_support_uses_graphql_path() {
+            let server = MockServer::start().await;
+            mount_vrf_identity(&server).await;
+            mount_graphql_probe(&server).await;
+            mount_graphql_bundle(
+                &server,
+                ResponseTemplate::new(200).set_body_json(graphql_bundle_body()),
+            )
+            .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/prefixes/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 0, "next": null, "previous": null, "results": []
+                })))
+                .expect(0)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/ip-addresses/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 0, "next": null, "previous": null, "results": []
+                })))
+                .expect(0)
+                .mount(&server)
+                .await;
+
+            let client = graphql_client(&server);
+            assert!(
+                client
+                    .effective_backend(ApiSurface::Vrf)
+                    .await
+                    .uses_graphql()
+            );
+            let detail = vrf_detail_by_ref(&client, "42", &not_found)
+                .await
+                .expect("graphql detail");
+            assert_eq!(detail.prefixes.len(), 2);
+            assert_eq!(detail.addresses.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn graphql_preference_without_support_falls_back_to_rest() {
+            let server = MockServer::start().await;
+            mount_vrf_identity(&server).await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("__schema"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "data": {"__schema": {"queryType": {"fields": []}}}
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": {}})))
+                .mount(&server)
+                .await;
+            mount_rest_children(&server).await;
+
+            let client = graphql_client(&server);
+            let effective = client.effective_backend(ApiSurface::Vrf).await;
+            assert!(!effective.uses_graphql(), "missing schema -> REST fallback");
+            assert!(
+                effective
+                    .reason()
+                    .is_some_and(|r| r.contains("prefix_list.vrf_id")),
+                "fallback reason names the missing schema piece"
+            );
+
+            let detail = vrf_detail_by_ref(&client, "42", &not_found)
+                .await
+                .expect("rest fallback detail");
+            assert_eq!(detail.summary.name, "customer-prod");
+
+            let requests = server.received_requests().await.unwrap();
+            assert!(
+                !requests
+                    .iter()
+                    .any(|r| String::from_utf8_lossy(&r.body).contains("ip_address_list(filters")),
+                "a capability fallback must not issue the GraphQL bundle query"
+            );
+        }
+
+        #[tokio::test]
+        async fn runtime_graphql_bundle_failure_retries_rest() {
+            let server = MockServer::start().await;
+            mount_vrf_identity(&server).await;
+            mount_graphql_probe(&server).await;
+            mount_graphql_bundle(
+                &server,
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "errors": [{"message": "maximum query depth exceeded"}]
+                })),
+            )
+            .await;
+            mount_rest_children(&server).await;
+
+            let detail = vrf_detail_by_ref(&graphql_client(&server), "42", &not_found)
+                .await
+                .expect("REST fallback detail");
+            assert_eq!(detail.summary.name, "customer-prod");
+            assert_eq!(detail.prefixes.len(), 2);
+            assert_eq!(detail.addresses.len(), 1);
+
+            let requests = server.received_requests().await.unwrap();
+            assert!(
+                requests
+                    .iter()
+                    .any(|r| String::from_utf8_lossy(&r.body).contains("ip_address_list(filters")),
+                "runtime fallback first attempts the GraphQL bundle"
+            );
+            assert!(
+                requests
+                    .iter()
+                    .any(|r| r.url.path() == "/api/ipam/prefixes/"),
+                "runtime GraphQL failure retries REST children"
+            );
+        }
+    }
+
     // --- Route-target relation graph: GraphQL accelerator vs REST ---
 
     mod route_target_backends {
@@ -3015,6 +3372,59 @@ mod tests {
                 .expect("graphql detail");
             assert!(detail.importing_vrfs.is_empty());
             assert!(detail.exporting_vrfs.is_empty());
+        }
+
+        #[tokio::test]
+        async fn runtime_graphql_bundle_failure_retries_rest() {
+            let server = MockServer::start().await;
+            mount_rt_identity(&server).await;
+            mount_graphql_probe(&server).await;
+            Mock::given(method("POST"))
+                .and(path("/graphql/"))
+                .and(body_string_contains("route_target_list(filters"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "errors": [{"message": "maximum query depth exceeded"}]
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/"))
+                .and(query_param("import_target_id", "5"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 1, "next": null, "previous": null,
+                    "results": [
+                        {"id": 1, "url": "u", "name": "customer-prod", "rd": "65000:100"}
+                    ]
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/api/ipam/vrfs/"))
+                .and(query_param("export_target_id", "5"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "count": 0, "next": null, "previous": null, "results": []
+                })))
+                .mount(&server)
+                .await;
+
+            let detail = route_target_detail_by_ref(&graphql_client(&server), "5", &not_found)
+                .await
+                .expect("REST fallback detail");
+            assert_eq!(detail.importing_vrfs.len(), 1);
+            assert_eq!(detail.importing_vrfs[0].name, "customer-prod");
+            assert!(detail.exporting_vrfs.is_empty());
+
+            let requests = server.received_requests().await.unwrap();
+            assert!(
+                requests
+                    .iter()
+                    .any(|r| String::from_utf8_lossy(&r.body).contains("route_target_list(filters")),
+                "runtime fallback first attempts the GraphQL bundle"
+            );
+            assert!(
+                requests.iter().any(|r| r.url.path() == "/api/ipam/vrfs/"),
+                "runtime GraphQL failure retries REST relations"
+            );
         }
 
         /// Capability gating: `route_target = "graphql"` but the schema lacks

--- a/src/netbox/capabilities.rs
+++ b/src/netbox/capabilities.rs
@@ -180,14 +180,12 @@ fn list_has_filter(caps: &GraphqlCapabilities, list_name: &str, key: &str) -> bo
     caps.filter_shape(filter_type, key).is_some()
 }
 
-/// GraphQL VRF support requires the VRF list plus `vrf_id` filtering on prefixes
-/// and IP addresses (the children bundle). All-or-nothing — a partial schema
-/// falls back to REST with the missing pieces named.
+/// GraphQL VRF support requires `vrf_id` filtering on prefixes and IP addresses
+/// (the children bundle). Identity/header resolution stays REST, so `vrf_list`
+/// is not required. All-or-nothing - a partial schema falls back to REST with the
+/// missing pieces named.
 fn vrf_support(caps: &GraphqlCapabilities) -> SurfaceSupport {
     let mut missing = Vec::new();
-    if caps.list("vrf_list").is_none() {
-        missing.push("vrf_list".to_string());
-    }
     if !list_has_filter(caps, "prefix_list", "vrf_id") {
         missing.push("prefix_list.vrf_id".to_string());
     }
@@ -344,7 +342,7 @@ mod tests {
     use crate::config::{ApiConfig, ProfileConfig};
     use crate::netbox::client::NetBoxClient;
     use crate::netbox::status::Status;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_string_contains, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn status() -> Status {
@@ -353,6 +351,83 @@ mod tests {
             django_version: None,
             python_version: None,
         }
+    }
+
+    fn graphql_profile(server: &MockServer) -> NetBoxClient {
+        NetBoxClient::new(
+            &ProfileConfig {
+                url: server.uri(),
+                api: Some(ApiConfig {
+                    search: Some(BackendPreference::Graphql),
+                    vrf: Some(BackendPreference::Graphql),
+                    route_target: Some(BackendPreference::Graphql),
+                }),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap()
+    }
+
+    async fn mount_graphql_probe(
+        server: &MockServer,
+        prefix_filter: serde_json::Value,
+        ip_filter: serde_json::Value,
+        route_target_filter: serde_json::Value,
+    ) {
+        let list_field = |name: &str, filter: &str| {
+            serde_json::json!({
+                "name": name,
+                "args": [
+                    {"name": "filters", "type": {"kind": "INPUT_OBJECT", "name": filter}}
+                ]
+            })
+        };
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("__schema"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {"__schema": {"queryType": {"fields": [
+                    list_field("prefix_list", "PrefixFilter"),
+                    list_field("ip_address_list", "IPAddressFilter"),
+                    list_field("route_target_list", "RouteTargetFilter"),
+                ]}}}
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("DeviceFilter"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "prefix": prefix_filter,
+                    "ip": ip_filter
+                }
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/graphql/"))
+            .and(body_string_contains("ASNFilter"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "routeTarget": route_target_filter
+                }
+            })))
+            .mount(server)
+            .await;
+    }
+
+    fn input_with_field(name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "inputFields": [
+                {"name": name, "type": {"kind": "INPUT_OBJECT", "name": "IntegerLookup"}}
+            ]
+        })
+    }
+
+    fn input_without_fields() -> serde_json::Value {
+        serde_json::json!({"inputFields": []})
     }
 
     #[tokio::test]
@@ -390,19 +465,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = NetBoxClient::new(
-            &ProfileConfig {
-                url: server.uri(),
-                api: Some(ApiConfig {
-                    search: Some(BackendPreference::Graphql),
-                    vrf: Some(BackendPreference::Graphql),
-                    route_target: Some(BackendPreference::Graphql),
-                }),
-                ..Default::default()
-            },
-            None,
-        )
-        .unwrap();
+        let client = graphql_profile(&server);
         let caps = client.capabilities(&status()).await;
 
         assert!(caps.graphql.probed);
@@ -425,6 +488,90 @@ mod tests {
                 .effective_backend(ApiSurface::Search)
                 .await
                 .uses_graphql()
+        );
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests.len(),
+            1,
+            "failed GraphQL probe should be cached for this client"
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_profile_reports_supported_surfaces() {
+        let server = MockServer::start().await;
+        mount_graphql_probe(
+            &server,
+            input_with_field("vrf_id"),
+            input_with_field("vrf_id"),
+            input_with_field("id"),
+        )
+        .await;
+
+        let client = graphql_profile(&server);
+        let caps = client.capabilities(&status()).await;
+        let surfaces = caps.graphql.surfaces.expect("surface support");
+        assert!(surfaces.vrf.supported);
+        assert!(surfaces.vrf.recommended);
+        assert!(surfaces.route_target.supported);
+        assert!(surfaces.route_target.recommended);
+        assert!(!surfaces.search.supported);
+
+        let routing = client.api_routing().await;
+        assert_eq!(routing.vrf.effective, "graphql");
+        assert_eq!(routing.route_target.effective, "graphql");
+    }
+
+    #[tokio::test]
+    async fn graphql_profile_names_missing_vrf_filters() {
+        let server = MockServer::start().await;
+        mount_graphql_probe(
+            &server,
+            input_without_fields(),
+            input_with_field("vrf_id"),
+            input_with_field("id"),
+        )
+        .await;
+
+        let client = graphql_profile(&server);
+        let caps = client.capabilities(&status()).await;
+        let surfaces = caps.graphql.surfaces.expect("surface support");
+        assert!(!surfaces.vrf.supported);
+        assert_eq!(surfaces.vrf.missing, vec!["prefix_list.vrf_id"]);
+
+        let effective = client.effective_backend(ApiSurface::Vrf).await;
+        assert!(!effective.uses_graphql());
+        assert!(
+            effective
+                .reason()
+                .is_some_and(|reason| reason.contains("prefix_list.vrf_id"))
+        );
+    }
+
+    #[tokio::test]
+    async fn graphql_profile_names_missing_route_target_filter() {
+        let server = MockServer::start().await;
+        mount_graphql_probe(
+            &server,
+            input_with_field("vrf_id"),
+            input_with_field("vrf_id"),
+            input_without_fields(),
+        )
+        .await;
+
+        let client = graphql_profile(&server);
+        let caps = client.capabilities(&status()).await;
+        let surfaces = caps.graphql.surfaces.expect("surface support");
+        assert!(!surfaces.route_target.supported);
+        assert_eq!(surfaces.route_target.missing, vec!["route_target_list.id"]);
+
+        let effective = client.effective_backend(ApiSurface::RouteTarget).await;
+        assert!(!effective.uses_graphql());
+        assert!(
+            effective
+                .reason()
+                .is_some_and(|reason| reason.contains("route_target_list.id"))
         );
     }
 }

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -31,6 +31,8 @@ const DEFAULT_PAGE_SIZE: usize = 100;
 /// `limit`/`offset` matching (see `list_all`).
 pub(crate) const MAX_PAGE_SIZE: usize = 1000;
 
+pub(crate) type GraphqlProbeResult = std::result::Result<GraphqlCapabilities, String>;
+
 /// An HTTP client bound to a single NetBox instance/profile.
 #[derive(Clone)]
 pub struct NetBoxClient {
@@ -41,7 +43,7 @@ pub struct NetBoxClient {
     page_size: usize,
     exclude_config_context: bool,
     api: ApiConfig,
-    graphql_capabilities: Arc<tokio::sync::OnceCell<GraphqlCapabilities>>,
+    graphql_capabilities: Arc<tokio::sync::OnceCell<GraphqlProbeResult>>,
 }
 
 impl NetBoxClient {
@@ -128,7 +130,7 @@ impl NetBoxClient {
             || self.api.route_target == Some(BackendPreference::Graphql)
     }
 
-    pub(crate) fn graphql_capability_cache(&self) -> &tokio::sync::OnceCell<GraphqlCapabilities> {
+    pub(crate) fn graphql_capability_cache(&self) -> &tokio::sync::OnceCell<GraphqlProbeResult> {
         &self.graphql_capabilities
     }
 

--- a/src/netbox/graphql.rs
+++ b/src/netbox/graphql.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
@@ -155,9 +155,16 @@ impl NetBoxClient {
     pub async fn graphql_capabilities(&self) -> Result<GraphqlCapabilities> {
         let capabilities = self
             .graphql_capability_cache()
-            .get_or_try_init(|| async { self.load_graphql_capabilities().await })
-            .await?;
-        Ok(capabilities.clone())
+            .get_or_init(|| async {
+                self.load_graphql_capabilities()
+                    .await
+                    .map_err(|err| format!("{err:#}"))
+            })
+            .await;
+        match capabilities {
+            Ok(capabilities) => Ok(capabilities.clone()),
+            Err(err) => Err(anyhow!(err.clone())),
+        }
     }
 
     async fn load_graphql_capabilities(&self) -> Result<GraphqlCapabilities> {
@@ -174,8 +181,9 @@ impl NetBoxClient {
     /// detail "bundle"), normalized into the REST wire models so the downstream
     /// `VrfDetail` build is byte-identical to the REST path. The caller resolves
     /// the VRF id and its header over REST first (identity stays canonical); this
-    /// fetches only the children. A real GraphQL/transport error propagates (fail
-    /// closed) rather than degrading to empty data.
+    /// fetches only the children. GraphQL/transport errors propagate to the detail
+    /// builder, which retries the same detail over REST rather than degrading to
+    /// empty data.
     pub(crate) async fn graphql_vrf_bundle(
         &self,
         vrf_id: u64,
@@ -184,20 +192,20 @@ impl NetBoxClient {
         let caps = self.graphql_capabilities().await?;
         let mut prefix_filters = Map::new();
         let mut ip_filters = Map::new();
-        gql_add_filter(
+        gql_add_required_filter(
             &caps,
             "prefix_list",
             &mut prefix_filters,
             "vrf_id",
             json!(vrf_id),
-        );
-        gql_add_filter(
+        )?;
+        gql_add_required_filter(
             &caps,
             "ip_address_list",
             &mut ip_filters,
             "vrf_id",
             json!(vrf_id),
-        );
+        )?;
         let prefix_type = caps
             .list("prefix_list")
             .and_then(|f| f.filter_type())
@@ -240,8 +248,8 @@ impl NetBoxClient {
     /// shape the REST path produces so the downstream `RouteTargetDetail` build is
     /// byte-identical. The caller resolves the route target's identity + header
     /// over REST first (identity stays canonical); this fetches only the relation
-    /// graph. A real GraphQL/transport error propagates (fail closed) rather than
-    /// degrading to empty data.
+    /// graph. GraphQL/transport errors propagate to the detail builder, which
+    /// retries the same detail over REST rather than degrading to empty data.
     ///
     /// A route target carries its VRF relations on both sides
     /// (`importing_vrfs`/`exporting_vrfs`), so one filtered `route_target_list`
@@ -252,13 +260,13 @@ impl NetBoxClient {
     ) -> Result<(Vec<VrfRef>, Vec<VrfRef>)> {
         let caps = self.graphql_capabilities().await?;
         let mut filters = Map::new();
-        gql_add_filter(
+        gql_add_required_filter(
             &caps,
             "route_target_list",
             &mut filters,
             "id",
             json!(route_target_id),
-        );
+        )?;
         let filter_type = caps
             .list("route_target_list")
             .and_then(|f| f.filter_type())
@@ -327,6 +335,25 @@ fn gql_add_filter(
     };
     filters.insert(key.into(), value);
     true
+}
+
+fn gql_add_required_filter(
+    caps: &GraphqlCapabilities,
+    list_name: &str,
+    filters: &mut Map<String, Value>,
+    key: &str,
+    value: Value,
+) -> Result<()> {
+    if gql_add_filter(caps, list_name, filters, key, value) {
+        return Ok(());
+    }
+    let Some(filter_type) = caps.list(list_name).and_then(|field| field.filter_type()) else {
+        bail!("GraphQL schema is missing the {list_name} filter type");
+    };
+    if caps.filter_shape(filter_type, key).is_none() {
+        bail!("GraphQL {filter_type} is missing required {key} filter");
+    }
+    bail!("GraphQL {filter_type}.{key} filter rejected the required value");
 }
 
 /// The combined VRF-bundle response. GraphQL ids are strings, `status` is a
@@ -767,6 +794,54 @@ mod tests {
         assert_eq!(
             caps.filter_value("DeviceFilter", "location_id", json!(7)),
             Some(json!({ "id": "7", "match_type": "EXACT" }))
+        );
+    }
+
+    #[test]
+    fn required_filter_errors_instead_of_querying_unscoped_data() {
+        let mut caps = GraphqlCapabilities::default();
+        caps.list_fields.insert(
+            "prefix_list".into(),
+            ListField {
+                filter_type: Some("PrefixFilter".into()),
+                pagination_arg: None,
+            },
+        );
+        caps.filters.insert("PrefixFilter".into(), HashMap::new());
+        let mut filters = Map::new();
+
+        let err = gql_add_required_filter(&caps, "prefix_list", &mut filters, "vrf_id", json!(42))
+            .expect_err("missing required filter should error");
+
+        assert!(
+            format!("{err:#}").contains("PrefixFilter is missing required vrf_id filter"),
+            "unexpected error: {err:#}"
+        );
+        assert!(filters.is_empty());
+    }
+
+    #[test]
+    fn pagination_clause_tracks_schema_support() {
+        let mut caps = GraphqlCapabilities::default();
+        caps.list_fields.insert(
+            "old_list".into(),
+            ListField {
+                filter_type: Some("OldFilter".into()),
+                pagination_arg: None,
+            },
+        );
+        caps.list_fields.insert(
+            "new_list".into(),
+            ListField {
+                filter_type: Some("NewFilter".into()),
+                pagination_arg: Some("pagination".into()),
+            },
+        );
+
+        assert_eq!(gql_pagination(&caps, "old_list", 200), "");
+        assert_eq!(
+            gql_pagination(&caps, "new_list", 200),
+            ", pagination: {offset: 0, limit: 200}"
         );
     }
 


### PR DESCRIPTION
## Summary

- cache GraphQL schema probe failures per client and require mandatory bundle filters before issuing GraphQL detail queries
- retry VRF and route-target detail over REST when an effective GraphQL bundle fails at runtime, preserving the same output shape instead of returning an accelerator error
- fix GraphQL routing docs/status wording across README, docs, changelog, and roadmap; deferred GraphQL probing/version/pagination work is tracked in ROADMAP

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo test --all-features`
- `cargo test --no-default-features`
