### PR TITLE
feat(search): use tree-aware scope filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `nbox search --region`/`--site-group`/`--location` now uses NetBox's native
+  tree-aware `region_id`/`site_group_id`/`location_id` filters on scoped prefix
+  and cluster search, so those scope filters include descendants server-side.
+  `--site` remains an exact `scope_type=dcim.site` + `scope_id=<id>` match, and
+  `--vrf` continues to combine with prefix scope filters.
+
 ## [0.13.0] - 2026-06-25
 
 ### Added

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -14,24 +14,6 @@ claim them; `tags`/`journal` are list-only.
 
 ---
 
-### Search scope/VRF filters are exact, not hierarchical
-
-**Issue:** `nbox search` takes `--vrf` (resolves id/RD/name, filters IP/prefix by
-`vrf_id=`) and the scope flags `--site/--region/--site-group/--location` (resolve
-the ref once, filter prefixes by `scope_type`+`scope_id`). The scope match is
-**exact**: `--region` filters by that region's own scope only — it does not pull
-in prefixes scoped to sites *inside* the region. At most one scope flag may be set
-at a time.
-
-**Impact:** A hierarchical question ("everything under region X") needs more than
-one query, or an id-based filter on an endpoint that supports it.
-
-**Mitigation:** Filter at the level the object is scoped, combine with `--vrf`, or
-use `nbox raw GET` with explicit params. Descendant/hierarchy expansion is not
-implemented.
-
----
-
 ### Parent-prefix enrichment is a best-effort longest match
 
 **Issue:** `nbox ip` computes the parent prefix locally (longest match) from the

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [Installation](#installation) below for setup instructions.
 ## Features
 
 - **Fast shell lookups** — `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `virtual-circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`, `route-target`, `mac`, and `interface`, each as a one-liner.
-- **Normalized search** — one `search` query runs in parallel across devices, sites, racks, IPs, prefixes, VLANs, circuits, virtual circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs, clusters, VRFs, and route targets, returning ranked, deduped hits. Scope it with `--site`/`--region`/`--site-group`/`--location` (one at a time, exact scope), or narrow by `--status`/`--tenant`/`--role`/`--tag`/`--vrf`.
+- **Normalized search** — one `search` query runs in parallel across devices, sites, racks, IPs, prefixes, VLANs, circuits, virtual circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs, clusters, VRFs, and route targets, returning ranked, deduped hits. Scope it with `--site` (exact) or `--region`/`--site-group`/`--location` (hierarchical where NetBox exposes tree filters), one at a time; or narrow by `--status`/`--tenant`/`--role`/`--tag`/`--vrf`.
 - **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` for free addresses and blocks (read-only — nothing is reserved).
 - **A k9s-style TUI** — a three-pane home (navigation rail → results → live preview), an overview dashboard, a hierarchical prefix tree, cross-object navigation between related objects (every detail's related-object tabs are navigable — open an interface from a device and see its cable path drawn as an A↔Z diagram), fuzzy filters, server-side name filtering on the browse list, recents, and an in-app profile + settings editor. Twelve themes; `NO_COLOR` honored.
 - **Agent-ready** — `nbox serve` is a read-only MCP server: the same lookups exposed as eleven tools (plus every object as an `nbox://{kind}/{ref}` resource), returning the exact JSON view models the CLI does, so AI agents (Claude Code, Claude Desktop, …) query NetBox safely. Stdio for a local subprocess, or a loopback HTTP transport with OIDC resource-server auth for a network-reachable, read-only deployment. See [docs/MCP.md](docs/MCP.md); [SKILL.md](SKILL.md) is an installable Agent Skill that drives the CLI on matching requests.
@@ -244,7 +244,8 @@ nbox                              # launch the TUI
 nbox status                       # connection + backend capabilities + NetBox/Django/Python versions
                                   # + token-validity preflight (NetBox 4.5+)
 nbox search <query> [--limit N] [--status/--site/--region/--site-group/--location/--tenant/--role/--tag <v>] [--owner <name>] [--owner-group <name>] [--vrf <id|rd|name>] [--cols a,b,c] [--partial]
-                                  # one scope flag at a time, exact match; --vrf filters IP/prefix results.
+                                  # one scope flag at a time; --site is exact, region/site-group/location include descendants where supported.
+                                  # --vrf filters IP/prefix results.
                                   # --owner/--owner-group filter by user/group name (NetBox 4.5+).
                                   # Full scope/filter semantics: docs/FEATURES.md
 nbox device <name-or-id> [--journal] [--journal-limit N]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,15 +102,15 @@ Polish the read experience. No writes here.
   explicit fetch-all / raise-cap action on the affected detail tabs, following
   the server's `next` link through `list_all` (the old `offset += page_size` row
   skip is already fixed in 0.12.0).
-- ☐ **Hierarchical scope filters (descendant expansion).** `--region`/`--site-group`/`--location` (and the
-  TUI scope) match **exactly** today — a region matches only prefixes scoped to the region itself, not the
-  sites inside it (`KNOWN_ISSUES.md`). NetBox's `PrefixFilter` has no `within`/descendant lookup (see the
-  Performance-candidates skip note below), so the fix is client-side: resolve the scope to its descendant
-  sites, then filter by those ids. Not a one-liner — it needs the region→site expansion path.
+- ☑ **Hierarchical scope filters.** `search --region`/`--site-group`/`--location`
+  now uses NetBox's native tree-aware scoped id filters (`region_id`,
+  `site_group_id`, `location_id`) on prefixes and clusters, so the selected node
+  and its descendants are included server-side. `--site` stays exact via the
+  polymorphic `scope_type=dcim.site` + `scope_id=<id>` match.
 - _Tracked vs by-design (`KNOWN_ISSUES.md` cross-reference, so the two docs stop drifting): the
   browse/sub-resource caps are covered by load-more above; the `offset += page_size` skip is **fixed**
-  (0.12.0, `list_all` now follows `next`); hierarchical scope by the item above; read-only by **Writes
-  — deferred** and CSV shape by **CSV/output-mode contracts**; device-by-name-vs-display is documented
+  (0.12.0, `list_all` now follows `next`); hierarchical scope is **fixed** by the item above; read-only
+  by **Writes — deferred** and CSV shape by **CSV/output-mode contracts**; device-by-name-vs-display is documented
   (a `device_by_ref` suffix-strip fallback is a candidate fix), not yet scheduled. The remaining two —
   parent-prefix enrichment as a best-effort longest match, and name lookups resolving exact-then-contains
   — are **by design** (surfacing ambiguity over guessing), acknowledged here, not tracked for a fix._
@@ -628,8 +628,9 @@ Consolidated future scope:
   limit, 11 read tools, `nbox://{kind}/{ref}` resources.
 - ☑ **Read coverage** — circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs,
   clusters; journal command + inline `--journal`; services on device detail; cable/interface trace.
-- ☑ **Scope/VRF** — `search --vrf`, scope filters (`--region`/`--site-group`/`--location`), exact
-  VRF-by-RD, VRF-scoped prefix child/IP sections.
+- ☑ **Scope/VRF** — `search --vrf`, hierarchical scope filters
+  (`--region`/`--site-group`/`--location`), exact VRF-by-RD, VRF-scoped prefix
+  child/IP sections.
 - ☑ **TUI** — list/preview split + focus, scrolling + position cues, profile switcher, the in-app
   Config modal (profile editor + settings + first-run onboarding).
 - ☑ **Secrets** — OS keyring token storage with env fallback (historical; the keyring surface was

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -34,11 +34,13 @@ flag, and the per-surface backend routing.
 ## How nbox adapts
 
 - **Scope (4.2).** Prefixes/VLANs/clusters use the polymorphic `scope`, so a plain
-  `?site=` slug filter is dead on those endpoints. `--site`/`--region`/`--group`/
-  `--location` resolve to a numeric id once, then go out-of-band per endpoint: the
-  polymorphic endpoints (prefixes, clusters) get `scope_type=dcim.<kind>` +
-  `scope_id=<id>`; the rest get `site_id`/`region_id`/… An endpoint with no clean
-  filter for the active scope skips itself rather than return an unfiltered set.
+  `?site=` slug filter is dead on those endpoints. `--site`/`--region`/
+  `--site-group`/`--location` resolve to a numeric id once, then go out-of-band
+  per endpoint: the scoped endpoints (prefixes, clusters) keep exact `--site`
+  with `scope_type=dcim.site` + `scope_id=<id>` and use NetBox's tree-aware
+  `region_id`/`site_group_id`/`location_id` filters for hierarchical scopes; the
+  rest get `site_id`/`region_id`/… An endpoint with no clean filter for the active
+  scope skips itself rather than return an unfiltered set.
 
 - **Search is always REST.** NetBox 4.3 reworked GraphQL filtering into advanced
   per-field lookups (AND/OR, custom fields — NetBox #7598). GraphQL has no

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -44,20 +44,21 @@ several sites) exit `5` and list the candidates; scope with `--vrf`/`--site`/`--
 `search --site/--region/--site-group/--location <ref>` resolves the reference
 once (by slug, name, or **id**) to a numeric id and filters prefixes by that
 scope — NetBox 4.2 replaced the prefix `site` field with the polymorphic `scope`,
-so prefixes are matched on `scope_type=dcim.site`/`dcim.region`/`dcim.sitegroup`/
-`dcim.location` + `scope_id`, not the dead `?site=` filter. The match is
-**exact**: each flag filters by its own scope only (no hierarchy/descendant
-expansion — `--region` does not pull in prefixes scoped to sites inside that
-region). At most **one** scope flag may be set (the prefix `scope` is a single
-type+id); passing more than one is a usage error (exit `2`). An unknown reference
-is a not-found error (exit `4`), not a silent empty result. Non-prefix endpoints
-filter by the **resolved id**, never a raw value (the plain `?site=` param wants a
-slug, so a `--site` given as an id or display name would silently match nothing):
-clusters carry the same polymorphic scope, so they honor all four scopes via
-`scope_type`+`scope_id`; devices honor every scope via `site_id`/`region_id`/
-`site_group_id`/`location_id`; VLANs and VMs honor `--site` via `site_id`;
-endpoints that can't filter by a given scope are skipped rather than sent a dead
-param.
+so scoped endpoints are filtered out-of-band rather than through the dead
+`?site=` prefix filter. `--site` is exact (`scope_type=dcim.site` +
+`scope_id=<id>` on prefixes/clusters; `site_id=<id>` where available). The
+hierarchical scopes use NetBox's tree-aware id filters where the endpoint
+supports them: `region_id`, `site_group_id`, and `location_id` include the
+selected node and its descendants. At most **one** scope flag may be set (the
+prefix `scope` is a single type+id); passing more than one is a usage error
+(exit `2`). An unknown reference is a not-found error (exit `4`), not a silent
+empty result. Non-prefix endpoints filter by the **resolved id**, never a raw
+value (the plain `?site=` param wants a slug, so a `--site` given as an id or
+display name would silently match nothing): clusters carry the same scoped model
+filters as prefixes; devices and racks honor every scope via
+`site_id`/`region_id`/`site_group_id`/`location_id`; VLANs and VMs honor `--site`
+via `site_id`; endpoints that can't filter by a given scope are skipped rather
+than sent a dead param.
 
 `search --vrf <id|rd|name>` resolves the VRF once (numeric id, then RD, then
 name — VRFs have no slug) and filters the VRF-capable endpoints (IPs, prefixes)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,23 +78,27 @@ pub enum Command {
         #[arg(long)]
         status: Option<String>,
 
-        /// Filter by site (slug, name, or id). Prefixes are matched on site
-        /// scope. Mutually exclusive with --region/--site-group/--location.
+        /// Filter by site (slug, name, or id). Scoped prefixes/clusters match
+        /// exact site scope. Mutually exclusive with --region/--site-group/
+        /// --location.
         #[arg(long)]
         site: Option<String>,
 
-        /// Filter by region (slug, name, or id). Prefixes are matched on region
-        /// scope. Mutually exclusive with --site/--site-group/--location.
+        /// Filter by region (slug, name, or id). Scoped prefixes/clusters include
+        /// descendants through NetBox's region_id filter. Mutually exclusive
+        /// with --site/--site-group/--location.
         #[arg(long)]
         region: Option<String>,
 
-        /// Filter by site group (slug, name, or id). Prefixes are matched on
-        /// site-group scope. Mutually exclusive with --site/--region/--location.
+        /// Filter by site group (slug, name, or id). Scoped prefixes/clusters include
+        /// descendants through NetBox's site_group_id filter. Mutually exclusive
+        /// with --site/--region/--location.
         #[arg(long = "site-group")]
         site_group: Option<String>,
 
-        /// Filter by location (slug, name, or id). Prefixes are matched on
-        /// location scope. Mutually exclusive with --site/--region/--site-group.
+        /// Filter by location (slug, name, or id). Scoped prefixes/clusters include
+        /// descendants through NetBox's location_id filter. Mutually exclusive
+        /// with --site/--region/--site-group.
         #[arg(long)]
         location: Option<String>,
 

--- a/src/netbox/query.rs
+++ b/src/netbox/query.rs
@@ -401,8 +401,8 @@ impl NetBoxClient {
 
     /// Resolve a region by numeric id, then slug, then exact name, then
     /// name-contains. Mirrors [`site_by_ref`](Self::site_by_ref); used to
-    /// translate `--region` into a numeric id for prefix `scope_type=dcim.region`
-    /// filtering. The id fast-path hits the detail endpoint; a hit returns
+    /// translate `--region` into the numeric id that search scope filters apply
+    /// per endpoint. The id fast-path hits the detail endpoint; a hit returns
     /// immediately (so `--region 5` resolves), but a 404 FALLS THROUGH to the
     /// slug/name lookups (a numeric slug/name still resolves).
     pub async fn region_by_ref(&self, value: &str) -> Result<Option<Region>> {
@@ -433,11 +433,10 @@ impl NetBoxClient {
 
     /// Resolve a site group by numeric id, then slug, then exact name, then
     /// name-contains. Mirrors [`site_by_ref`](Self::site_by_ref); used to
-    /// translate `--site-group` into a numeric id for prefix
-    /// `scope_type=dcim.sitegroup` filtering. The id fast-path hits the detail
-    /// endpoint; a hit returns immediately (so `--site-group 5` resolves), but a
-    /// 404 FALLS THROUGH to the slug/name lookups (a numeric slug/name still
-    /// resolves).
+    /// translate `--site-group` into the numeric id that search scope filters
+    /// apply per endpoint. The id fast-path hits the detail endpoint; a hit
+    /// returns immediately (so `--site-group 5` resolves), but a 404 FALLS
+    /// THROUGH to the slug/name lookups (a numeric slug/name still resolves).
     pub async fn site_group_by_ref(&self, value: &str) -> Result<Option<SiteGroup>> {
         if let Ok(id) = value.parse::<u64>()
             && let Some(g) = self
@@ -466,10 +465,10 @@ impl NetBoxClient {
 
     /// Resolve a location by numeric id, then slug, then exact name, then
     /// name-contains. Mirrors [`site_by_ref`](Self::site_by_ref); used to
-    /// translate `--location` into a numeric id for prefix
-    /// `scope_type=dcim.location` filtering. The id fast-path hits the detail
-    /// endpoint; a hit returns immediately (so `--location 5` resolves), but a 404
-    /// FALLS THROUGH to the slug/name lookups (a numeric slug/name still resolves).
+    /// translate `--location` into the numeric id that search scope filters apply
+    /// per endpoint. The id fast-path hits the detail endpoint; a hit returns
+    /// immediately (so `--location 5` resolves), but a 404 FALLS THROUGH to the
+    /// slug/name lookups (a numeric slug/name still resolves).
     pub async fn location_by_ref(&self, value: &str) -> Result<Option<Location>> {
         if let Ok(id) = value.parse::<u64>()
             && let Some(l) = self

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -153,11 +153,13 @@ impl ObjectKind {
 /// `site`/`region`/`site_group`/`location` are *scope* filters: NetBox 4.2's
 /// prefix `scope` is a single polymorphic type+id, so at most one of them may be
 /// set at a time (enforced in [`NetBoxClient::search`]). All four are resolved to
-/// a numeric id up front and handled out-of-band per endpoint — as `scope_type`+
-/// `scope_id` on the polymorphic endpoints (prefixes, clusters) and as
-/// `site_id`/`region_id`/`site_group_id`/`location_id` on the rest — never through
-/// the plain-value allowlist below (the plain `?site=` param wants a slug, so an
-/// id or display name would silently match nothing).
+/// a numeric id up front and handled out-of-band per endpoint. Prefixes/clusters
+/// use exact `scope_type=dcim.site` + `scope_id=<id>` for `--site`, and NetBox's
+/// tree-aware `region_id`/`site_group_id`/`location_id` filters for the non-site
+/// scopes. Other endpoints use the clean `site_id`/`region_id`/… filter when
+/// available. Scope filters never flow through the plain-value allowlist below
+/// (the plain `?site=` param wants a slug, so an id or display name would
+/// silently match nothing).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SearchFilters {
     pub status: Option<String>,
@@ -201,9 +203,11 @@ impl SearchFilters {
     ///
     /// Scope filters (`site`/`region`/`site_group`/`location`) are *not* included
     /// here — they're resolved to a numeric id once and applied out-of-band per
-    /// endpoint (as `site_id`/`region_id`/… or `scope_type`+`scope_id`). The plain
-    /// `?site=` param expects a *slug*, so a `--site` given as an id or display
-    /// name would silently match nothing; the resolved id avoids that.
+    /// endpoint (`scope_type`+`scope_id` for exact `--site` on scoped models,
+    /// tree-aware `region_id`/`site_group_id`/`location_id` for non-site scopes,
+    /// or `site_id`/`region_id`/… on other endpoints). The plain `?site=` param
+    /// expects a *slug*, so a `--site` given as an id or display name would
+    /// silently match nothing; the resolved id avoids that.
     fn params_for(&self, supported: &[&str]) -> Option<Vec<(&'static str, String)>> {
         let active: [(&'static str, &Option<String>); 6] = [
             ("status", &self.status),
@@ -313,6 +317,27 @@ fn skip_for_any_scope(scope: Option<&ResolvedScope>) -> bool {
     scope.is_some()
 }
 
+fn scoped_model_params(scope: Option<&ResolvedScope>) -> Vec<(&'static str, String)> {
+    let Some(s) = scope else {
+        return Vec::new();
+    };
+    match s.content_type {
+        // Preserve exact site semantics. The polymorphic `scope` exact match is
+        // deliberately narrower than NetBox's `_site` helper and avoids widening
+        // `--site` if scoped models ever grow indirect site inheritance.
+        "dcim.site" => vec![
+            ("scope_type", s.content_type.to_string()),
+            ("scope_id", s.id.to_string()),
+        ],
+        // NetBox's ScopedFilterSet backs these with TreeNodeMultipleChoiceFilter,
+        // so the selected node and its descendants are matched server-side.
+        "dcim.region" => vec![("region_id", s.id.to_string())],
+        "dcim.sitegroup" => vec![("site_group_id", s.id.to_string())],
+        "dcim.location" => vec![("location_id", s.id.to_string())],
+        _ => Vec::new(),
+    }
+}
+
 /// A typed not-found error for an unresolved scope reference, e.g. a `--region`
 /// that matches nothing. Exit 4, with an actionable hint — mirrors the original
 /// `--site` not-found message.
@@ -347,8 +372,10 @@ fn vlan_subtitle(v: &Vlan) -> Option<String> {
 /// the schema canary (``mod schema_canary`` below) validates against a pinned
 /// NetBox OpenAPI snapshot. The scope filters (`site`/`region`/`site_group`/
 /// `location`) are *not* here — they're resolved to an id once and applied
-/// out-of-band per endpoint (`site_id`/`region_id`/… or `scope_type`+`scope_id`)
-/// by each branch, never as the raw `?site=` slug.
+/// out-of-band per endpoint (`scope_type`+`scope_id` for exact `--site` on
+/// scoped models, native scoped id filters for non-site scopes, or
+/// `site_id`/`region_id`/… elsewhere) by each branch, never as the raw `?site=`
+/// slug.
 ///
 /// `tag`/`owner`/`owner_group` are common to most kinds; `status`/`tenant`/
 /// `role` vary. Returns an empty slice for endpoints that aren't part of the
@@ -375,9 +402,9 @@ fn search_supported(ep: Endpoint) -> &'static [&'static str] {
         // a `tenant=` NetBox silently ignores, returning the kind *unfiltered* —
         // a silent over-broad result. The schema canary pins this.
         Endpoint::RackGroups | Endpoint::VirtualMachineTypes => &["tag", "owner", "owner_group"],
-        // Prefixes and clusters apply scope out-of-band (scope_type+scope_id),
-        // so they pass a scope-stripped filters variant and a smaller in-band
-        // set (no owner/role — those aren't sent in-band on these branches).
+        // Prefixes and clusters apply scope out-of-band, so they pass a
+        // scope-stripped filters variant and a smaller in-band set (no
+        // owner/role — those aren't sent in-band on these branches).
         Endpoint::Prefixes => &["status", "tenant", "role", "tag"],
         Endpoint::Clusters => &["status", "tenant", "tag"],
         _ => &[],
@@ -422,12 +449,10 @@ impl NetBoxClient {
         let f = &req.filters;
 
         // Resolve the (single) scope filter to a content type + numeric id once,
-        // up front. NetBox 4.2 replaced the prefix `site` FK with a polymorphic
-        // `scope` (a single type+id), so a plain `?site=`/`?region=`/… is a dead
-        // filter on prefixes — they need `scope_type=<ct>` + `scope_id=<id>`. An
-        // unknown ref is a hard not-found error (exit 4) so search fails loudly
-        // rather than quietly returning nothing. Scope is an *exact* match: each
-        // flag filters by its own scope only — no hierarchy/descendant semantics.
+        // up front. Prefixes/clusters keep exact `--site` semantics via
+        // `scope_type`+`scope_id`, while non-site scopes use NetBox's native
+        // tree-aware scoped id filters. An unknown ref is a hard not-found error
+        // (exit 4) so search fails loudly rather than quietly returning nothing.
         // Resolve the (optional) `--vrf` reference (id | rd | name) to a numeric
         // id once, up front. An unknown VRF is a hard not-found error (exit 4) so
         // search fails loudly rather than quietly returning nothing — matching the
@@ -759,15 +784,13 @@ impl NetBoxClient {
         vrf_id: Option<u64>,
         limit: usize,
     ) -> Result<Vec<SearchResult>> {
-        // Scope is handled out-of-band, not through the allowlist: NetBox 4.2
-        // dropped the prefix `site` FK for the polymorphic `scope`, so a plain
-        // `?site=`/`?region=`/… is a dead filter. The caller resolves the single
-        // active scope flag to an id up front; we translate it to
-        // `scope_type=<ct>` + `scope_id=<id>` (e.g. `dcim.region`), which the 4.2+
-        // API honors as an EXACT match (no hierarchy/descendant expansion). The
-        // scope refs are cleared from the filters before the allowlist check
-        // (otherwise `params_for` would skip the endpoint on `site`) and
-        // re-expressed as scope params below.
+        // Scope is handled out-of-band, not through the allowlist. NetBox 4.2
+        // dropped the prefix `site` FK for the polymorphic `scope`, so scope refs
+        // are resolved to ids up front, cleared before the allowlist check, and
+        // re-expressed below. `--site` stays exact via `scope_type`+`scope_id`;
+        // region/site-group/location use NetBox's tree-aware scoped id filters
+        // (`region_id`, `site_group_id`, `location_id`) so descendants are
+        // included by the server without a client-side hierarchy crawl.
         let without_scope = SearchFilters {
             site: None,
             region: None,
@@ -780,10 +803,7 @@ impl NetBoxClient {
         else {
             return Ok(Vec::new());
         };
-        if let Some(s) = scope {
-            params.push(("scope_type", s.content_type.to_string()));
-            params.push(("scope_id", s.id.to_string()));
-        }
+        params.extend(scoped_model_params(scope));
         // Prefixes carry a VRF: apply the resolved `--vrf` id as `vrf_id=`. This
         // is orthogonal to scope — NetBox ANDs them, so a vrf+scope combo narrows
         // to prefixes matching both.
@@ -1243,13 +1263,9 @@ impl NetBoxClient {
         scope: Option<&ResolvedScope>,
         limit: usize,
     ) -> Result<Vec<SearchResult>> {
-        // NetBox 4.2+ scopes a cluster polymorphically (same `scope_type`/
-        // `scope_id` filter as prefixes), so honor a region/site-group/location
-        // scope the way `search_prefixes` does: clear the scope refs from the
-        // allowlist (so `--site` doesn't skip the endpoint) and re-express the
-        // single active scope as `scope_type`+`scope_id`. `--site` flows through
-        // here too (as `dcim.site`), since clusters honor it via the polymorphic
-        // scope as well.
+        // NetBox 4.2+ scopes a cluster polymorphically, like prefixes. Clear the
+        // scope refs before the allowlist check, then apply the same exact-site /
+        // descendant-aware non-site scope params as `search_prefixes`.
         let without_scope = SearchFilters {
             site: None,
             region: None,
@@ -1264,10 +1280,7 @@ impl NetBoxClient {
         else {
             return Ok(Vec::new());
         };
-        if let Some(s) = scope {
-            params.push(("scope_type", s.content_type.to_string()));
-            params.push(("scope_id", s.id.to_string()));
-        }
+        params.extend(scoped_model_params(scope));
         let page: Page<Cluster> = self.list_limited(Endpoint::Clusters, params, limit).await?;
         Ok(page
             .results
@@ -1537,6 +1550,27 @@ mod tests {
                      snapshot has no such GET param on this endpoint — the server would \
                      silently ignore it (over-broad results). Fix search_supported or \
                      refresh the snapshot."
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_canary_scoped_models_keep_tree_scope_filters() {
+        let snapshot: serde_json::Value =
+            serde_json::from_str(include_str!("../../tests/schema/netbox-4.6.2.json"))
+                .expect("pinned snapshot is valid JSON");
+        for path in ["/api/ipam/prefixes/", "/api/virtualization/clusters/"] {
+            let params = snapshot[path]
+                .as_array()
+                .unwrap_or_else(|| panic!("{path}: snapshot entry is not a param list"));
+            let param_set: std::collections::HashSet<&str> =
+                params.iter().filter_map(|v| v.as_str()).collect();
+            for filter in ["region_id", "site_group_id", "site_id", "location_id"] {
+                assert!(
+                    param_set.contains(filter),
+                    "{path}: missing `{filter}` in the pinned NetBox snapshot; \
+                     search scope filtering relies on ScopedFilterSet's tree-aware id filters"
                 );
             }
         }

--- a/tests/compat_tests.rs
+++ b/tests/compat_tests.rs
@@ -5,7 +5,9 @@
 //! can't pass silently. The matrix it mirrors lives in `docs/COMPATIBILITY.md`.
 //!
 //!   - **4.2** introduced the polymorphic `scope` (`scope_type` + `scope_id`),
-//!     dropping the prefix `site` FK → scope filtering sends `scope_type=dcim.<kind>`.
+//!     dropping the prefix `site` FK. Exact `--site` filtering uses that
+//!     polymorphic scope; hierarchical non-site search uses scoped id filters
+//!     where NetBox exposes them.
 //!   - **4.3** moved GraphQL filtering to per-field lookups and dropped the
 //!     full-text `q` filter → `nbox search` is always REST.
 //!   - **4.5** dropped the prefix `utilization` field → nbox computes container

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -50,6 +50,9 @@ export NETBOX_TOKEN="$(./tests/integration/resolve-token.sh)"
 - site `ci-site`
 - VRF `ci-vrf`
 - prefix `10.10.0.0/16` scoped to the site (`scope_type=dcim.site`)
+- prefixes `10.20.0.0/16`, `10.30.0.0/16`, `10.40.0.0/16`, and
+  `10.41.0.0/16` scoped to region/site-group/location/child-location fixtures
+  for hierarchical search-scope checks
 - duplicate prefix `10.0.0.0/24` in **two** tables: VRF `ci-vrf` and global
   (exercises `--vrf` disambiguation / ambiguity)
 - VLAN vid `1234` (`ci-vlan`) at `ci-site`

--- a/tests/integration/seed.py
+++ b/tests/integration/seed.py
@@ -11,12 +11,12 @@ Objects created, in dependency order:
   - a region                      (slug: ci-region)
   - a site-group                  (slug: ci-sitegroup)
   - a site                        (slug: ci-site, in ci-region AND ci-sitegroup)
-  - a location                    (slug: ci-loc, inside ci-site)
+  - a location + child location   (slugs: ci-loc, ci-loc-child; inside ci-site)
   - a VRF                         (name: ci-vrf)
   - a site-scoped prefix          (10.10.0.0/16, scope_type=dcim.site)
-  - region/site-group/location    (10.20/10.30/10.40.0.0/16 — one per scope type
-    scoped prefixes                so each --region/--site-group/--location hit
-                                   is unambiguous)
+  - region/site-group/location    (10.20/10.30/10.40.0.0/16 scoped to the
+    scoped prefixes                selected scopes, plus 10.41.0.0/16 scoped to
+                                   ci-loc-child)
   - a duplicate prefix            (10.0.0.0/24 in ci-vrf AND in the global table)
   - a VLAN                        (vid 1234 "ci-vlan" at ci-site)
   - a duplicate VLAN              (vid 1234 "ci-vlan2" at ci-site2 — exit-5 case)
@@ -104,6 +104,13 @@ def ensure(endpoint, lookup, body):
     return post(endpoint, body)
 
 
+def brief_id(value):
+    """Return an id from either a nested NetBox brief object or a raw id."""
+    if isinstance(value, dict):
+        return value.get("id")
+    return value
+
+
 def main():
     print(f"Seeding {NBOX_URL} ...")
 
@@ -116,10 +123,10 @@ def main():
     print(f"tag: {tag['slug']} (id {tag['id']})")
 
     # --- region / site-group (the site's polymorphic-scope parents) ----------
-    # NetBox 4.2 scope is one (type, id) pair, so to exercise --region /
-    # --site-group / --location independently each gets its OWN scoped prefix
-    # below. The region and site-group both contain ci-site; the location lives
-    # inside ci-site. Region/site-group only need name+slug.
+    # The region and site-group both contain ci-site; the location lives inside
+    # ci-site. Search scope filters use NetBox's tree-aware region_id /
+    # site_group_id / location_id filters for non-site scopes, so the live tests
+    # assert both selected-scope hits and descendant hits.
     region = ensure(
         "/dcim/regions/",
         {"slug": "ci-region"},
@@ -165,6 +172,29 @@ def main():
     )
     print(f"location: {location['slug']} (id {location['id']}) at ci-site")
 
+    child_location = ensure(
+        "/dcim/locations/",
+        {"slug": "ci-loc-child"},
+        {
+            "name": "ci-loc-child",
+            "slug": "ci-loc-child",
+            "site": site["id"],
+            "parent": location["id"],
+            "status": "active",
+        },
+    )
+    if brief_id(child_location.get("parent")) != location["id"] or brief_id(
+        child_location.get("site")
+    ) != site["id"]:
+        child_location = patch(
+            f"/dcim/locations/{child_location['id']}/",
+            {"site": site["id"], "parent": location["id"]},
+        )
+    print(
+        f"child location: {child_location['slug']} "
+        f"(id {child_location['id']}) under ci-loc"
+    )
+
     # --- VRF -----------------------------------------------------------------
     vrf = ensure("/ipam/vrfs/", {"name": "ci-vrf"}, {"name": "ci-vrf"})
     print(f"vrf: {vrf['name']} (id {vrf['id']})")
@@ -184,14 +214,15 @@ def main():
     print(f"scoped prefix: {scoped_prefix['prefix']} (scope=dcim.site:{site['id']})")
 
     # --- region / site-group / location scoped prefixes ----------------------
-    # One prefix per scope TYPE so each `nbox search --region|--site-group|
-    # --location` filter has exactly one expected hit, proving the polymorphic
-    # scope_type=<ct>&scope_id=<id> filter against the real 4.2 API (an EXACT
-    # match — no hierarchy expansion). Distinct CIDRs keep them unambiguous.
+    # Prefixes scoped to the selected non-site scopes plus a child location. The
+    # live tests assert that NetBox's native tree filters include descendants:
+    # region/site-group find the site-scoped 10.10/16, and location finds the
+    # child-location-scoped 10.41/16.
     for cidr, ct, obj, label in [
         ("10.20.0.0/16", "dcim.region", region, "region"),
         ("10.30.0.0/16", "dcim.sitegroup", site_group, "site-group"),
         ("10.40.0.0/16", "dcim.location", location, "location"),
+        ("10.41.0.0/16", "dcim.location", child_location, "child-location"),
     ]:
         p = ensure(
             "/ipam/prefixes/",

--- a/tests/it_netbox.rs
+++ b/tests/it_netbox.rs
@@ -228,6 +228,17 @@ fn search_site_returns_scope_filtered_prefix() {
             .any(|r| r["kind"] == "prefix" && r["display"] == "10.10.0.0/16"),
         "site-scoped prefix 10.10.0.0/16 not returned for --site ci-site: {results}"
     );
+
+    let exact = run_nbox(&["-o", "json", "search", "10.20", "--site", "ci-site"]);
+    assert_ok(&exact, "search 10.20 --site ci-site");
+    let exact_results = json_of(&exact);
+    let exact_arr = exact_results.as_array().expect("search JSON is an array");
+    assert!(
+        !exact_arr
+            .iter()
+            .any(|r| r["kind"] == "prefix" && r["display"] == "10.20.0.0/16"),
+        "--site must stay exact and not include region-scoped prefixes: {exact_results}"
+    );
 }
 
 // --- prefix ----------------------------------------------------------------
@@ -461,40 +472,32 @@ fn pagination_spans_multiple_pages() {
 // --- scope filters: region / site-group / location -------------------------
 
 /// Each of `--region` / `--site-group` / `--location` resolves the ref to an id
-/// and applies the prefix `scope_type=<ct>` + `scope_id=<id>` filter against the
-/// real 4.2 API. The seed gives each scope type its OWN prefix (10.20/10.30/
-/// 10.40.0.0/16), so a query for the shared "10." stem under each scope returns
-/// exactly that scope's prefix — proving the polymorphic content-type mapping
-/// (`dcim.region`/`dcim.sitegroup`/`dcim.location`) end to end, which wiremock
-/// can't validate against the live serializer.
+/// and uses NetBox's native tree-aware scoped id filters against the real API.
+/// The seed includes both selected-scope prefixes and descendant-scope prefixes,
+/// proving the server-side hierarchy path that wiremock can't validate.
 #[test]
 #[ignore = "requires a live NetBox (netbox-integration workflow)"]
-fn search_region_scope_returns_region_scoped_prefix() {
+fn search_scope_filters_include_descendant_prefixes() {
     for (flag, ref_, expected) in [
-        ("--region", "ci-region", "10.20.0.0/16"),
-        ("--site-group", "ci-sitegroup", "10.30.0.0/16"),
-        ("--location", "ci-loc", "10.40.0.0/16"),
+        ("--region", "ci-region", ["10.20.0.0/16", "10.10.0.0/16"]),
+        (
+            "--site-group",
+            "ci-sitegroup",
+            ["10.30.0.0/16", "10.10.0.0/16"],
+        ),
+        ("--location", "ci-loc", ["10.40.0.0/16", "10.41.0.0/16"]),
     ] {
         let what = format!("search 10. {flag} {ref_}");
         let out = run_nbox(&["-o", "json", "search", "10.", flag, ref_]);
         assert_ok(&out, &what);
         let results = json_of(&out);
         let arr = results.as_array().expect("search JSON is an array");
-        // The scope's own prefix is present.
-        assert!(
-            arr.iter()
-                .any(|r| r["kind"] == "prefix" && r["display"] == expected),
-            "{flag} {ref_} should surface {expected}: {results}"
-        );
-        // Scope is an EXACT match (no hierarchy expansion): the OTHER scopes'
-        // prefixes must NOT leak in.
-        for other in ["10.20.0.0/16", "10.30.0.0/16", "10.40.0.0/16"] {
-            if other != expected {
-                assert!(
-                    !arr.iter().any(|r| r["display"] == other),
-                    "{flag} {ref_} leaked another scope's prefix {other}: {results}"
-                );
-            }
+        for expected_prefix in expected {
+            assert!(
+                arr.iter()
+                    .any(|r| r["kind"] == "prefix" && r["display"] == expected_prefix),
+                "{flag} {ref_} should surface {expected_prefix}: {results}"
+            );
         }
     }
 }

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -905,17 +905,19 @@ async fn search_skips_non_site_endpoints_unchanged_with_active_site() {
         })))
         .mount(&server)
         .await;
-    // Endpoints that DO honor `--site` (directly or via scope) are reached.
-    mount_empty(&server, "/api/dcim/devices/").await; // accepts `site`
-    mount_empty(&server, "/api/ipam/vlans/").await; // accepts `site`
-    mount_empty(&server, "/api/ipam/prefixes/").await; // scope-filtered
-    mount_empty(&server, "/api/virtualization/virtual-machines/").await; // accepts `site`
-    mount_empty(&server, "/api/virtualization/virtual-machine-types/").await; // accepts `site`
-    mount_empty(&server, "/api/virtualization/clusters/").await; // accepts `site`
-    mount_empty(&server, "/api/dcim/racks/").await;
+    // Endpoints that honor `--site` (directly or via scope) are reached.
+    mount_empty(&server, "/api/dcim/devices/").await; // site_id-filtered
+    mount_empty(&server, "/api/ipam/vlans/").await; // site_id-filtered
+    mount_empty(&server, "/api/ipam/prefixes/").await; // exact site scope
+    mount_empty(&server, "/api/virtualization/virtual-machines/").await; // site_id-filtered
+    mount_empty(&server, "/api/virtualization/clusters/").await; // exact site scope
+    mount_empty(&server, "/api/dcim/racks/").await; // site_id-filtered
+    // Defensive catch-alls for endpoints that are skipped under active scope;
+    // if they are accidentally reached, `outcome.errors` below catches it.
+    mount_empty(&server, "/api/virtualization/virtual-machine-types/").await;
     mount_empty(&server, "/api/dcim/rack-groups/").await;
     mount_empty(&server, "/api/ipam/vrfs/").await;
-    mount_empty(&server, "/api/ipam/route-targets/").await; // accepts `site` (site_id)
+    mount_empty(&server, "/api/ipam/route-targets/").await;
     // The site-search branch (`q=` lookup) is reached too; fall through to a
     // catch-all empty page for `/api/dcim/sites/` so it doesn't 404.
     Mock::given(method("GET"))
@@ -946,10 +948,16 @@ async fn search_skips_non_site_endpoints_unchanged_with_active_site() {
     );
 }
 
-/// Shared helper: a scope flag resolves its ref to an id and the prefix request
-/// carries `scope_type=<content_type>` + `scope_id`. `endpoint`/`content_type`
-/// vary per scope kind; `filters` selects which flag is set.
-async fn assert_scope_filters_prefixes(endpoint: &str, content_type: &str, filters: SearchFilters) {
+/// Shared helper: a non-site scope flag resolves its ref to an id and the prefix
+/// request carries NetBox's native tree-aware id filter (`region_id`,
+/// `site_group_id`, or `location_id`). `endpoint`/`expected_filter` vary per
+/// scope kind; `filters` selects which flag is set.
+async fn assert_scope_filters_prefixes(
+    endpoint: &str,
+    expected_filter: &'static str,
+    content_type: &str,
+    filters: SearchFilters,
+) {
     let server = MockServer::start().await;
 
     // Scope resolution: `*_by_ref` looks the slug up first; return id 7.
@@ -967,12 +975,13 @@ async fn assert_scope_filters_prefixes(endpoint: &str, content_type: &str, filte
     // Catch-all for the scope endpoint so other lookups don't 404.
     mount_empty(&server, endpoint).await;
 
-    // The prefix endpoint must carry the translated scope params, and a matching
-    // prefix comes back (proving it's queried, not skipped).
+    // The prefix endpoint must carry the native scoped id filter, and a matching
+    // prefix comes back (proving it's queried, not skipped). NetBox backs these
+    // filters with TreeNodeMultipleChoiceFilter, so descendants are included
+    // server-side.
     Mock::given(method("GET"))
         .and(path("/api/ipam/prefixes/"))
-        .and(query_param("scope_type", content_type))
-        .and(query_param("scope_id", "7"))
+        .and(query_param(expected_filter, "7"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "count": 1, "next": null, "previous": null,
             "results": [{
@@ -1011,9 +1020,10 @@ async fn assert_scope_filters_prefixes(endpoint: &str, content_type: &str, filte
 }
 
 #[tokio::test]
-async fn search_with_region_scopes_prefixes_by_scope_type_and_id() {
+async fn search_with_region_scopes_prefixes_by_tree_filter() {
     assert_scope_filters_prefixes(
         "/api/dcim/regions/",
+        "region_id",
         "dcim.region",
         SearchFilters {
             region: Some("scope-ref".into()),
@@ -1024,9 +1034,10 @@ async fn search_with_region_scopes_prefixes_by_scope_type_and_id() {
 }
 
 #[tokio::test]
-async fn search_with_site_group_scopes_prefixes_by_scope_type_and_id() {
+async fn search_with_site_group_scopes_prefixes_by_tree_filter() {
     assert_scope_filters_prefixes(
         "/api/dcim/site-groups/",
+        "site_group_id",
         "dcim.sitegroup",
         SearchFilters {
             site_group: Some("scope-ref".into()),
@@ -1037,9 +1048,10 @@ async fn search_with_site_group_scopes_prefixes_by_scope_type_and_id() {
 }
 
 #[tokio::test]
-async fn search_with_location_scopes_prefixes_by_scope_type_and_id() {
+async fn search_with_location_scopes_prefixes_by_tree_filter() {
     assert_scope_filters_prefixes(
         "/api/dcim/locations/",
+        "location_id",
         "dcim.location",
         SearchFilters {
             location: Some("scope-ref".into()),
@@ -1112,9 +1124,14 @@ async fn search_with_unknown_location_errors_not_found() {
     .await;
 }
 
-/// Shared helper: a scope flag also filters CLUSTERS by `scope_type`+`scope_id`
-/// (NetBox 4.2+ scopes a cluster polymorphically, same as a prefix).
-async fn assert_scope_filters_clusters(endpoint: &str, content_type: &str, filters: SearchFilters) {
+/// Shared helper: a non-site scope flag also filters CLUSTERS by NetBox's native
+/// tree-aware scoped id filters, same as prefixes.
+async fn assert_scope_filters_clusters(
+    endpoint: &str,
+    expected_filter: &'static str,
+    content_type: &str,
+    filters: SearchFilters,
+) {
     let server = MockServer::start().await;
 
     // Scope resolution: `*_by_ref` looks the slug up first; return id 7.
@@ -1131,12 +1148,11 @@ async fn assert_scope_filters_clusters(endpoint: &str, content_type: &str, filte
         .await;
     mount_empty(&server, endpoint).await;
 
-    // The cluster endpoint must carry the translated scope params, and a matching
+    // The cluster endpoint must carry the native scoped id filter, and a matching
     // cluster comes back (proving it's queried, not skipped).
     Mock::given(method("GET"))
         .and(path("/api/virtualization/clusters/"))
-        .and(query_param("scope_type", content_type))
-        .and(query_param("scope_id", "7"))
+        .and(query_param(expected_filter, "7"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "count": 1, "next": null, "previous": null,
             "results": [{
@@ -1175,9 +1191,10 @@ async fn assert_scope_filters_clusters(endpoint: &str, content_type: &str, filte
 }
 
 #[tokio::test]
-async fn search_with_region_scopes_clusters_by_scope_type_and_id() {
+async fn search_with_region_scopes_clusters_by_tree_filter() {
     assert_scope_filters_clusters(
         "/api/dcim/regions/",
+        "region_id",
         "dcim.region",
         SearchFilters {
             region: Some("scope-ref".into()),
@@ -1188,9 +1205,10 @@ async fn search_with_region_scopes_clusters_by_scope_type_and_id() {
 }
 
 #[tokio::test]
-async fn search_with_site_group_scopes_clusters_by_scope_type_and_id() {
+async fn search_with_site_group_scopes_clusters_by_tree_filter() {
     assert_scope_filters_clusters(
         "/api/dcim/site-groups/",
+        "site_group_id",
         "dcim.sitegroup",
         SearchFilters {
             site_group: Some("scope-ref".into()),
@@ -1201,9 +1219,10 @@ async fn search_with_site_group_scopes_clusters_by_scope_type_and_id() {
 }
 
 #[tokio::test]
-async fn search_with_location_scopes_clusters_by_scope_type_and_id() {
+async fn search_with_location_scopes_clusters_by_tree_filter() {
     assert_scope_filters_clusters(
         "/api/dcim/locations/",
+        "location_id",
         "dcim.location",
         SearchFilters {
             location: Some("scope-ref".into()),
@@ -1612,6 +1631,87 @@ async fn search_combines_vrf_and_site_scope_on_prefixes() {
 }
 
 #[tokio::test]
+async fn search_with_scope_and_vrf_filters_prefixes() {
+    // Non-site scopes use NetBox's native tree-aware id filters on prefixes, and
+    // `--vrf` remains orthogonal: NetBox ANDs `region_id` and `vrf_id`.
+    let server = MockServer::start().await;
+
+    // Region resolution → id 3.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/regions/"))
+        .and(query_param("slug", "us-east"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": 3, "url": "http://nb/api/dcim/regions/3/", "name": "US East", "slug": "us-east"}]
+        })))
+        .mount(&server)
+        .await;
+    // VRF resolution (by id) → id 7.
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/vrfs/7/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "http://nb/api/ipam/vrfs/7/", "name": "blue"
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/"))
+        .and(query_param("region_id", "3"))
+        .and(query_param("vrf_id", "7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 31, "url": "http://nb/api/ipam/prefixes/31/", "prefix": "10.0.0.0/24",
+                "scope_type": "dcim.site", "scope": {"id": 9, "display": "iad1"},
+                "vrf": {"id": 7, "display": "blue"}
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/"))
+        .and(query_param("region_id", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/virtualization/clusters/"))
+        .and(query_param("region_id", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/racks/"))
+        .and(query_param("region_id", "3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(empty()))
+        .mount(&server)
+        .await;
+
+    let outcome = client(&server)
+        .search(SearchRequest {
+            query: "10.0".into(),
+            limit: 25,
+            filters: SearchFilters {
+                region: Some("us-east".into()),
+                vrf: Some("7".into()),
+                ..Default::default()
+            },
+        })
+        .await
+        .unwrap();
+
+    assert!(outcome.errors.is_empty(), "errors: {:?}", outcome.errors);
+    let prefix = outcome
+        .results
+        .iter()
+        .find(|r| r.kind == ObjectKind::Prefix)
+        .expect("vrf+region-scoped prefix surfaced");
+    assert_eq!(prefix.display, "10.0.0.0/24");
+}
+
+#[tokio::test]
 async fn search_region_scope_skips_non_prefix_non_device_non_cluster_endpoints() {
     // An id-based scope (region) has no clean filter on IPs/sites/circuits/…, so
     // those endpoints are skipped (never hit). Only the region lookup and the
@@ -1634,9 +1734,11 @@ async fn search_region_scope_skips_non_prefix_non_device_non_cluster_endpoints()
     mount_empty(&server, "/api/ipam/prefixes/").await; // scope-filtered
     mount_empty(&server, "/api/dcim/devices/").await; // region_id-filtered
     mount_empty(&server, "/api/dcim/racks/").await;
+    // Defensive catch-alls for skipped endpoints; `outcome.errors` catches any
+    // accidental request to them.
     mount_empty(&server, "/api/dcim/rack-groups/").await;
     mount_empty(&server, "/api/ipam/vrfs/").await;
-    mount_empty(&server, "/api/ipam/route-targets/").await; // region_id-filtered
+    mount_empty(&server, "/api/ipam/route-targets/").await;
     mount_empty(&server, "/api/virtualization/clusters/").await; // scope-filtered
 
     let outcome = client(&server)


### PR DESCRIPTION
## Summary

- Map non-site scoped prefix/cluster search to NetBox native `region_id`, `site_group_id`, and `location_id` filters so region/site-group/location scopes include descendants server-side.
- Keep `--site` exact via `scope_type=dcim.site` + `scope_id`, and keep `--vrf` orthogonal with prefix scope filters.
- Refresh CLI/docs/known-issues/roadmap and live integration fixtures to remove the stale exact-only scope claim.

## Tests

- `cargo fmt --all -- --check`
- `python3 -m py_compile tests/integration/seed.py`
- `git diff --check`
- `cargo test --test search_tests`
- `cargo test schema_canary_scoped_models_keep_tree_scope_filters`
- `cargo test search_with_scope_and_vrf_filters_prefixes`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --all-targets --no-default-features --locked -- -D warnings`
- `cargo test --all-features --locked`
- `cargo test --no-default-features --locked`
- Live NetBox 4.2 lane locally:
  - `docker compose -f tests/integration/docker-compose.yml up -d`
  - `./tests/integration/wait-for-ready.sh 420`
  - `./tests/integration/seed.py`
  - `cargo test --test it_netbox -- --ignored --skip graphql_backend`
  - `docker compose -f tests/integration/docker-compose.yml down -v`

## Review notes

- Initial local reviewer found stale integration/docs exact-scope assertions; fixed and verified with the live 4.2 lane.
- Final reviewer found no blockers; low stale test comments were cleaned before commit.
