### PR TITLE
perf(prefix): cover full /24 address details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Prefix contained IP detail cap.** Prefix detail now fetches up to 512
+  contained IP rows while child prefixes and other detail sections stay at the
+  shared 200-row cap. This covers a full IPv4 `/24` (254 hosts) in CLI, MCP, and
+  TUI prefix detail without adding a new flag or changing the output shape.
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,15 +93,15 @@ Polish the read experience. No writes here.
     `within "10.0.0.0/24"`. Every Nav-rail kind is now filterable; the router's
     `None` → search arm stays as a defensive fallback for a future non-filterable
     browse kind.
-- ☐ **Targeted fetch-all for capped sub-resources.** Browse intentionally stops
-  at `BROWSE_CAP` (currently 500) and expects server-side filtering, not scrolling
-  through thousands of rows. Detail tabs stop at `DETAIL_SECTION_CAP` (200). The
-  only proven remaining cap pain is bounded sub-resources that operators naturally
-  inspect as a whole, e.g. a full `/24`'s contained IPs (254 hosts) truncating at
-  200. Do **not** resurrect generic load-more-on-scroll for every browse; add an
-  explicit fetch-all / raise-cap action on the affected detail tabs, following
-  the server's `next` link through `list_all` (the old `offset += page_size` row
-  skip is already fixed in 0.12.0).
+- ☑ **Prefix contained IP cap for full `/24`s.** Prefix detail's contained-IP tab
+  now fetches up to 512 rows in CLI, MCP, and TUI detail, covering a full IPv4
+  `/24` (254 hosts) while child prefixes and other detail tabs stay at
+  `DETAIL_SECTION_CAP` (200). Browse intentionally remains capped at
+  `BROWSE_CAP` (currently 500) and expects server-side filtering, not scrolling
+  through thousands of rows. Do **not** resurrect generic load-more-on-scroll for
+  every browse; only add targeted higher caps/load-more on detail tabs when a
+  real operator workflow proves the need. The old `offset += page_size` row skip
+  is already fixed in 0.12.0.
 - ☐ **Hierarchical scope filters (descendant expansion).** `--region`/`--site-group`/`--location` (and the
   TUI scope) match **exactly** today — a region matches only prefixes scoped to the region itself, not the
   sites inside it (`KNOWN_ISSUES.md`). NetBox's `PrefixFilter` has no `within`/descendant lookup (see the

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -53,16 +53,18 @@ use crate::netbox::prefix_tree::build_nodes;
 use crate::netbox::query;
 use crate::netbox::search::ObjectKind;
 
-/// Cap on the child rows pulled into any one detail-view section: a device's
-/// interfaces/IPs/services, a prefix's child prefixes/member IPs, a VLAN's
-/// referencing prefixes, or a VRF's scoped prefixes/addresses. One concept
+/// Cap on the child rows pulled into most detail-view sections: a device's
+/// interfaces/IPs/services, a prefix's child prefixes, a VLAN's referencing
+/// prefixes, or a VRF's scoped prefixes/addresses. One concept
 /// ("rows in one detail section") → one cap, named at the rendering layer the
 /// cap operates on, not the dcim/ipam domain layer. Sized generously below
 /// NetBox's `MAX_PAGE_SIZE` (1000) so a section-full is a single round trip.
-/// NOTE: a full `/24` (254 hosts) still truncates at 200; closing that fully is
-/// a targeted `--all` toggle, not a cap bump (200 covers the vast majority and
-/// ends the prior 50-vs-200 inconsistency).
+/// NOTE: prefix contained IPs use a targeted higher cap below so a full IPv4
+/// `/24` fits without changing every detail tab's fetch budget.
 const DETAIL_SECTION_CAP: usize = 200;
+/// Prefix detail's contained-address tab needs room for a full IPv4 `/24` while
+/// still staying bounded and below NetBox's `MAX_PAGE_SIZE` (1000).
+const PREFIX_CONTAINED_IP_CAP: usize = 512;
 /// How many recent journal entries to fold into a detail view with `--journal`.
 pub const JOURNAL_INLINE_MAX: usize = 5;
 
@@ -262,7 +264,7 @@ pub async fn resolve_prefix(
 }
 
 /// `prefix <cidr>`: resolve a prefix (scoped by `vrf`) and build its view with
-/// children and member IPs (cap [`DETAIL_SECTION_CAP`]). Shared by CLI/MCP.
+/// child prefixes and member IPs. Shared by CLI/MCP.
 pub async fn prefix_view_by_ref(
     client: &NetBoxClient,
     cidr: &str,
@@ -273,15 +275,23 @@ pub async fn prefix_view_by_ref(
     // Scope children/member IPs to the resolved prefix's VRF (or the global table
     // when it has none), so a CIDR shared across VRFs can't pull the wrong VRF's.
     let vrf_id = prefix.vrf.as_ref().map(|v| v.id);
-    // Children and contained IPs are independent; fetch them concurrently (as
-    // the TUI `ObjectKind::Prefix` arms do) so the CLI/MCP prefix detail costs
-    // one round-trip for the header plus one for both child collections, not
-    // two sequential awaits.
-    let (children, ips) = tokio::try_join!(
-        client.prefix_children(cidr, vrf_id, DETAIL_SECTION_CAP),
-        client.prefix_ips(cidr, vrf_id, DETAIL_SECTION_CAP),
-    )?;
+    let (children, ips) = prefix_children_and_ips(client, cidr, vrf_id).await?;
     Ok(PrefixView::build(prefix, children, ips))
+}
+
+async fn prefix_children_and_ips(
+    client: &NetBoxClient,
+    cidr: &str,
+    vrf_id: Option<u64>,
+) -> Result<(Vec<Prefix>, Vec<IpAddress>)> {
+    // Children and contained IPs are independent; fetch them concurrently so
+    // prefix detail costs one round-trip for the header plus one for both child
+    // collections, not two sequential awaits. Only contained IPs get the higher
+    // cap; child prefixes keep the shared detail-section budget.
+    tokio::try_join!(
+        client.prefix_children(cidr, vrf_id, DETAIL_SECTION_CAP),
+        client.prefix_ips(cidr, vrf_id, PREFIX_CONTAINED_IP_CAP),
+    )
 }
 
 /// Fetch the VLAN's group (for its scope) only when the VLAN actually has one.
@@ -1912,13 +1922,7 @@ pub async fn load_detail(client: &NetBoxClient, kind: ObjectKind, id: u64) -> Re
             links = prefix_links(&p);
             let cidr = p.prefix.clone();
             let vrf_id = p.vrf.as_ref().map(|v| v.id);
-            // Children and contained IPs are independent; fetch them concurrently
-            // (as build_vrf_detail does) so prefix detail costs one round-trip for
-            // the header plus one for both child collections, not two sequential.
-            let (children, ips) = tokio::try_join!(
-                client.prefix_children(&cidr, vrf_id, DETAIL_SECTION_CAP),
-                client.prefix_ips(&cidr, vrf_id, DETAIL_SECTION_CAP),
-            )?;
+            let (children, ips) = prefix_children_and_ips(client, &cidr, vrf_id).await?;
             let (title, prefix_body, prefix_tabs) = prefix_detail_parts(p, children, ips);
             tabs = prefix_tabs;
             (title, prefix_body)
@@ -2168,13 +2172,7 @@ pub async fn load_detail_by_ref(
             links = prefix_links(&p);
             let cidr = p.prefix.clone();
             let vrf_id = p.vrf.as_ref().map(|v| v.id);
-            // Children and contained IPs are independent; fetch them concurrently
-            // (as build_vrf_detail does) so prefix detail costs one round-trip for
-            // the header plus one for both child collections, not two sequential.
-            let (children, ips) = tokio::try_join!(
-                client.prefix_children(&cidr, vrf_id, DETAIL_SECTION_CAP),
-                client.prefix_ips(&cidr, vrf_id, DETAIL_SECTION_CAP),
-            )?;
+            let (children, ips) = prefix_children_and_ips(client, &cidr, vrf_id).await?;
             let (title, prefix_body, prefix_tabs) = prefix_detail_parts(p, children, ips);
             tabs = prefix_tabs;
             (id, title, prefix_body)

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -425,6 +425,15 @@ async fn get_ip_returns_ip_view_with_parent_context() {
 #[tokio::test]
 async fn get_prefix_returns_children_and_ips() {
     let mock = MockServer::start().await;
+    let ip_results: Vec<_> = (1u16..=254u16)
+        .map(|host| {
+            json!({
+                "id": u64::from(1000 + host),
+                "url": "u",
+                "address": format!("10.44.208.{host}/24")
+            })
+        })
+        .collect();
     // prefix_candidates: exact CIDR match.
     Mock::given(method("GET"))
         .and(path("/api/ipam/prefixes/"))
@@ -442,6 +451,8 @@ async fn get_prefix_returns_children_and_ips() {
     Mock::given(method("GET"))
         .and(path("/api/ipam/prefixes/"))
         .and(query_param("within", "10.44.208.0/24"))
+        .and(query_param("vrf_id", "null"))
+        .and(query_param("limit", "200"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "count": 1, "next": null, "previous": null,
             "results": [{"id": 6, "url": "u", "prefix": "10.44.208.0/26"}]
@@ -452,9 +463,11 @@ async fn get_prefix_returns_children_and_ips() {
     Mock::given(method("GET"))
         .and(path("/api/ipam/ip-addresses/"))
         .and(query_param("parent", "10.44.208.0/24"))
+        .and(query_param("vrf_id", "null"))
+        .and(query_param("limit", "512"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "count": 1, "next": null, "previous": null,
-            "results": [{"id": 7, "url": "u", "address": "10.44.208.1/24"}]
+            "count": 254, "next": null, "previous": null,
+            "results": ip_results
         })))
         .mount(&mock)
         .await;
@@ -468,6 +481,9 @@ async fn get_prefix_returns_children_and_ips() {
     assert_eq!(value["status"], "active");
     assert_eq!(value["child_prefixes"][0], "10.44.208.0/26");
     assert_eq!(value["ip_addresses"][0]["address"], "10.44.208.1/24");
+    let addresses = value["ip_addresses"].as_array().expect("ip addresses");
+    assert_eq!(addresses.len(), 254);
+    assert_eq!(addresses[253]["address"], "10.44.208.254/24");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a targeted 512-row cap for prefix contained IPs so a full IPv4 /24 address tab is not truncated at 200
- centralize prefix child/address fan-out so CLI/MCP and both TUI prefix detail paths share the same behavior
- keep child prefixes and every other detail tab on the existing 200-row DETAIL_SECTION_CAP
- update changelog and roadmap to mark this specific cap pain handled while generic load-more remains deferred

## Tests

- cargo fmt --all -- --check
- cargo test mcp::tests::get_prefix_returns_children_and_ips
- cargo test prefix
- cargo test pagination_tests
- cargo test --lib
- cargo clippy --all-targets --all-features --locked -- -D warnings
- cargo clippy --all-targets --no-default-features --locked -- -D warnings
- cargo test --all-features --locked
- cargo test --no-default-features --locked

## Review Notes

- No CLI flag, MCP argument, or JSON shape change.
- The focused MCP test now pins child prefix limit=200, contained IP limit=512, and 254 returned /24 host rows.
- Local reviewer agent found no blocking findings after the manual self-review pass.
