### PR TITLE
test(it): assert route_target effective backend on the live 4.5 lane

### DIFF
--- a/tests/it_netbox.rs
+++ b/tests/it_netbox.rs
@@ -180,6 +180,11 @@ fn graphql_backend_status_and_vrf_detail_work() {
     assert_eq!(v["api"]["vrf"]["configured"], "graphql", "got: {v}");
     assert_eq!(v["api"]["vrf"]["effective"], "graphql", "got: {v}");
     assert_eq!(
+        v["api"]["route_target"]["configured"], "graphql",
+        "got: {v}"
+    );
+    assert_eq!(v["api"]["route_target"]["effective"], "graphql", "got: {v}");
+    assert_eq!(
         v["api"]["search"]["effective"], "rest",
         "search must stay REST: {v}"
     );


### PR DESCRIPTION
Quick follow-up to #91. The live `graphql_backend_status_and_vrf_detail_work` test asserted the `vrf` and `search` effective backends but not `route_target`. Now that the RT GraphQL surface is hardened (#91), add the symmetric assertions:

```rust
assert_eq!(v["api"]["route_target"]["configured"], "graphql", ...);
assert_eq!(v["api"]["route_target"]["effective"],  "graphql", ...);
```

so a regression in route-target backend selection is caught against the real NetBox 4.5 GraphQL schema.

This can only be validated by the `live NetBox 4.5 GraphQL backend` lane (the test is `#[ignore]`'d and needs the seeded fixture) — that lane passing is the proof the live 4.5 schema resolves the RT surface to GraphQL.