### PR TITLE
perf(mcp): reuse get cache for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **MCP resource cache reuse.** `nbox://{kind}/{ref}` resource reads now share
+  the same short-lived `nbox_get` cache entry, so an attached resource and the
+  matching tool call do not re-fetch the same object graph within the cache TTL.
+  `nbox_cache_clear` clears both paths.
 - **GraphQL accelerator fallback is more resilient.** If an effective GraphQL
   `vrf` or `route_target` bundle fails at runtime (for example, a low NetBox
   `GRAPHQL_MAX_QUERY_DEPTH`), nbox now warns and retries the same detail over

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -566,8 +566,9 @@ Consolidated future scope:
   same object graph de-dupe within the TTL), with an `nbox_cache_clear` tool so agents can force fresh
   reads after out-of-band changes. ☑ **Preview-pane caching** — the results preview shares the detail
   cache key, so scrolling back over seen rows is instant and a preview warms the cache for opening that
-  object (and vice versa). Remaining cache work is performance polish, not correctness: ☐ route MCP
-  resource reads through the same `nbox_get` cache; ☐ alias ref-loaded detail views to their id key
+  object (and vice versa). ☑ MCP resource reads route through the same `nbox_get` cache, so attached
+  resources and direct `nbox_get` calls share the within-TTL view. Remaining cache work is performance
+  polish, not correctness: ☐ alias ref-loaded detail views to their id key
   after the resolved `DetailView { kind, id, .. }` is known; ☐ consider short-TTL caches for repeated
   MCP search/tags/tagged/get-interface calls; ☐ optionally add MCP `cached_at`/age annotation. CLI
   intentionally remains uncached — one-shot commands should read fresh from source.
@@ -762,10 +763,11 @@ escape hatch, and GraphQL still cannot replace canonical REST `q` search.
 - ☐ **Version-gated endpoint availability cache.** On NetBox <4.6, search repeatedly probes 4.6-only
   `rack-groups` / `virtual-machine-types` and swallows 404 as empty. Cache that absence per client after the
   first 404 or derive it once from status/capabilities, while keeping always-present endpoints fail-closed.
-- ☐ **MCP/resource cache expansion.** Route `nbox://{kind}/{ref}` resource reads through the same cache path
-  as `nbox_get`; after a ref load returns a `DetailView`, also populate the id cache key; consider short-TTL
-  normalized-arg caches for `nbox_search`, `nbox_get_interface`, tags/tagged, and journal. Keep
-  `nbox_cache_clear` clearing all read caches.
+- ☑ **MCP resource cache reuse.** `nbox://{kind}/{ref}` resource reads now route through the same cache
+  path as `nbox_get`, and `nbox_cache_clear` clears both.
+- ☐ **MCP/cache follow-ups.** After a ref load returns a `DetailView`, also populate the id cache key where
+  resolver semantics make that safe; consider short-TTL normalized-arg caches for `nbox_search`,
+  `nbox_get_interface`, tags/tagged, and journal.
 - ☐ **Output streaming fast path.** JSON/CSV output currently materializes `serde_json::Value`/`String` before
   writing. Fast-path no-shaping JSON (`no --fields`, no envelope changes) to `serde_json::to_writer(_pretty)`
   on locked stdout; stream CSV rows instead of building a full string. This matters most for `raw GET`, tagged,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -897,14 +897,14 @@ impl NboxMcp {
     }
 
     /// Read an `nbox://{kind}/{ref}` resource: parse the URI, resolve through
-    /// the same shared view layer as `nbox_get`, and return the object's JSON
-    /// view as a single text content. Disambiguators (`vrf`/`site`/`group`) have
-    /// no place in a flat URI, so an ambiguous `ref` surfaces its candidate list
-    /// as an `invalid_params` error — the caller can then use `nbox_get`.
+    /// the same cached path as `nbox_get`, and return the object's JSON view as
+    /// a single text content. Disambiguators (`vrf`/`site`/`group`) have no
+    /// place in a flat URI, so an ambiguous `ref` surfaces its candidate list as
+    /// an `invalid_params` error — the caller can then use `nbox_get`.
     async fn read_resource_impl(&self, uri: &str) -> Result<ReadResourceResult, ErrorData> {
         let (kind, reference) = parse_resource_uri(uri)?;
         let Json(value) = self
-            .get_impl(GetArgs {
+            .get_cached(GetArgs {
                 kind,
                 reference,
                 vrf: None,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -62,6 +62,22 @@ fn server_for(mock: &MockServer) -> NboxMcp {
     )
 }
 
+/// A server with the MCP read cache enabled for cache-behavior tests.
+fn cached_server_for(mock: &MockServer) -> NboxMcp {
+    let profile = ProfileConfig {
+        url: mock.uri(),
+        ..Default::default()
+    };
+    let cache = crate::cache::Cache::from_settings(
+        "t".into(),
+        &crate::config::CacheSettings {
+            enabled: true,
+            ttl_secs: 30,
+        },
+    );
+    NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
+}
+
 #[tokio::test]
 async fn nbox_get_consults_cache_and_clear_busts_it() {
     // No reachable NetBox: a cache HIT must answer with no network, and after a
@@ -99,6 +115,105 @@ async fn nbox_get_consults_cache_and_clear_busts_it() {
         server.get_cached(args).await.is_err(),
         "after clear, a miss hits NetBox (unreachable in this test)"
     );
+}
+
+#[tokio::test]
+async fn read_resource_consults_nbox_get_cache() {
+    // No reachable NetBox: a resource cache HIT must answer with no network.
+    let profile = ProfileConfig {
+        url: "http://127.0.0.1:9/".into(),
+        ..Default::default()
+    };
+    let cache = crate::cache::Cache::from_settings(
+        "t".into(),
+        &crate::config::CacheSettings {
+            enabled: true,
+            ttl_secs: 30,
+        },
+    );
+    let server = NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache);
+
+    let key = crate::cache::CacheKey::object("site", "iad1", "vrf=;site=;group=");
+    server
+        .cache
+        .put(&key, &json!({ "name": "IAD1", "from_cache": true }));
+
+    let result = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("served from cache without touching the network");
+    let value = one_text(&result, "nbox://site/iad1");
+    assert_eq!(value["name"], json!("IAD1"));
+    assert_eq!(value["from_cache"], json!(true));
+}
+
+#[tokio::test]
+async fn nbox_get_and_resource_share_cache_entry() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 1, "url": "u", "name": "IAD1", "slug": "iad1",
+                "status": {"value": "active", "label": "Active"}
+            }]
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server = cached_server_for(&mock);
+    let Json(via_get) = server
+        .nbox_get(Parameters(get_args(GetKind::Site, "iad1")))
+        .await
+        .expect("site via nbox_get");
+    let result = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("site via resource");
+    let via_resource = one_text(&result, "nbox://site/iad1");
+
+    assert_eq!(
+        via_get, via_resource,
+        "resource read must reuse the same cached view as nbox_get"
+    );
+    mock.verify().await;
+}
+
+#[tokio::test]
+async fn cache_clear_busts_resource_cache_entries() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 1, "url": "u", "name": "IAD1", "slug": "iad1",
+                "status": {"value": "active", "label": "Active"}
+            }]
+        })))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let server = cached_server_for(&mock);
+    let first = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("first resource read fills cache");
+    assert_eq!(one_text(&first, "nbox://site/iad1")["name"], json!("IAD1"));
+
+    server.nbox_cache_clear().await.expect("cache clear");
+
+    let second = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("second resource read refetches after clear");
+    assert_eq!(one_text(&second, "nbox://site/iad1")["name"], json!("IAD1"));
+    mock.verify().await;
 }
 
 /// An empty paginated page, for endpoints a flow touches but doesn't care about.
@@ -2226,7 +2341,7 @@ mod contracts {
 
     /// Contract item: a resource read of `nbox://{kind}/{ref}` returns byte-for-
     /// byte the same JSON view as `nbox_get` for that kind. The resource path is
-    /// only a URI veneer over `get_impl`, and this pins that they cannot drift.
+    /// only a URI veneer over `get_cached`, and this pins that they cannot drift.
     #[tokio::test]
     async fn resource_read_matches_nbox_get() {
         // Two servers with identical mounts: one drives `nbox_get`, the other the


### PR DESCRIPTION
## Summary
- route `nbox://{kind}/{ref}` resource reads through the same `get_cached` path as `nbox_get`
- add MCP cache tests for resource cache hits, `nbox_get`/resource cache sharing with one origin fetch, and `nbox_cache_clear` busting resource entries
- update `CHANGELOG.md`/`ROADMAP.md`; keep broader id/ref aliasing and short-TTL caches as roadmap follow-ups

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --all-targets --no-default-features --locked -- -D warnings`
- `cargo test -q mcp::tests`
- `cargo test --all-features --locked`
- `cargo test --no-default-features --locked`

## Notes
- Independent branch from `origin/master`; this does not depend on PR #93 or #94.
- No MCP output shape changes: resources still pretty-print the same JSON view as `nbox_get`.
- Deferred: natural-ref/id alias cache warming remains on the roadmap because resolver semantics vary by kind and are easier to collapse incorrectly.