### PR TITLE
Harden recent cleanup coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Editor / OS noise
 *.swp
 .DS_Store
+.last_review_sha
 
 # Python bytecode (e.g. from the integration seed script)
 __pycache__/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,6 +102,12 @@ Polish the read experience. No writes here.
   every browse; only add targeted higher caps/load-more on detail tabs when a
   real operator workflow proves the need. The old `offset += page_size` row skip
   is already fixed in 0.12.0.
+- ☐ **Capped detail-section truncation cues.** Prefix contained IPs now have a
+  boundary test proving the 512-row cap, but larger prefixes can still be
+  silently clipped at that detail-section budget. Add a shared view/model cue for
+  capped sections (`<cap>+` in the TUI/plain views, and an additive JSON field if
+  needed) once we want to make truncation explicit across detail tabs rather than
+  only increasing one cap.
 - ☑ **Hierarchical scope filters.** `search --region`/`--site-group`/`--location`
   now uses NetBox's native tree-aware scoped id filters (`region_id`,
   `site_group_id`, `location_id`) on prefixes and clusters, so the selected node

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -78,6 +78,24 @@ fn cached_server_for(mock: &MockServer) -> NboxMcp {
     NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
 }
 
+/// A cached server whose entries expire immediately. This keeps TTL-expiry tests
+/// deterministic without sleeping for the production minimum TTL.
+fn zero_ttl_cached_server_for(mock: &MockServer) -> NboxMcp {
+    let profile = ProfileConfig {
+        url: mock.uri(),
+        ..Default::default()
+    };
+    let cache = crate::cache::Cache::new(
+        std::sync::Arc::new(crate::cache::MemoryStore::new()),
+        "t".into(),
+        crate::cache::CacheConfig {
+            enabled: true,
+            ttl_secs: 0,
+        },
+    );
+    NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
+}
+
 #[tokio::test]
 async fn nbox_get_consults_cache_and_clear_busts_it() {
     // No reachable NetBox: a cache HIT must answer with no network, and after a
@@ -212,6 +230,38 @@ async fn cache_clear_busts_resource_cache_entries() {
         .read_resource_impl("nbox://site/iad1")
         .await
         .expect("second resource read refetches after clear");
+    assert_eq!(one_text(&second, "nbox://site/iad1")["name"], json!("IAD1"));
+    mock.verify().await;
+}
+
+#[tokio::test]
+async fn resource_cache_refetches_after_ttl_expiry() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 1, "url": "u", "name": "IAD1", "slug": "iad1",
+                "status": {"value": "active", "label": "Active"}
+            }]
+        })))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let server = zero_ttl_cached_server_for(&mock);
+    let first = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("first resource read fills cache");
+    assert_eq!(one_text(&first, "nbox://site/iad1")["name"], json!("IAD1"));
+
+    let second = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("second resource read refetches after immediate expiry");
     assert_eq!(one_text(&second, "nbox://site/iad1")["name"], json!("IAD1"));
     mock.verify().await;
 }
@@ -2353,6 +2403,67 @@ mod contracts {
         // A member IP row is itself an object with a stable key set.
         assert_keys(&value["ip_addresses"][0], &["address"]);
         assert_eq!(value["ip_addresses"][0]["address"], "10.44.208.1/24");
+    }
+
+    #[tokio::test]
+    async fn prefix_contained_ip_section_stops_at_dedicated_cap() {
+        let mock = MockServer::start().await;
+        let addresses: Vec<_> = (0..512)
+            .map(|i| {
+                json!({
+                    "id": i + 1,
+                    "url": "u",
+                    "address": format!("10.44.{}.{}/22", i / 256, i % 256),
+                })
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/prefixes/"))
+            .and(query_param("prefix", "10.44.0.0/22"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{
+                    "id": 5, "url": "u", "prefix": "10.44.0.0/22",
+                    "status": {"value": "active", "label": "Active"}
+                }]
+            })))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/prefixes/"))
+            .and(query_param("within", "10.44.0.0/22"))
+            .and(query_param("limit", "200"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(empty_page()))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/ip-addresses/"))
+            .and(query_param("parent", "10.44.0.0/22"))
+            .and(query_param("limit", "512"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 513,
+                "next": "http://nb/api/ipam/ip-addresses/?offset=512",
+                "previous": null,
+                "results": addresses
+            })))
+            .mount(&mock)
+            .await;
+
+        let Json(value) = server_for(&mock)
+            .nbox_get(Parameters(get_args(GetKind::Prefix, "10.44.0.0/22")))
+            .await
+            .expect("prefix lookup");
+
+        let ips = value["ip_addresses"]
+            .as_array()
+            .expect("ip_addresses is an array");
+        assert_eq!(ips.len(), 512, "contained-IP section cap drifted");
+        assert_eq!(ips.last().unwrap()["address"], "10.44.1.255/22");
+        assert!(
+            !ips.iter().any(|ip| ip["address"] == "10.44.2.0/22"),
+            "row 513 should remain outside the capped detail section"
+        );
     }
 
     /// Contract item: a resource read of `nbox://{kind}/{ref}` returns byte-for-

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -317,24 +317,26 @@ fn skip_for_any_scope(scope: Option<&ResolvedScope>) -> bool {
     scope.is_some()
 }
 
-fn scoped_model_params(scope: Option<&ResolvedScope>) -> Vec<(&'static str, String)> {
+fn scoped_model_params(scope: Option<&ResolvedScope>) -> Result<Vec<(&'static str, String)>> {
     let Some(s) = scope else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     match s.content_type {
         // Preserve exact site semantics. The polymorphic `scope` exact match is
         // deliberately narrower than NetBox's `_site` helper and avoids widening
         // `--site` if scoped models ever grow indirect site inheritance.
-        "dcim.site" => vec![
+        "dcim.site" => Ok(vec![
             ("scope_type", s.content_type.to_string()),
             ("scope_id", s.id.to_string()),
-        ],
+        ]),
         // NetBox's ScopedFilterSet backs these with TreeNodeMultipleChoiceFilter,
         // so the selected node and its descendants are matched server-side.
-        "dcim.region" => vec![("region_id", s.id.to_string())],
-        "dcim.sitegroup" => vec![("site_group_id", s.id.to_string())],
-        "dcim.location" => vec![("location_id", s.id.to_string())],
-        _ => Vec::new(),
+        "dcim.region" => Ok(vec![("region_id", s.id.to_string())]),
+        "dcim.sitegroup" => Ok(vec![("site_group_id", s.id.to_string())]),
+        "dcim.location" => Ok(vec![("location_id", s.id.to_string())]),
+        other => anyhow::bail!(
+            "unsupported scoped-model search scope {other}; refusing an unscoped query"
+        ),
     }
 }
 
@@ -803,7 +805,7 @@ impl NetBoxClient {
         else {
             return Ok(Vec::new());
         };
-        params.extend(scoped_model_params(scope));
+        params.extend(scoped_model_params(scope)?);
         // Prefixes carry a VRF: apply the resolved `--vrf` id as `vrf_id=`. This
         // is orthogonal to scope — NetBox ANDs them, so a vrf+scope combo narrows
         // to prefixes matching both.
@@ -1280,7 +1282,7 @@ impl NetBoxClient {
         else {
             return Ok(Vec::new());
         };
-        params.extend(scoped_model_params(scope));
+        params.extend(scoped_model_params(scope)?);
         let page: Page<Cluster> = self.list_limited(Endpoint::Clusters, params, limit).await?;
         Ok(page
             .results
@@ -1714,6 +1716,32 @@ mod tests {
         let f = SearchFilters::default();
         let p = endpoint_params("edge", &f, &["status"]).unwrap();
         assert_eq!(p, vec![("q", "edge".to_string())]);
+    }
+
+    #[test]
+    fn scoped_model_params_fail_closed_for_unknown_scope_type() {
+        assert_eq!(
+            scoped_model_params(None).unwrap(),
+            Vec::<(&'static str, String)>::new()
+        );
+        assert_eq!(
+            scoped_model_params(Some(&ResolvedScope {
+                content_type: "dcim.region",
+                id: 3,
+            }))
+            .unwrap(),
+            vec![("region_id", "3".to_string())]
+        );
+
+        let err = scoped_model_params(Some(&ResolvedScope {
+            content_type: "extras.gadget",
+            id: 99,
+        }))
+        .expect_err("unsupported scopes must not become unscoped queries");
+        assert!(
+            format!("{err:#}").contains("refusing an unscoped query"),
+            "got: {err:#}"
+        );
     }
 
     #[test]

--- a/tests/it_netbox.rs
+++ b/tests/it_netbox.rs
@@ -478,14 +478,25 @@ fn pagination_spans_multiple_pages() {
 #[test]
 #[ignore = "requires a live NetBox (netbox-integration workflow)"]
 fn search_scope_filters_include_descendant_prefixes() {
-    for (flag, ref_, expected) in [
-        ("--region", "ci-region", ["10.20.0.0/16", "10.10.0.0/16"]),
+    for (flag, ref_, expected, absent) in [
+        (
+            "--region",
+            "ci-region",
+            ["10.20.0.0/16", "10.10.0.0/16"],
+            &["10.30.0.0/16"][..],
+        ),
         (
             "--site-group",
             "ci-sitegroup",
             ["10.30.0.0/16", "10.10.0.0/16"],
+            &["10.20.0.0/16"][..],
         ),
-        ("--location", "ci-loc", ["10.40.0.0/16", "10.41.0.0/16"]),
+        (
+            "--location",
+            "ci-loc",
+            ["10.40.0.0/16", "10.41.0.0/16"],
+            &["10.20.0.0/16", "10.30.0.0/16"][..],
+        ),
     ] {
         let what = format!("search 10. {flag} {ref_}");
         let out = run_nbox(&["-o", "json", "search", "10.", flag, ref_]);
@@ -497,6 +508,13 @@ fn search_scope_filters_include_descendant_prefixes() {
                 arr.iter()
                     .any(|r| r["kind"] == "prefix" && r["display"] == expected_prefix),
                 "{flag} {ref_} should surface {expected_prefix}: {results}"
+            );
+        }
+        for absent_prefix in absent {
+            assert!(
+                !arr.iter()
+                    .any(|r| r["kind"] == "prefix" && r["display"] == *absent_prefix),
+                "{flag} {ref_} leaked sibling scope prefix {absent_prefix}: {results}"
             );
         }
     }


### PR DESCRIPTION
## Summary

- add `.last_review_sha` to `.gitignore`
- harden the PR #93 prefix contained-IP cap with a 512-row boundary test and roadmap the remaining explicit truncation-cue UX
- make scoped prefix/cluster search fail closed if an unsupported resolved scope ever reaches the scoped-model param mapper, and strengthen the live NetBox hierarchy test with sibling-scope negative assertions
- add an MCP resource cache TTL-expiry test so the resource path proves it refetches after expiration, not only after explicit cache clear

## Linear

- LAN-103
- LAN-104
- LAN-105

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --all-targets --no-default-features --locked -- -D warnings`
- `cargo test --all-features --locked`
- `cargo test --no-default-features --locked`
- push hooks: fmt, clippy, test
