### PR TITLE
ci: fix NetBox 4.6 fixture token provisioning + gate PRs on 4.6

### DIFF
--- a/.github/workflows/netbox-integration.yml
+++ b/.github/workflows/netbox-integration.yml
@@ -110,7 +110,13 @@ jobs:
         run: NETBOX_READY_HTTP_CODES=200,403 ./tests/integration/wait-for-ready.sh 420
 
       - name: Resolve NetBox 4.5 API token
-        run: echo "NETBOX_TOKEN=$(./tests/integration/resolve-token.sh)" >> "$GITHUB_ENV"
+        # Assign first so a non-zero exit from resolve-token.sh (e.g. the image
+        # never provisioned the token) fails this step loudly under `set -e`,
+        # rather than writing an empty NETBOX_TOKEN that surfaces later as a
+        # misleading readiness timeout.
+        run: |
+          token="$(./tests/integration/resolve-token.sh)"
+          echo "NETBOX_TOKEN=${token}" >> "$GITHUB_ENV"
 
       - name: Wait for NetBox to be ready
         run: ./tests/integration/wait-for-ready.sh 60
@@ -143,7 +149,9 @@ jobs:
 
   netbox-46-compat:
     name: live NetBox 4.6 compatibility
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Runs on every trigger (PRs, master pushes, the nightly schedule, manual
+    # dispatch) — 4.6 is the current NetBox line and the dev target, so it gates
+    # PRs like 4.2/4.5. The nightly schedule additionally catches image drift.
     runs-on: ubuntu-latest
     env:
       NETBOX_IMAGE: netboxcommunity/netbox:v4.6.2
@@ -166,7 +174,13 @@ jobs:
         run: NETBOX_READY_HTTP_CODES=200,403 ./tests/integration/wait-for-ready.sh 420
 
       - name: Resolve NetBox 4.6 API token
-        run: echo "NETBOX_TOKEN=$(./tests/integration/resolve-token.sh)" >> "$GITHUB_ENV"
+        # Assign first so a non-zero exit from resolve-token.sh (e.g. the image
+        # never provisioned the token) fails this step loudly under `set -e`,
+        # rather than writing an empty NETBOX_TOKEN that surfaces later as a
+        # misleading readiness timeout.
+        run: |
+          token="$(./tests/integration/resolve-token.sh)"
+          echo "NETBOX_TOKEN=${token}" >> "$GITHUB_ENV"
 
       - name: Wait for NetBox to be ready
         run: ./tests/integration/wait-for-ready.sh 60

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Editor / OS noise
 *.swp
 .DS_Store
+.last_review_sha
 
 # Python bytecode (e.g. from the integration seed script)
 __pycache__/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,6 +102,12 @@ Polish the read experience. No writes here.
   every browse; only add targeted higher caps/load-more on detail tabs when a
   real operator workflow proves the need. The old `offset += page_size` row skip
   is already fixed in 0.12.0.
+- ☐ **Capped detail-section truncation cues.** Prefix contained IPs now have a
+  boundary test proving the 512-row cap, but larger prefixes can still be
+  silently clipped at that detail-section budget. Add a shared view/model cue for
+  capped sections (`<cap>+` in the TUI/plain views, and an additive JSON field if
+  needed) once we want to make truncation explicit across detail tabs rather than
+  only increasing one cap.
 - ☑ **Hierarchical scope filters.** `search --region`/`--site-group`/`--location`
   now uses NetBox's native tree-aware scoped id filters (`region_id`,
   `site_group_id`, `location_id`) on prefixes and clusters, so the selected node

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -78,6 +78,24 @@ fn cached_server_for(mock: &MockServer) -> NboxMcp {
     NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
 }
 
+/// A cached server whose entries expire immediately. This keeps TTL-expiry tests
+/// deterministic without sleeping for the production minimum TTL.
+fn zero_ttl_cached_server_for(mock: &MockServer) -> NboxMcp {
+    let profile = ProfileConfig {
+        url: mock.uri(),
+        ..Default::default()
+    };
+    let cache = crate::cache::Cache::new(
+        std::sync::Arc::new(crate::cache::MemoryStore::new()),
+        "t".into(),
+        crate::cache::CacheConfig {
+            enabled: true,
+            ttl_secs: 0,
+        },
+    );
+    NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
+}
+
 #[tokio::test]
 async fn nbox_get_consults_cache_and_clear_busts_it() {
     // No reachable NetBox: a cache HIT must answer with no network, and after a
@@ -212,6 +230,38 @@ async fn cache_clear_busts_resource_cache_entries() {
         .read_resource_impl("nbox://site/iad1")
         .await
         .expect("second resource read refetches after clear");
+    assert_eq!(one_text(&second, "nbox://site/iad1")["name"], json!("IAD1"));
+    mock.verify().await;
+}
+
+#[tokio::test]
+async fn resource_cache_refetches_after_ttl_expiry() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/sites/"))
+        .and(query_param("slug", "iad1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": 1, "url": "u", "name": "IAD1", "slug": "iad1",
+                "status": {"value": "active", "label": "Active"}
+            }]
+        })))
+        .expect(2)
+        .mount(&mock)
+        .await;
+
+    let server = zero_ttl_cached_server_for(&mock);
+    let first = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("first resource read fills cache");
+    assert_eq!(one_text(&first, "nbox://site/iad1")["name"], json!("IAD1"));
+
+    let second = server
+        .read_resource_impl("nbox://site/iad1")
+        .await
+        .expect("second resource read refetches after immediate expiry");
     assert_eq!(one_text(&second, "nbox://site/iad1")["name"], json!("IAD1"));
     mock.verify().await;
 }
@@ -2353,6 +2403,67 @@ mod contracts {
         // A member IP row is itself an object with a stable key set.
         assert_keys(&value["ip_addresses"][0], &["address"]);
         assert_eq!(value["ip_addresses"][0]["address"], "10.44.208.1/24");
+    }
+
+    #[tokio::test]
+    async fn prefix_contained_ip_section_stops_at_dedicated_cap() {
+        let mock = MockServer::start().await;
+        let addresses: Vec<_> = (0..512)
+            .map(|i| {
+                json!({
+                    "id": i + 1,
+                    "url": "u",
+                    "address": format!("10.44.{}.{}/22", i / 256, i % 256),
+                })
+            })
+            .collect();
+
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/prefixes/"))
+            .and(query_param("prefix", "10.44.0.0/22"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{
+                    "id": 5, "url": "u", "prefix": "10.44.0.0/22",
+                    "status": {"value": "active", "label": "Active"}
+                }]
+            })))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/prefixes/"))
+            .and(query_param("within", "10.44.0.0/22"))
+            .and(query_param("limit", "200"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(empty_page()))
+            .mount(&mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/ipam/ip-addresses/"))
+            .and(query_param("parent", "10.44.0.0/22"))
+            .and(query_param("limit", "512"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 513,
+                "next": "http://nb/api/ipam/ip-addresses/?offset=512",
+                "previous": null,
+                "results": addresses
+            })))
+            .mount(&mock)
+            .await;
+
+        let Json(value) = server_for(&mock)
+            .nbox_get(Parameters(get_args(GetKind::Prefix, "10.44.0.0/22")))
+            .await
+            .expect("prefix lookup");
+
+        let ips = value["ip_addresses"]
+            .as_array()
+            .expect("ip_addresses is an array");
+        assert_eq!(ips.len(), 512, "contained-IP section cap drifted");
+        assert_eq!(ips.last().unwrap()["address"], "10.44.1.255/22");
+        assert!(
+            !ips.iter().any(|ip| ip["address"] == "10.44.2.0/22"),
+            "row 513 should remain outside the capped detail section"
+        );
     }
 
     /// Contract item: a resource read of `nbox://{kind}/{ref}` returns byte-for-

--- a/src/netbox/search.rs
+++ b/src/netbox/search.rs
@@ -317,24 +317,26 @@ fn skip_for_any_scope(scope: Option<&ResolvedScope>) -> bool {
     scope.is_some()
 }
 
-fn scoped_model_params(scope: Option<&ResolvedScope>) -> Vec<(&'static str, String)> {
+fn scoped_model_params(scope: Option<&ResolvedScope>) -> Result<Vec<(&'static str, String)>> {
     let Some(s) = scope else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     match s.content_type {
         // Preserve exact site semantics. The polymorphic `scope` exact match is
         // deliberately narrower than NetBox's `_site` helper and avoids widening
         // `--site` if scoped models ever grow indirect site inheritance.
-        "dcim.site" => vec![
+        "dcim.site" => Ok(vec![
             ("scope_type", s.content_type.to_string()),
             ("scope_id", s.id.to_string()),
-        ],
+        ]),
         // NetBox's ScopedFilterSet backs these with TreeNodeMultipleChoiceFilter,
         // so the selected node and its descendants are matched server-side.
-        "dcim.region" => vec![("region_id", s.id.to_string())],
-        "dcim.sitegroup" => vec![("site_group_id", s.id.to_string())],
-        "dcim.location" => vec![("location_id", s.id.to_string())],
-        _ => Vec::new(),
+        "dcim.region" => Ok(vec![("region_id", s.id.to_string())]),
+        "dcim.sitegroup" => Ok(vec![("site_group_id", s.id.to_string())]),
+        "dcim.location" => Ok(vec![("location_id", s.id.to_string())]),
+        other => anyhow::bail!(
+            "unsupported scoped-model search scope {other}; refusing an unscoped query"
+        ),
     }
 }
 
@@ -803,7 +805,7 @@ impl NetBoxClient {
         else {
             return Ok(Vec::new());
         };
-        params.extend(scoped_model_params(scope));
+        params.extend(scoped_model_params(scope)?);
         // Prefixes carry a VRF: apply the resolved `--vrf` id as `vrf_id=`. This
         // is orthogonal to scope — NetBox ANDs them, so a vrf+scope combo narrows
         // to prefixes matching both.
@@ -1280,7 +1282,7 @@ impl NetBoxClient {
         else {
             return Ok(Vec::new());
         };
-        params.extend(scoped_model_params(scope));
+        params.extend(scoped_model_params(scope)?);
         let page: Page<Cluster> = self.list_limited(Endpoint::Clusters, params, limit).await?;
         Ok(page
             .results
@@ -1714,6 +1716,32 @@ mod tests {
         let f = SearchFilters::default();
         let p = endpoint_params("edge", &f, &["status"]).unwrap();
         assert_eq!(p, vec![("q", "edge".to_string())]);
+    }
+
+    #[test]
+    fn scoped_model_params_fail_closed_for_unknown_scope_type() {
+        assert_eq!(
+            scoped_model_params(None).unwrap(),
+            Vec::<(&'static str, String)>::new()
+        );
+        assert_eq!(
+            scoped_model_params(Some(&ResolvedScope {
+                content_type: "dcim.region",
+                id: 3,
+            }))
+            .unwrap(),
+            vec![("region_id", "3".to_string())]
+        );
+
+        let err = scoped_model_params(Some(&ResolvedScope {
+            content_type: "extras.gadget",
+            id: 99,
+        }))
+        .expect_err("unsupported scopes must not become unscoped queries");
+        assert!(
+            format!("{err:#}").contains("refusing an unscoped query"),
+            "got: {err:#}"
+        );
     }
 
     #[test]

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -77,7 +77,15 @@ services:
       SUPERUSER_NAME: admin
       SUPERUSER_EMAIL: admin@example.com
       SUPERUSER_PASSWORD: admin
+      # Token SECRET. NetBox 4.6's netbox-docker entrypoint (`super_user.py`)
+      # provisions the superuser token only when BOTH this secret AND the v2
+      # public key (`SUPERUSER_API_KEY` below) are set; older images (4.2 v1,
+      # 4.5) created it from this secret alone and ignore the key var.
       SUPERUSER_API_TOKEN: "0123456789abcdef0123456789abcdef0fedcba9"
+      # v2 token PUBLIC key (12 chars; the `nbt_<key>.<secret>` format NetBox
+      # 4.5+ uses). Required by the 4.6 entrypoint; `resolve-token.sh` reads it
+      # back from the DB and emits `nbt_<key>.<secret>`. Harmless on 4.2/4.5.
+      SUPERUSER_API_KEY: "citoken12345"
       # NetBox 4.5+ requires at least one pepper to create/use v2 API tokens.
       # netbox-docker maps API_TOKEN_PEPPER_1 into NetBox's API_TOKEN_PEPPERS
       # config dict. Static is fine here: this is an ephemeral CI fixture.

--- a/tests/integration/resolve-token.sh
+++ b/tests/integration/resolve-token.sh
@@ -11,12 +11,27 @@ COMPOSE_FILE="${COMPOSE_FILE:-tests/integration/docker-compose.yml}"
 NETBOX_TOKEN="${NETBOX_TOKEN:-0123456789abcdef0123456789abcdef0fedcba9}"
 NETBOX_USERNAME="${NETBOX_USERNAME:-admin}"
 
+# Read the token's public key. `filter().first()` (not `get()`) so a missing
+# token prints an empty line instead of raising `DoesNotExist` (a traceback that
+# `tail` would otherwise turn into a bogus "key"). stderr is dropped so only the
+# key reaches stdout.
 key="$(
   docker compose -f "${COMPOSE_FILE}" exec -T netbox \
     /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py shell -c \
-    "from users.models import Token; print(Token.objects.get(user__username='${NETBOX_USERNAME}').key)" \
-    | tail -n 1
+    "from users.models import Token; t = Token.objects.filter(user__username='${NETBOX_USERNAME}').first(); print(t.key if t else '')" \
+    2>/dev/null | tail -n 1
 )"
+
+# Fail LOUD if the image never provisioned the token. Otherwise an empty key
+# silently yields a bogus token and surfaces downstream as a misleading "NetBox
+# did not become ready (HTTP 403)" timeout (see the 4.6 lane regression: the
+# netbox-docker entrypoint now needs SUPERUSER_API_KEY *and* SUPERUSER_API_TOKEN).
+if [ -z "${key}" ]; then
+  echo "resolve-token: no API token found for user '${NETBOX_USERNAME}' on this fixture." >&2
+  echo "  The NetBox image did not provision the superuser token — check that both" >&2
+  echo "  SUPERUSER_API_TOKEN and SUPERUSER_API_KEY are set in docker-compose.yml." >&2
+  exit 1
+fi
 
 case "${key}" in
   nbt_*)

--- a/tests/it_netbox.rs
+++ b/tests/it_netbox.rs
@@ -478,14 +478,25 @@ fn pagination_spans_multiple_pages() {
 #[test]
 #[ignore = "requires a live NetBox (netbox-integration workflow)"]
 fn search_scope_filters_include_descendant_prefixes() {
-    for (flag, ref_, expected) in [
-        ("--region", "ci-region", ["10.20.0.0/16", "10.10.0.0/16"]),
+    for (flag, ref_, expected, absent) in [
+        (
+            "--region",
+            "ci-region",
+            ["10.20.0.0/16", "10.10.0.0/16"],
+            &["10.30.0.0/16"][..],
+        ),
         (
             "--site-group",
             "ci-sitegroup",
             ["10.30.0.0/16", "10.10.0.0/16"],
+            &["10.20.0.0/16"][..],
         ),
-        ("--location", "ci-loc", ["10.40.0.0/16", "10.41.0.0/16"]),
+        (
+            "--location",
+            "ci-loc",
+            ["10.40.0.0/16", "10.41.0.0/16"],
+            &["10.20.0.0/16", "10.30.0.0/16"][..],
+        ),
     ] {
         let what = format!("search 10. {flag} {ref_}");
         let out = run_nbox(&["-o", "json", "search", "10.", flag, ref_]);
@@ -497,6 +508,13 @@ fn search_scope_filters_include_descendant_prefixes() {
                 arr.iter()
                     .any(|r| r["kind"] == "prefix" && r["display"] == expected_prefix),
                 "{flag} {ref_} should surface {expected_prefix}: {results}"
+            );
+        }
+        for absent_prefix in absent {
+            assert!(
+                !arr.iter()
+                    .any(|r| r["kind"] == "prefix" && r["display"] == *absent_prefix),
+                "{flag} {ref_} leaked sibling scope prefix {absent_prefix}: {results}"
             );
         }
     }


### PR DESCRIPTION
## Why the nightly 4.6 lane failed

The 4.6 compatibility lane (added in #90, `schedule`-only, so this was its **first-ever run**) failed at **"Wait for NetBox to be ready"** with a persistent **HTTP 403** for 60s, then skipped seed + tests. **nbox never ran — the fixture never came up.**

Root cause: NetBox 4.6's netbox-docker entrypoint (`super_user.py`) now provisions the superuser token **only when both** `SUPERUSER_API_TOKEN` (the secret) **and** `SUPERUSER_API_KEY` (the v2 public key) are set:

```python
if su_api_key and su_api_token:
    Token.objects.create(user=u, token=su_api_token, version=V2, key=su_api_key)
else:
    print('⚠️ No API token was created for the superuser as SUPERUSER_API_TOKEN and SUPERUSER_API_KEY are not set')
```

Our compose set only `SUPERUSER_API_TOKEN`, so **no token was created** (`Token.DoesNotExist`) → `resolve-token.sh` emitted an empty token → the authenticated readiness probe got 403 forever → timeout. (4.2 v1 / 4.5 created the token from the secret alone and are unaffected.)

## Fix (verified locally against `netboxcommunity/netbox:v4.6.2`)

- **compose:** add `SUPERUSER_API_KEY: "citoken12345"` (deterministic 12-char v2 key). The entrypoint now provisions `nbt_citoken12345.<secret>`; the readiness probe gets **200**; **all 21 gated tests pass** against live 4.6.2 (incl. the scope-hierarchy + GraphQL tests). The key var is ignored by the 4.2/4.5 images.
- **`resolve-token.sh`:** read the key with `filter().first()` (no `DoesNotExist` traceback) and **fail loud** (exit 1, clear message) when no token exists — so a future drift reads as a token error, not a misleading readiness timeout.
- **workflow:** assign the token before writing `$GITHUB_ENV` so a resolve failure fails the step under `set -e`.

## 4.6 on PRs (the second ask)

**Yes — enabling it.** Removed the `schedule`-only gate so the 4.6 lane runs on every trigger, gating PRs like 4.2/4.5. Rationale: 4.6 is the **current** NetBox line and our dev target, so it's the most important to catch regressions on pre-merge; it runs in parallel with the other lanes (bounded wall-clock); and the nightly schedule still runs it to catch image drift. Trade-off: three live-NetBox boots per PR instead of two. If you'd rather cap at two PR lanes, the cleanest trim is moving **4.2** (oldest/most stable) to schedule-only — say the word and I'll do that instead.

## Validation

This PR's own CI exercises the fix: with 4.6 now on PRs, the `live NetBox 4.6 compatibility` lane runs here alongside 4.2/4.5 — three green live lanes prove the compose change doesn't regress 4.2/4.5 and that 4.6 is fixed.