### PR TITLE
feat(write): device set status pilot + shared choice validation (ADR-0001)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ minimize tokens, `--fields` to trim payloads).
 
 ```
 nbox device <name|slug|id>
+                                  # optional write subcommand:
+  device <name> set status <value> [--message "…"]
+                                  #   --dry-run | --allow-writes --confirm
+                                  #   (ADR-0001 safe write; read-only default)
 nbox ip <address> [--vrf <name|slug|rd>]  # surfaces nat_inside/nat_outside (NetBox 4.6) when set
 nbox prefix <cidr> [--vrf <name|slug|rd>]
 nbox next-ip <cidr> [--count N] [--vrf <name|slug|rd>]
@@ -177,13 +181,19 @@ nbox device edge01 --json | jq '.primary_ip4'
 ## Notes
 
 - The first write landed behind ADR-0001: `nbox interface <device> <interface>
-  set description "…"` is a safe, plan-first `PATCH`. Reads remain the default —
-  apply needs BOTH `--allow-writes` (the gate) AND `--confirm` (or a TTY prompt
-  in plain output); `--dry-run` previews with no mutation and needs neither.
+  set description "…"` and `nbox device <name> set status <value>` are safe,
+  plan-first `PATCH`es. Reads remain the default — apply needs BOTH
+  `--allow-writes` (the gate) AND `--confirm` (or a TTY prompt in plain
+  output); `--dry-run` previews with no mutation and needs neither.
   `--confirm` without `--allow-writes` is a usage error (exit 2, empty stdout).
   Non-TTY / `--json` / `--csv` / `--no-tui` never prompt. `--json --dry-run`
   returns the stable `MutationPlan`; `--json --confirm` returns a `MutationReceipt`
-  (both `schema_version: 1`). The MCP server stays read-only.
+  (both `schema_version: 1`). For `device set status`, the allowed values are
+  enumerated live from NetBox (read-only `OPTIONS`) and the input is normalized
+  to the canonical value (a label is accepted case-insensitively when it maps
+  unambiguously to one value); an unknown or ambiguous status is a usage error
+  (exit 2) naming the input and listing the allowed values, before any `PATCH`.
+  The MCP server stays read-only.
 - Filters that an object type can't satisfy cause that type to be skipped in
   `search` (nbox does not send NetBox unknown query params).
 - `owner` (NetBox 4.5+): a native owner field (user or group) surfaced on most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     patch, full object, or `--message` body is ever logged.
   - **MCP stays read-only.** No write tools are exposed; per-user NetBox write
     identity (Pattern 2) is a prerequisite for MCP writes.
+- **`nbox device <name> set status <value>` — the second safe write.** Reuses
+  the ADR-0001 foundation (the same `MutationPlan`/`MutationReceipt` engine,
+  `--dry-run` / `--allow-writes --confirm` / `--message` gate, `ETag`+`If-Match`
+  on 4.6+, pre-4.6 `last_updated`+before-hash fallback, and local write audit)
+  as the interface-description pilot. Sends a minimal `PATCH` body
+  (`{"status": "<value>"}`); a no-op status (current value already matches)
+  sends no `PATCH`.
+  - **Choice validation.** `status` is a server-enumerated field, so nbox asks
+    NetBox for the allowed values via a read-only `OPTIONS` before any `PATCH`,
+    and normalizes the operator's input to the canonical wire value. Canonical
+    values are accepted; labels are accepted case-insensitively when they map
+    unambiguously to one value. Unknown or ambiguous status is a usage error
+    (exit 2, empty stdout) that names the input and lists the allowed canonical
+    values — before any `PATCH`. This is the smallest reusable mechanism for
+    REST choice fields (`src/netbox/choices.rs`), not a generic schema editor;
+    writable-field discovery, required-field checking, and relation shaping
+    stay out of scope (ROADMAP).
+  - **Shared CLI write path.** The gate decision and the dry-run/prompt/apply/
+    audit lifecycle are factored into shared helpers (`gate_write`,
+    `apply_or_preview`) now used by both write commands, so there is one write
+    path, not two.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ this device, what owns this prefix?* — from the shell, a k9s-style TUI, or an 
 server for AI agents.
 
 **Status: pre-1.0.** Reads are the default; a narrow safe-write foundation
-(ADR-0001) has landed behind `--allow-writes` + confirmation — one pilot
-command today (`nbox interface <device> <interface> set description "…"`).
-Broader writes are on the [ROADMAP](ROADMAP.md).
+(ADR-0001) has landed behind `--allow-writes` + confirmation — two pilot
+commands today (`nbox interface <device> <interface> set description "…"`
+and `nbox device <name> set status <value>`). Broader writes are on the
+[ROADMAP](ROADMAP.md).
 
 ## Quick Start
 
@@ -251,6 +252,7 @@ nbox search <query> [--limit N] [--status/--site/--region/--site-group/--locatio
                                   # --owner/--owner-group filter by user/group name (NetBox 4.5+).
                                   # Full scope/filter semantics: docs/FEATURES.md
 nbox device <name-or-id> [--journal] [--journal-limit N]
+  device <name> set status <value>                    # write: status validated live via OPTIONS; --dry-run | --allow-writes --confirm [--message]
 nbox ip <address> [--vrf <name>] [--journal]    # --vrf disambiguates duplicates across VRFs
                                   # shows nat_inside/nat_outside (NetBox 4.6) when set
 nbox prefix <cidr> [--vrf <name>] [--journal]   # includes utilization + children when present

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,8 @@
 nbox is a **read-first** NetBox CLI, TUI, and MCP server. The near-term goal is the **best
 possible read experience** — fast, correct, and pleasant both in the terminal and to agents.
 A narrow **safe-write foundation** has now landed (ADR-0001): a gated, opt-in, before/after-previewed
-`PATCH` engine, with the first pilot being `interface <device> <iface> set description`. Reads stay
+`PATCH` engine, with two pilots landed — `interface <device> <iface> set description` and
+`device <name> set status <value>`. Reads stay
 the default everywhere and the write surface widens only as the read tool proves out in practice
 (see [Writes](#writes--deferred-later-track)).
 
@@ -422,16 +423,26 @@ the read tool proves out in practice. Consolidated future scope:
   "…"` pilot (`--allow-writes` + `--confirm`/`--dry-run`, `ETag`/`If-Match` on
   4.6+, `last_updated`+before-hash fallback, `--message`, local write audit).
 - ☑ `nbox interface <device> <iface> set description "…"` — the first write
-  command (on the ADR-0001 foundation). `nbox device <name> set status <value>`,
-  `nbox ip <addr> reserve --description "…"`, and `nbox tag add <type> <name>
-  <tag>` remain open, each reusing the same planner/diff/confirm/concurrency/audit
-  contracts.
-- ☐ **IPAM allocate** — claim the next IP/prefix, plus IP-range `available-ips` (POST to
-  `available-ips` / `available-prefixes`); the read half (`next-ip` / `next-prefix`, range lookup)
-  already ships.
+  command (on the ADR-0001 foundation). `nbox ip <addr> reserve --description "…"`
+  and `nbox tag add <type> <name> <tag>` remain open, each reusing the same
+  planner/diff/confirm/concurrency/audit contracts.
+- ☑ `nbox device <name> set status <value>` — the second write command,
+  reusing the ADR-0001 foundation. Allowed `status` values are enumerated live
+  from NetBox (read-only `OPTIONS`) and the operator's input is normalized to
+  the canonical value (a label is accepted case-insensitively when it maps
+  unambiguously to one value); unknown/ambiguous status is a usage error before
+  any `PATCH`. Same `--dry-run` / `--allow-writes --confirm` / `--message` /
+  ETag+`If-Match` / pre-4.6 fallback / local write-audit contracts as the
+  interface pilot. The smallest reusable choice-validation mechanism
+  (`src/netbox/choices.rs`) backs it, not a generic schema editor.
 - ☑ `changelog_message` support on writes — opt-in via `--message`, validated to
   NetBox's 200-character limit before applying; recorded in the object-change
   entry (never logged locally beyond a present-flag + length).
+- ☐ **IPAM allocate** — claim the next IP/prefix, plus IP-range `available-ips` (POST to
+  `available-ips` / `available-prefixes`); the read half (`next-ip` / `next-prefix`, range lookup)
+  already ships.
+- ☐ `nbox ip <addr> reserve --description "…"` and `nbox tag add <type> <name>
+  <tag>` — the next write commands, each reusing the same foundation.
 - ☐ **Write-capable MCP tools** — opt-in, return the diff for the agent to confirm; read-only stays the
   default — plus the **per-user credential vault (Pattern 2)** for real per-user NetBox RBAC over MCP.
 - ☐ TUI edit mode (`e` / `d` / confirm).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,16 +1,17 @@
 # Features
 
 nbox is a NetBox client — a CLI and a TUI over the same core. Reads are the
-default; a narrow safe-write foundation (ADR-0001) adds one plan-first `PATCH`
-command behind `--allow-writes` + confirmation. The MCP server stays read-only.
+default; a narrow safe-write foundation (ADR-0001) adds two plan-first `PATCH`
+commands behind `--allow-writes` + confirmation — `interface … set description`
+and `device … set status`. The MCP server stays read-only.
 
 ## Lookups
 
 | Command | What |
 | ------- | ---- |
 | `nbox search <q>` | Parallel search across devices/sites/racks/IPs/prefixes/VLANs/circuits/virtual-circuits/aggregates/ASNs/IP-ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets. Filters: `--status/--site/--region/--site-group/--location/--tenant/--role/--tag/--owner/--owner-group/--vrf`, `--limit`, `--cols`, `--partial`. |
-| `nbox device <name\|slug\|id> [--journal]` | Device + interfaces, IPs, cables, VLANs, services. |
-| `nbox interface <device> <iface>` | One interface: type, MTU, MAC, mode, VLANs, cable, **cable path** (an A↔Z trace diagram naming the device at each end), addresses. |
+| `nbox device <name\|slug\|id> [--journal]` | Device + interfaces, IPs, cables, VLANs, services. `set status <value>` is a safe write (ADR-0001): status validated live via OPTIONS, behind `--allow-writes` + confirm. |
+| `nbox interface <device> <iface>` | One interface: type, MTU, MAC, mode, VLANs, cable, **cable path** (an A↔Z trace diagram naming the device at each end), addresses. `set description "…"` is a safe write (ADR-0001), behind `--allow-writes` + confirm. |
 | `nbox ip <addr> [--vrf] [--journal]` | IP + most-specific parent prefix (VRF-scoped) and its VLAN plus the prefix's `scope`/`scope_type` (site, location, region, …); surfaces `nat_inside`/`nat_outside` (NetBox 4.6) when set. |
 | `nbox prefix <cidr> [--vrf] [--journal]` | Prefix with utilization, children, and contained IPs. |
 | `nbox next-ip <cidr> [--count] [--vrf]` | Next available address(es). |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,6 +150,12 @@ pub enum Command {
         /// Max inline journal entries to fold in (implies --journal; default 5).
         #[arg(long, value_name = "N")]
         journal_limit: Option<usize>,
+
+        /// Optional write action. Omit to read the device (`nbox device
+        /// <value>`); pass `set` to update a field (a write, behind
+        /// `--allow-writes` + confirmation — ADR-0001).
+        #[command(subcommand)]
+        action: Option<DeviceAction>,
     },
 
     /// Look up an IP address.
@@ -603,6 +609,55 @@ pub enum InterfaceAction {
         field: String,
 
         /// New value verbatim. Pass an empty string (`""`) to clear the field.
+        /// A value equal to the current one is a no-op: apply sends no `PATCH`
+        /// and reports "no change".
+        value: String,
+
+        /// Record this message in NetBox's object-change entry (a write-only
+        /// request field, never stored on the object). Validated to NetBox's
+        /// 200-character limit before applying. Optional.
+        #[arg(long, value_name = "MESSAGE")]
+        message: Option<String>,
+
+        /// Preview the plan + diff and perform no mutation. Needs neither
+        /// `--allow-writes` nor confirmation. With `--json`, returns the stable
+        /// `MutationPlan` JSON.
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+
+        /// Apply the reviewed plan without an interactive prompt. Does NOT
+        /// enable writes on its own — `--confirm` without `--allow-writes` is a
+        /// usage error (exit 2). With `--json`, returns the stable
+        /// `MutationReceipt` JSON.
+        #[arg(long)]
+        confirm: bool,
+
+        /// The write-enable gate: required to apply ANY mutation. Kept separate
+        /// from `--confirm` so a read-only invocation can never be silently
+        /// turned into a write (ADR-0001 §4).
+        #[arg(long = "allow-writes")]
+        allow_writes: bool,
+    },
+}
+
+/// Write actions on a device (ADR-0001 safe-write foundation). The v1
+/// surface is intentionally narrow: one operation (`set`) on one field
+/// (`status`). No generic `edit`, no free-form patch — broader writes come
+/// later, on the same planner/diff/confirm/concurrency/audit contracts.
+#[derive(Debug, Subcommand)]
+pub enum DeviceAction {
+    /// Set a writable field on a device. A write: requires the `--allow-writes`
+    /// gate AND confirmation (`--confirm`, or an interactive prompt on a TTY in
+    /// plain output). `--dry-run` previews with no mutation and needs neither.
+    Set {
+        /// Field to set. Only `status` is supported in this pilot; any other
+        /// value is a usage error (exit 2) before any network write. Allowed
+        /// `status` values are read live from NetBox (OPTIONS) — a canonical
+        /// value (`active`) or a label (`Active`) matched case-insensitively
+        /// when it maps unambiguously to one value.
+        field: String,
+
+        /// New value verbatim. For `status`, the canonical value or a label.
         /// A value equal to the current one is a no-op: apply sends no `PATCH`
         /// and reports "no change".
         value: String,
@@ -1171,5 +1226,91 @@ mod tests {
             bare.command,
             Some(Command::Aggregate { journal: false, .. })
         ));
+    }
+
+    #[test]
+    fn device_read_unchanged_with_optional_set_subcommand() {
+        // Omitting `set` keeps the read path: `action` is `None`.
+        let read = Cli::try_parse_from(["nbox", "device", "edge01", "--journal"]).unwrap();
+        assert!(matches!(
+            read.command,
+            Some(Command::Device {
+                value,
+                journal: true,
+                action: None,
+                ..
+            }) if value == "edge01"
+        ));
+    }
+
+    #[test]
+    fn device_set_status_parses_flags() {
+        let set = Cli::try_parse_from([
+            "nbox",
+            "device",
+            "edge01",
+            "set",
+            "status",
+            "active",
+            "--dry-run",
+        ])
+        .unwrap();
+        let Some(Command::Device {
+            value,
+            action:
+                Some(DeviceAction::Set {
+                    field,
+                    value: new_value,
+                    message,
+                    dry_run,
+                    confirm,
+                    allow_writes,
+                }),
+            ..
+        }) = set.command
+        else {
+            panic!("expected device set status");
+        };
+        assert_eq!(value, "edge01");
+        assert_eq!(field, "status");
+        assert_eq!(new_value, "active");
+        assert!(dry_run);
+        assert!(!confirm);
+        assert!(!allow_writes);
+        assert!(message.is_none());
+
+        // The write flags compose: --allow-writes + --confirm + --message.
+        let apply = Cli::try_parse_from([
+            "nbox",
+            "--no-tui",
+            "device",
+            "edge01",
+            "set",
+            "status",
+            "Offline",
+            "--allow-writes",
+            "--confirm",
+            "--message",
+            "draining",
+        ])
+        .unwrap();
+        let Some(Command::Device {
+            action:
+                Some(DeviceAction::Set {
+                    field,
+                    value: new_value,
+                    message: Some(msg),
+                    dry_run: false,
+                    confirm: true,
+                    allow_writes: true,
+                }),
+            ..
+        }) = apply.command
+        else {
+            panic!("expected device set status apply");
+        };
+        assert_eq!(field, "status");
+        assert_eq!(new_value, "Offline");
+        assert_eq!(msg, "draining");
     }
 }

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -431,6 +431,200 @@ fn interface_before_hash(iface: &Interface) -> String {
     mutation::before_hash(&m)
 }
 
+// ===== Safe write follow-on: device status (ADR-0001) =====================
+//
+// The second write command reuses the same planner/diff/confirm/concurrency/
+// audit contracts as the interface-description pilot. The new piece is choice
+// validation: `status` is a server-enumerated field, so the planner asks
+// NetBox (read-only `OPTIONS`) for the allowed values and normalizes the
+// operator's input to the canonical wire value BEFORE building the plan — an
+// unknown or ambiguous status is a usage error (exit 2) with no `PATCH`.
+// Still operation- and field-specific (one field: `status`); no generic editor.
+
+/// The only writable field on a device in this pilot (ADR-0001 §6).
+pub(crate) const DEVICE_WRITABLE_FIELD: &str = "status";
+
+/// Plan a device `status` update: enumerate the allowed status values from
+/// NetBox (read-only `OPTIONS`) and normalize the input, resolve the device,
+/// read the authoritative current state with its `ETag` (4.6+) or `last_updated`
+/// (pre-4.6), derive the minimal `PATCH` (`{"status": "<value>"}`), and build
+/// the [`MutationPlan`].
+///
+/// `new_status` is the operator's input verbatim — a canonical value
+/// (`active`) or a label (`Active`) matched case-insensitively when it maps
+/// unambiguously to one value. Unknown/ambiguous input is a usage error here,
+/// before any `PATCH`, naming the input and listing the allowed canonical
+/// values. A no-op (current value already matches) yields `no_op: true` and an
+/// empty `patch`. `changelog_message` is validated against NetBox's length
+/// limit here, before any network write.
+pub(crate) async fn plan_device_status_update(
+    client: &NetBoxClient,
+    device: &str,
+    new_status: &str,
+    changelog_message: Option<&str>,
+    profile: &str,
+    not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
+) -> Result<MutationPlan> {
+    // Message length is pure input validation — check first, before any network.
+    let message = match changelog_message {
+        Some(m) if !m.is_empty() => Some(m.to_string()),
+        _ => None,
+    };
+    mutation::validate_changelog_message(&message)?;
+
+    // Enumerate the allowed status values from NetBox (read-only OPTIONS) and
+    // normalize the operator's input to the canonical wire value. An
+    // unknown/ambiguous input is a usage error (exit 2) BEFORE resolving the
+    // device — no PATCH is ever built from an unvalidated value (ADR-0001 §6).
+    let choices = client.device_status_choices().await?;
+    let normalized =
+        crate::netbox::choices::resolve_choice(&choices, DEVICE_WRITABLE_FIELD, new_status)?;
+
+    // Resolve the device by reference (reuses the read path so ambiguity /
+    // not-found / case-insensitive fallback behave exactly like `nbox device`).
+    let dev = client
+        .device_by_ref(device)
+        .await?
+        .ok_or_else(|| not_found("device", device))?;
+    // Read the authoritative current state with its `ETag` header (4.6+) or
+    // `last_updated` (pre-4.6 fallback). The list above gave us the id; the
+    // detail gives the ETag plus the canonical object.
+    let endpoint = format!("/api/dcim/devices/{}/", dev.id);
+    let (current, etag): (Device, Option<String>) = client.get_with_etag(&endpoint, &[]).await?;
+
+    let target = PlanTarget {
+        kind: "device".to_string(),
+        r#ref: device.to_string(),
+        id: current.id,
+        display: current
+            .display
+            .clone()
+            .or_else(|| Some(current.name.clone()))
+            .unwrap_or_else(|| device.to_string()),
+        endpoint,
+        profile: profile.to_string(),
+    };
+
+    let precondition = match etag {
+        Some(e) => Precondition::Etag { etag: e },
+        None => Precondition::LastUpdated {
+            last_updated: current.last_updated.clone(),
+            before_hash: device_before_hash(&current),
+        },
+    };
+
+    // The current status value (the canonical wire value, e.g. "active").
+    let current_status = current.status.as_ref().map(|c| c.value.clone());
+    let before = serde_json::to_value(&current_status).unwrap_or(Value::Null);
+    let after = serde_json::to_value(&normalized).unwrap_or(Value::Null);
+    let no_op = current_status.as_deref() == Some(normalized.as_str());
+    let patch = if no_op {
+        serde_json::json!({})
+    } else {
+        serde_json::json!({ "status": normalized })
+    };
+    let fields = vec![FieldChange {
+        field: DEVICE_WRITABLE_FIELD.to_string(),
+        before: before.clone(),
+        after: after.clone(),
+    }];
+
+    let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
+    let confirm_token = mutation::confirm_token(&target, &precondition, &patch, expires_epoch);
+
+    Ok(MutationPlan {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: Operation::Update,
+        target,
+        precondition,
+        fields,
+        patch,
+        no_op,
+        warnings: Vec::new(),
+        errors: Vec::new(),
+        changelog_message: message,
+        confirm_token,
+        expires_at: mutation::format_iso_utc(expires_epoch),
+    })
+}
+
+/// Apply a planned device `status` update (ADR-0001 §5 steps 5–7): verify the
+/// plan's confirmation token + expiry, short-circuit a no-op, then send the
+/// minimal `PATCH` (`{"status": "<value>"}`) with the recorded precondition.
+/// Returns a [`MutationReceipt`] from the PATCH response.
+pub(crate) async fn apply_device_status_update(
+    client: &NetBoxClient,
+    plan: &MutationPlan,
+) -> Result<MutationReceipt> {
+    plan.verify()?;
+
+    if plan.no_op {
+        return Ok(no_op_receipt(plan));
+    }
+
+    // The wire body is the object-field patch plus the opt-in changelog_message
+    // (a NetBox write-only request field, recorded in the object-change entry,
+    // never stored on the object).
+    let mut body = plan.patch.clone();
+    if let Some(msg) = &plan.changelog_message {
+        body["changelog_message"] = serde_json::json!(msg);
+    }
+
+    let (_updated, new_etag, status): (Device, Option<String>, u16) = match &plan.precondition {
+        Precondition::Etag { etag } => {
+            client
+                .patch(&plan.target.endpoint, &body, Some(etag))
+                .await?
+        }
+        Precondition::LastUpdated {
+            last_updated,
+            before_hash,
+        } => {
+            // Read-before-write (pre-4.6 fallback): re-fetch and refuse if the
+            // object moved. `last_updated` ticking is the primary signal; the
+            // before-hash is a belt-and-suspenders guard for the rare case it
+            // didn't.
+            let (current, _): (Device, Option<String>) =
+                client.get_with_etag(&plan.target.endpoint, &[]).await?;
+            if current.last_updated != *last_updated || device_before_hash(&current) != *before_hash
+            {
+                return Err(NboxError::StalePrecondition(String::new()).into());
+            }
+            client.patch(&plan.target.endpoint, &body, None).await?
+        }
+    };
+
+    Ok(MutationReceipt {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: plan.operation,
+        target: plan.target.clone(),
+        fields: plan.fields.clone(),
+        applied: true,
+        no_op: false,
+        status,
+        etag: new_etag,
+        request_id: None,
+        message: format!(
+            "applied: {} {} ({})",
+            plan.target.kind,
+            plan.target.display,
+            plan.changed_field_names().join(", ")
+        ),
+    })
+}
+
+/// Normalized before-hash over the device's in-scope writable field (`status`).
+/// The apply re-reads and recomputes this; a mismatch vs the plan's recorded
+/// `before_hash` means the object changed in NetBox.
+fn device_before_hash(dev: &Device) -> String {
+    let mut m = BTreeMap::new();
+    m.insert(
+        DEVICE_WRITABLE_FIELD.to_string(),
+        serde_json::to_value(dev.status.as_ref().map(|c| c.value.clone())).unwrap_or(Value::Null),
+    );
+    mutation::before_hash(&m)
+}
+
 /// `ip <address>`: resolve an IP (scoped by `vrf`, ambiguity-checked) and
 /// enrich with its most-specific parent prefix. Shared by CLI/MCP.
 pub async fn ip_view_by_ref(

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -477,6 +477,18 @@ pub(crate) async fn plan_device_status_update(
     // unknown/ambiguous input is a usage error (exit 2) BEFORE resolving the
     // device — no PATCH is ever built from an unvalidated value (ADR-0001 §6).
     let choices = client.device_status_choices().await?;
+    // Empty metadata means the OPTIONS enumeration came back without choices
+    // (an unexpected schema, a permission-stripped `actions`, or a proxy that
+    // dropped the body). Fail with a clear cause rather than letting
+    // `resolve_choice` report the input as an invalid value against an empty
+    // allow-list — and never send an unvalidated write (ADR-0001 §6).
+    if choices.is_empty() {
+        return Err(NboxError::Usage(format!(
+            "could not enumerate allowed values for device {DEVICE_WRITABLE_FIELD} from NetBox \
+             OPTIONS; refusing to send an unvalidated write"
+        ))
+        .into());
+    }
     let normalized =
         crate::netbox::choices::resolve_choice(&choices, DEVICE_WRITABLE_FIELD, new_status)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,30 @@ pub async fn run(cli: Cli) -> Result<()> {
             value,
             journal,
             journal_limit,
-        }) => run_device(&ctx, &value, journal, journal_limit).await,
+            action,
+        }) => match action {
+            None => run_device(&ctx, &value, journal, journal_limit).await,
+            Some(crate::cli::DeviceAction::Set {
+                field,
+                value: new_value,
+                message,
+                dry_run,
+                confirm,
+                allow_writes,
+            }) => {
+                Box::pin(run_device_set(
+                    &ctx,
+                    &value,
+                    &field,
+                    &new_value,
+                    message.as_deref(),
+                    dry_run,
+                    confirm,
+                    allow_writes,
+                ))
+                .await
+            }
+        },
         Some(Command::Ip {
             address,
             vrf,
@@ -1201,48 +1224,13 @@ fn write_action(
     }
 }
 
-/// `nbox interface <device> <interface> set <field> <value>` — the first safe
-/// write (ADR-0001). The lifecycle (ADR-0001 §5): resolve → read → plan →
-/// render → confirm → apply → receipt. Enablement + confirmation are separate
-/// (ADR §4): apply needs BOTH the `--allow-writes` gate AND confirmation
-/// (`--confirm`, or a TTY prompt in plain output); `--dry-run` needs neither.
-/// Non-TTY / JSON / CSV / `--no-tui` never prompt. The audit event (field names
-/// only, never values/tokens/objects/the message body) is emitted on every
-/// planned outcome; a pre-plan usage refusal emits none.
-#[allow(clippy::too_many_arguments)] // the CLI flag set; collapsing loses clarity
-async fn run_interface_set(
-    ctx: &Ctx,
-    device: &str,
-    interface: &str,
-    field: &str,
-    value: &str,
-    message: Option<&str>,
-    dry_run: bool,
-    confirm: bool,
-    allow_writes: bool,
-) -> Result<()> {
+/// Resolve the write gate + confirmation flags into a [`WriteAction`], refusing
+/// (exit 2, empty stdout) before any plan/network when the gate is missing or
+/// confirmation can't be obtained non-interactively. Shared by every write
+/// command so the gate matrix + refusal messages are one path (ADR-0001 §4/§5).
+/// `--dry-run` is exempt (mutates nothing) and always proceeds to plan + render.
+fn gate_write(ctx: &Ctx, dry_run: bool, confirm: bool, allow_writes: bool) -> Result<WriteAction> {
     use std::io::IsTerminal as _;
-    use std::io::Write as _;
-
-    use crate::netbox::write_audit::{Outcome, Started, Surface};
-
-    // Field validation is pure input checking — fail closed before any network
-    // use so `set status active` is a usage error regardless of the other flags.
-    if field != detail::INTERFACE_WRITABLE_FIELD {
-        return Err(error::NboxError::Usage(format!(
-            "only `{}` is writable on an interface in v1; got \"{field}\". \
-             Broader writes land later on the same safe-write contracts (ADR-0001 §6).",
-            detail::INTERFACE_WRITABLE_FIELD
-        ))
-        .into());
-    }
-
-    // Gate decision BEFORE any plan/network: a read-only invocation can never
-    // become a write (ADR-0001 §4/§5). `--dry-run` is exempt (mutates nothing).
-    // A refusal here keeps stdout empty (no diff) and names the required flag.
-    // The decision is a pure function of the flags + interactive context, so the
-    // full gate matrix is unit-tested in [`write_action`] (no TTY/network).
-    //
     // `interactive` requires a fully interactive terminal: plain output AND both
     // stdout AND stdin are TTYs (a piped/closed stdin cannot answer a prompt) AND
     // not `--no-tui`. Requiring stdin keeps the "non-TTY never prompts" contract
@@ -1253,36 +1241,53 @@ async fn run_interface_set(
         && !ctx.no_tui;
     let action = write_action(dry_run, confirm, allow_writes, interactive);
     match action {
-        WriteAction::RefuseNoGate => {
-            return Err(error::NboxError::Usage(
-                "writes are not enabled. To apply, pass `--allow-writes` AND confirm \
-                 (`--confirm`, or answer the prompt on a TTY). To preview only, pass `--dry-run`."
-                    .to_string(),
-            )
-            .into());
-        }
-        WriteAction::RefuseNeedsConfirm => {
-            return Err(error::NboxError::Usage(
-                "non-interactive write requires confirmation. Add `--confirm` to apply \
-                 (or `--dry-run` to preview the plan)."
-                    .to_string(),
-            )
-            .into());
-        }
+        WriteAction::RefuseNoGate => Err(error::NboxError::Usage(
+            "writes are not enabled. To apply, pass `--allow-writes` AND confirm \
+             (`--confirm`, or answer the prompt on a TTY). To preview only, pass `--dry-run`."
+                .to_string(),
+        )
+        .into()),
+        WriteAction::RefuseNeedsConfirm => Err(error::NboxError::Usage(
+            "non-interactive write requires confirmation. Add `--confirm` to apply \
+             (or `--dry-run` to preview the plan)."
+                .to_string(),
+        )
+        .into()),
         // DryRun / Apply / Prompt all proceed past the gate to plan + (render | apply).
-        _ => {}
+        _ => Ok(action),
     }
+}
 
-    let (client, profile) = connect_named(ctx)?;
-    let host = audit_origin(client.base_url());
+/// The shared post-plan write lifecycle (ADR-0001 §5 steps 4–7): given an
+/// already-built [`MutationPlan`] and the resolved [`WriteAction`], render a
+/// dry-run, prompt on a TTY (when `Prompt`), and apply (when `Apply`/`Prompt`
+/// accepted) — emitting the single structured write-audit event for each
+/// outcome. The two write commands share this so the gate/prompt/audit
+/// orchestration is one path, not two; only the field check + the planner +
+/// the applier differ per command. `apply` boxes the command-specific apply
+/// future so this stays generic over the target kind.
+///
+/// `plan` is borrowed for the whole body (the diff render, the audit event,
+/// and the apply all read it); nothing moves it.
+async fn apply_or_preview(
+    ctx: &Ctx,
+    client: &NetBoxClient,
+    plan: &MutationPlan,
+    action: WriteAction,
+    profile: &str,
+    host: &str,
+    apply: impl for<'a> Fn(
+        &'a NetBoxClient,
+        &'a MutationPlan,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = anyhow::Result<MutationReceipt>> + 'a>,
+    >,
+) -> Result<()> {
+    use std::io::Write as _;
 
-    // 2–4) read + plan. (1 — resolve — happens inside the planner.)
-    let plan = detail::plan_interface_description_update(
-        &client, device, interface, value, message, &profile, &not_found,
-    )
-    .await?;
-    let audit_fields: Vec<&str> = plan.changed_field_names();
-    let field_names: Vec<&str> = audit_fields.clone();
+    use crate::netbox::write_audit::{Outcome, Started, Surface};
+
+    let field_names: Vec<&str> = plan.changed_field_names();
     // Audit the *planned* (normalized) message, not the raw `--message` arg: the
     // planner normalizes an empty/whitespace-only message to `None`, so it audits
     // as absent. The length is a character count (matching NetBox's 200-char
@@ -1294,11 +1299,11 @@ async fn run_interface_set(
 
     // `--dry-run`: plan + render, no mutation, no gate, no confirm. ADR §5.
     if action == WriteAction::DryRun {
-        let ev = audit_event(
+        audit_event(
             Surface::Cli,
-            &profile,
-            &host,
-            &plan,
+            profile,
+            host,
+            plan,
             &field_names,
             Outcome::DryRun,
             "GET",
@@ -1307,18 +1312,18 @@ async fn run_interface_set(
             0,
             message_present,
             message_len,
-        );
-        ev.emit();
+        )
+        .emit();
         if ctx.format == Format::Plain {
             eprintln!("planned, no changes sent");
         }
-        return emit(ctx, &plan, || render_plan_plain(&plan));
+        return emit(ctx, plan, || render_plan_plain(plan));
     }
 
     // 5) confirm. On a plain TTY without `--confirm`, show the diff then prompt.
     if action == WriteAction::Prompt {
         // The diff goes to stdout (the operator's review); the prompt to stderr.
-        render_plan_plain(&plan);
+        render_plan_plain(plan);
         if plan.no_op {
             // A no-op needs no confirmation — nothing would change. Still emit
             // the dry-plan-style line and let the apply path short-circuit.
@@ -1334,8 +1339,8 @@ async fn run_interface_set(
         if accepted.is_none() {
             write_audit::WriteAuditEvent {
                 surface: Surface::Cli,
-                profile: &profile,
-                host: &host,
+                profile,
+                host,
                 operation: plan.operation,
                 target_kind: &plan.target.kind,
                 target_id: plan.target.id,
@@ -1359,7 +1364,7 @@ async fn run_interface_set(
     // 6) apply (+ 7 receipt). The apply verifies the plan's token + expiry,
     // short-circuits a no-op, and sends the minimal PATCH with the precondition.
     let sw = Started::now();
-    match detail::apply_interface_description_update(&client, &plan).await {
+    match apply(client, plan).await {
         Ok(receipt) => {
             let outcome = if receipt.no_op {
                 Outcome::NoOp
@@ -1368,9 +1373,9 @@ async fn run_interface_set(
             };
             audit_event(
                 Surface::Cli,
-                &profile,
-                &host,
-                &plan,
+                profile,
+                host,
+                plan,
                 &field_names,
                 outcome,
                 "PATCH",
@@ -1393,9 +1398,9 @@ async fn run_interface_set(
             // the error variants don't surface the HTTP status.
             audit_event(
                 Surface::Cli,
-                &profile,
-                &host,
-                &plan,
+                profile,
+                host,
+                plan,
                 &field_names,
                 outcome,
                 "PATCH",
@@ -1409,6 +1414,111 @@ async fn run_interface_set(
             Err(e)
         }
     }
+}
+
+/// `nbox interface <device> <interface> set <field> <value>` — the first safe
+/// write (ADR-0001). The lifecycle (ADR-0001 §5): resolve → read → plan →
+/// render → confirm → apply → receipt. Enablement + confirmation are separate
+/// (ADR §4): apply needs BOTH the `--allow-writes` gate AND confirmation
+/// (`--confirm`, or a TTY prompt in plain output); `--dry-run` needs neither.
+/// Non-TTY / JSON / CSV / `--no-tui` never prompt. The audit event (field names
+/// only, never values/tokens/objects/the message body) is emitted on every
+/// planned outcome; a pre-plan usage refusal emits none.
+#[allow(clippy::too_many_arguments)] // the CLI flag set; collapsing loses clarity
+async fn run_interface_set(
+    ctx: &Ctx,
+    device: &str,
+    interface: &str,
+    field: &str,
+    value: &str,
+    message: Option<&str>,
+    dry_run: bool,
+    confirm: bool,
+    allow_writes: bool,
+) -> Result<()> {
+    // Field validation is pure input checking — fail closed before any network
+    // use so `set status active` is a usage error regardless of the other flags.
+    if field != detail::INTERFACE_WRITABLE_FIELD {
+        return Err(error::NboxError::Usage(format!(
+            "only `{}` is writable on an interface in v1; got \"{field}\". \
+             Broader writes land later on the same safe-write contracts (ADR-0001 §6).",
+            detail::INTERFACE_WRITABLE_FIELD
+        ))
+        .into());
+    }
+
+    // Gate decision BEFORE any plan/network: a read-only invocation can never
+    // become a write (ADR-0001 §4/§5). `--dry-run` is exempt (mutates nothing).
+    // A refusal here keeps stdout empty (no diff) and names the required flag.
+    // The decision is a pure function of the flags + interactive context, so the
+    // full gate matrix is unit-tested in [`write_action`] (no TTY/network).
+    let action = gate_write(ctx, dry_run, confirm, allow_writes)?;
+
+    let (client, profile) = connect_named(ctx)?;
+    let host = audit_origin(client.base_url());
+
+    // 2–4) read + plan. (1 — resolve — happens inside the planner.)
+    let plan = detail::plan_interface_description_update(
+        &client, device, interface, value, message, &profile, &not_found,
+    )
+    .await?;
+
+    // The shared dry-run/prompt/apply/audit lifecycle — one write path for both
+    // write commands; only the field check, planner, and applier differ.
+    apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
+        Box::pin(detail::apply_interface_description_update(c, p))
+    })
+    .await
+}
+
+/// `nbox device <device> set <field> <value>` — the second safe write
+/// (ADR-0001 follow-on), reusing the same gate/planner/lifecycle/audit path as
+/// the interface pilot. Only `status` is writable in this pilot; its allowed
+/// values are enumerated live from NetBox (read-only `OPTIONS`) and the
+/// operator's input is normalized to the canonical value (a label is accepted
+/// case-insensitively when it maps unambiguously to one value) before any
+/// `PATCH`. Unknown/ambiguous status is a usage error (exit 2) naming the input
+/// and listing the allowed values. No-op status change sends no `PATCH`.
+#[allow(clippy::too_many_arguments)] // the CLI flag set; collapsing loses clarity
+async fn run_device_set(
+    ctx: &Ctx,
+    device: &str,
+    field: &str,
+    value: &str,
+    message: Option<&str>,
+    dry_run: bool,
+    confirm: bool,
+    allow_writes: bool,
+) -> Result<()> {
+    // Field validation is pure input checking — fail closed before any network
+    // use so `set <non-status>` is a usage error regardless of the other flags.
+    if field != detail::DEVICE_WRITABLE_FIELD {
+        return Err(error::NboxError::Usage(format!(
+            "only `{}` is writable on a device in this pilot; got \"{field}\". \
+             Broader writes land later on the same safe-write contracts (ADR-0001 §6).",
+            detail::DEVICE_WRITABLE_FIELD
+        ))
+        .into());
+    }
+
+    // Gate decision BEFORE any plan/network (shared with the interface pilot).
+    let action = gate_write(ctx, dry_run, confirm, allow_writes)?;
+
+    let (client, profile) = connect_named(ctx)?;
+    let host = audit_origin(client.base_url());
+
+    // The planner enumerates the allowed status values from NetBox (read-only
+    // OPTIONS) and normalizes the input before building the plan — an
+    // unknown/ambiguous status is a usage error (exit 2) with no `PATCH`.
+    let plan =
+        detail::plan_device_status_update(&client, device, value, message, &profile, &not_found)
+            .await?;
+
+    // The shared dry-run/prompt/apply/audit lifecycle — one write path.
+    apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
+        Box::pin(detail::apply_device_status_update(c, p))
+    })
+    .await
 }
 
 /// Classify an apply error into the coarse audit outcome. A stale precondition
@@ -1497,7 +1607,7 @@ fn audit_event<'a>(
 /// precondition in force, and (for dry-run) the no-op note. Goes to stdout as
 /// the operator's review; the apply prompt and status lines go to stderr.
 fn render_plan_plain(plan: &MutationPlan) {
-    println!("interface: {}", plan.target.display);
+    println!("{}: {}", plan.target.kind, plan.target.display);
     for f in &plan.fields {
         println!(
             "  {}: {} → {}",

--- a/src/netbox/choices.rs
+++ b/src/netbox/choices.rs
@@ -116,21 +116,25 @@ struct WireChoice {
 /// field wasn't found or carried no choices (the caller treats that as a
 /// "couldn't enumerate" usage error so no unvalidated value is ever sent).
 ///
-/// DRF's `OPTIONS` metadata nests writable-field schemas under
-/// `actions.<POST|PUT|PATCH>.body.<field>`. NetBox exposes the create (`POST`)
-/// body on the list endpoint; `PUT`/`PATCH` appear on the detail endpoint. nbox
-/// issues `OPTIONS` on the **list** endpoint and reads `POST` first (the
-/// canonical writable-action body), falling back to `PUT` then `PATCH` so a
-/// deployment that surfaces the field under a different verb still validates.
+/// DRF's `SimpleMetadata` nests writable-field schemas **directly** under the
+/// verb — `actions.<POST|PUT|PATCH>.<field>` (verified against NetBox 4.6.2's
+/// live `OPTIONS`). A `body`-wrapped variant (`actions.<verb>.body.<field>`) is
+/// tolerated as a fallback for any deployment/proxy that reshapes it. NetBox
+/// exposes the create (`POST`) action on the list endpoint and `PUT` on the
+/// detail; nbox issues `OPTIONS` on the **list** endpoint and reads `POST`
+/// first, falling back to `PUT` then `PATCH` so the field still validates.
 pub fn extract_choices(body: &serde_json::Value, field: &str) -> Vec<ChoiceOption> {
     let Some(actions) = body.get("actions") else {
         return Vec::new();
     };
     for verb in ["POST", "PUT", "PATCH"] {
-        let Some(field_meta) = actions
-            .get(verb)
-            .and_then(|a| a.get("body"))
-            .and_then(|b| b.get(field))
+        let Some(verb_meta) = actions.get(verb) else {
+            continue;
+        };
+        // Direct (real NetBox) first, then the `body`-wrapped fallback.
+        let Some(field_meta) = verb_meta
+            .get(field)
+            .or_else(|| verb_meta.get("body").and_then(|b| b.get(field)))
         else {
             continue;
         };
@@ -283,7 +287,52 @@ mod tests {
     }
 
     #[test]
+    fn extract_choices_reads_direct_post_field() {
+        // The real NetBox 4.6.2 shape: field schemas sit DIRECTLY under the verb
+        // (`actions.POST.status.choices`), with no `body` wrapper.
+        let body = json!({
+            "name": "Device",
+            "actions": {
+                "POST": {
+                    "name": {"type": "string", "label": "Name"},
+                    "status": {
+                        "type": "choice",
+                        "label": "Status",
+                        "choices": [
+                            {"value": "active", "display": "Active"},
+                            {"value": "offline", "display": "Offline"}
+                        ]
+                    }
+                }
+            }
+        });
+        let opts = extract_choices(&body, "status");
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].value, "active");
+        assert_eq!(opts[1].value, "offline");
+    }
+
+    #[test]
+    fn extract_choices_reads_direct_put_field() {
+        // PUT-only direct shape (the detail endpoint exposes PUT); POST absent.
+        let body = json!({
+            "actions": {
+                "PUT": {
+                    "status": {
+                        "type": "choice",
+                        "choices": [{"value": "planned", "display": "Planned"}]
+                    }
+                }
+            }
+        });
+        let opts = extract_choices(&body, "status");
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].value, "planned");
+    }
+
+    #[test]
     fn extract_choices_reads_post_body_under_actions() {
+        // `body`-wrapped fallback (tolerated for a reshaping proxy/deployment).
         let body = json!({
             "name": "Device",
             "actions": {

--- a/src/netbox/choices.rs
+++ b/src/netbox/choices.rs
@@ -1,0 +1,358 @@
+//! REST choice-field validation (ADR-0001 follow-on write surface).
+//!
+//! A *choice* field (e.g. a device's `status`) takes one value from a small,
+//! server-defined set. Before nbox sends a `PATCH` touching one, it asks NetBox
+//! which values are allowed and normalizes the operator's input to the canonical
+//! value — so an unknown or ambiguous status is a usage error (exit 2) **before**
+//! any `PATCH`, naming the input and listing the allowed canonical values.
+//!
+//! This is deliberately the *smallest* reusable mechanism for that: a pure
+//! resolver over an enumerated option set, plus a pure extractor that pulls the
+//! choices out of a NetBox `OPTIONS` response. The network (issuing `OPTIONS`)
+//! lives in [`NetBoxClient`](super::client::NetBoxClient); this module is the
+//! pure contract so the normalization policy is unit-testable with no I/O.
+//!
+//! It is NOT a generic schema-edit system: it validates one named choice field
+//! against the choices NetBox exposes, nothing more. Writable-field discovery,
+//! required-field checking, and relation shaping stay out of scope (ROADMAP).
+
+use serde::Deserialize;
+
+use crate::error::NboxError;
+
+/// One enumerated value for a choice field, as NetBox reports it via `OPTIONS`.
+/// `value` is the canonical wire value (what nbox sends in the `PATCH` body and
+/// compares against the current state); `label` is the human form NetBox shows,
+/// when the deployment exposes one (NetBox's `OPTIONS` uses `display`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChoiceOption {
+    /// The canonical wire value (e.g. `active`).
+    pub value: String,
+    /// The human label (e.g. `Active`), when NetBox exposes one.
+    pub label: Option<String>,
+}
+
+/// Normalize an operator's input against an enumerated choice set to the
+/// canonical wire value. Pure (no I/O) so the policy is unit-tested directly.
+///
+/// Matching, in order (ADR-0001 §6 — accept canonical values; accept labels
+/// case-insensitively when they map unambiguously to one value):
+/// 1. an **exact** value match wins (the canonical form);
+/// 2. otherwise, a case-insensitive **label** match that maps to exactly one
+///    distinct value wins;
+/// 3. otherwise the input is rejected — unknown (no match) or ambiguous (a
+///    case-insensitive label matched more than one distinct value).
+///
+/// The error names the field, the input, and lists the allowed canonical values
+/// (the `value`s, in the order NetBox returned them) so the message is
+/// actionable. `field_label` is the human name of the field for the message
+/// (e.g. `"status"`).
+pub fn resolve_choice(
+    options: &[ChoiceOption],
+    field_label: &str,
+    input: &str,
+) -> Result<String, NboxError> {
+    let allowed = allowed_values(options);
+
+    // 1) exact canonical-value match.
+    if let Some(opt) = options.iter().find(|o| o.value == input) {
+        return Ok(opt.value.clone());
+    }
+
+    // 2) case-insensitive label match, collected to distinct values.
+    let want = input.to_lowercase();
+    let label_values: Vec<&str> = options
+        .iter()
+        .filter(|o| o.label.as_deref().is_some_and(|l| l.to_lowercase() == want))
+        .map(|o| o.value.as_str())
+        .collect();
+    match label_values.len() {
+        0 => Err(unknown_choice_error(field_label, input, &allowed)),
+        1 => Ok(label_values[0].to_string()),
+        // A case-insensitive label matched more than one distinct value — the
+        // input is ambiguous. Treat like an unknown (still names the input +
+        // lists allowed values); the message flags the ambiguity.
+        _ => Err(NboxError::Usage(format!(
+            "ambiguous {field_label} \"{input}\" (matches several values case-insensitively). \
+             Allowed: {allowed}"
+        ))),
+    }
+}
+
+/// The allowed canonical values as a comma-separated list, in NetBox's order,
+/// for the usage-error message.
+fn allowed_values(options: &[ChoiceOption]) -> String {
+    options
+        .iter()
+        .map(|o| o.value.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The unknown-choice usage error: names the field, the input, and the allowed
+/// canonical values. Exit 2 (a usage error, before any `PATCH`).
+fn unknown_choice_error(field_label: &str, input: &str, allowed: &str) -> NboxError {
+    NboxError::Usage(format!(
+        "invalid {field_label} \"{input}\"; allowed values: {allowed}"
+    ))
+}
+
+/// One choice as NetBox serializes it in the `OPTIONS` choices array. The
+/// canonical shape is `{"value": "active", "display": "Active"}`; `display` is
+/// tolerated as absent (some fields/deployments expose value only) and `label`
+/// is accepted as a fallback for the human form.
+#[derive(Debug, Deserialize)]
+struct WireChoice {
+    value: String,
+    #[serde(default)]
+    display: Option<String>,
+    #[serde(default)]
+    label: Option<String>,
+}
+
+/// Pull a named field's choices out of a NetBox `OPTIONS` response body. Pure
+/// (operates on the already-fetched JSON) so it is unit-tested against canned
+/// payloads. Returns the choices in NetBox's order; an empty `Vec` means the
+/// field wasn't found or carried no choices (the caller treats that as a
+/// "couldn't enumerate" usage error so no unvalidated value is ever sent).
+///
+/// DRF's `OPTIONS` metadata nests writable-field schemas under
+/// `actions.<POST|PUT|PATCH>.body.<field>`. NetBox exposes the create (`POST`)
+/// body on the list endpoint; `PUT`/`PATCH` appear on the detail endpoint. nbox
+/// issues `OPTIONS` on the **list** endpoint and reads `POST` first (the
+/// canonical writable-action body), falling back to `PUT` then `PATCH` so a
+/// deployment that surfaces the field under a different verb still validates.
+pub fn extract_choices(body: &serde_json::Value, field: &str) -> Vec<ChoiceOption> {
+    let Some(actions) = body.get("actions") else {
+        return Vec::new();
+    };
+    for verb in ["POST", "PUT", "PATCH"] {
+        let Some(field_meta) = actions
+            .get(verb)
+            .and_then(|a| a.get("body"))
+            .and_then(|b| b.get(field))
+        else {
+            continue;
+        };
+        let Some(choices) = field_meta.get("choices").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        let opts: Vec<ChoiceOption> = choices
+            .iter()
+            .filter_map(|c| {
+                // Tolerate the wire shape (`{value, display}`) and a bare
+                // `{"value": "…"}`; skip anything without a value.
+                serde_json::from_value::<WireChoice>(c.clone())
+                    .ok()
+                    .map(|w| ChoiceOption {
+                        value: w.value,
+                        // NetBox's key is `display`; `label` is a fallback.
+                        label: w.display.or(w.label),
+                    })
+            })
+            .collect();
+        if !opts.is_empty() {
+            return opts;
+        }
+    }
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn opts() -> Vec<ChoiceOption> {
+        vec![
+            ChoiceOption {
+                value: "active".into(),
+                label: Some("Active".into()),
+            },
+            ChoiceOption {
+                value: "planned".into(),
+                label: Some("Planned".into()),
+            },
+            ChoiceOption {
+                value: "offline".into(),
+                label: Some("Offline".into()),
+            },
+            ChoiceOption {
+                value: "failed".into(),
+                label: Some("Failed".into()),
+            },
+            ChoiceOption {
+                value: "decommissioning".into(),
+                label: Some("Decommissioning".into()),
+            },
+        ]
+    }
+
+    #[test]
+    fn exact_canonical_value_matches() {
+        assert_eq!(
+            resolve_choice(&opts(), "status", "active").unwrap(),
+            "active"
+        );
+        assert_eq!(
+            resolve_choice(&opts(), "status", "decommissioning").unwrap(),
+            "decommissioning"
+        );
+    }
+
+    #[test]
+    fn label_matches_case_insensitively_to_one_value() {
+        // NetBox's label is "Active"; the operator typed the label, or a
+        // differently-cased form of it.
+        assert_eq!(
+            resolve_choice(&opts(), "status", "Active").unwrap(),
+            "active"
+        );
+        assert_eq!(
+            resolve_choice(&opts(), "status", "ACTIVE").unwrap(),
+            "active"
+        );
+        assert_eq!(
+            resolve_choice(&opts(), "status", "Planned").unwrap(),
+            "planned"
+        );
+    }
+
+    #[test]
+    fn unknown_value_is_a_usage_error_listing_allowed_values() {
+        let err = resolve_choice(&opts(), "status", "bogus").unwrap_err();
+        assert_eq!(err.exit_code(), 2, "unknown choice is a usage error");
+        let msg = format!("{err}");
+        assert!(msg.contains("invalid status \"bogus\""), "{msg}");
+        assert!(
+            msg.contains("active, planned, offline, failed, decommissioning"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn ambiguous_label_is_a_usage_error() {
+        // Two choices whose labels collide case-insensitively → ambiguous.
+        let ambiguous = vec![
+            ChoiceOption {
+                value: "active".into(),
+                label: Some("Up".into()),
+            },
+            ChoiceOption {
+                value: "online".into(),
+                label: Some("up".into()),
+            },
+        ];
+        let err = resolve_choice(&ambiguous, "status", "UP").unwrap_err();
+        assert_eq!(err.exit_code(), 2);
+        let msg = format!("{err}");
+        assert!(msg.contains("ambiguous"), "{msg}");
+        assert!(msg.contains("Allowed:"), "{msg}");
+    }
+
+    #[test]
+    fn empty_option_set_is_a_usage_error() {
+        // No choices enumerated → the input can't match anything.
+        let err = resolve_choice(&[], "status", "active").unwrap_err();
+        assert_eq!(err.exit_code(), 2);
+        assert!(format!("{err}").contains("invalid status \"active\""));
+    }
+
+    #[test]
+    fn choices_without_labels_still_match_exact_value() {
+        // A deployment that exposes values but no labels: only canonical values
+        // match (no case-insensitive label path).
+        let value_only = vec![
+            ChoiceOption {
+                value: "active".into(),
+                label: None,
+            },
+            ChoiceOption {
+                value: "offline".into(),
+                label: None,
+            },
+        ];
+        assert_eq!(
+            resolve_choice(&value_only, "status", "active").unwrap(),
+            "active"
+        );
+        // A cased form that isn't an exact value and has no label to fall back
+        // to is rejected (labels aren't exposed).
+        let err = resolve_choice(&value_only, "status", "Active").unwrap_err();
+        assert_eq!(err.exit_code(), 2);
+    }
+
+    #[test]
+    fn extract_choices_reads_post_body_under_actions() {
+        let body = json!({
+            "name": "Device",
+            "actions": {
+                "POST": {
+                    "body": {
+                        "status": {
+                            "type": "choice",
+                            "label": "Status",
+                            "choices": [
+                                {"value": "active", "display": "Active"},
+                                {"value": "offline", "display": "Offline"}
+                            ]
+                        },
+                        "name": {"type": "string", "label": "Name"}
+                    }
+                }
+            }
+        });
+        let opts = extract_choices(&body, "status");
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].value, "active");
+        assert_eq!(opts[0].label.as_deref(), Some("Active"));
+        assert_eq!(opts[1].value, "offline");
+    }
+
+    #[test]
+    fn extract_choices_falls_back_to_put_then_patch() {
+        // A detail-endpoint-style OPTIONS surfaces the writable field under
+        // PUT/PATCH, not POST. The extractor still finds it.
+        let body = json!({
+            "actions": {
+                "PUT": {"body": {}},
+                "PATCH": {
+                    "body": {
+                        "status": {"choices": [{"value": "planned", "display": "Planned"}]}
+                    }
+                }
+            }
+        });
+        let opts = extract_choices(&body, "status");
+        assert_eq!(opts.len(), 1);
+        assert_eq!(opts[0].value, "planned");
+    }
+
+    #[test]
+    fn extract_choices_returns_empty_when_field_or_choices_absent() {
+        let body = json!({"actions": {"POST": {"body": {"name": {"type": "string"}}}}});
+        assert!(extract_choices(&body, "status").is_empty());
+        // Field present but no `choices` array.
+        let body = json!({"actions": {"POST": {"body": {"status": {"type": "choice"}}}}});
+        assert!(extract_choices(&body, "status").is_empty());
+        // No `actions` key at all.
+        assert!(extract_choices(&json!({"renders": []}), "status").is_empty());
+    }
+
+    #[test]
+    fn extract_choices_tolerates_bare_value_and_label_fallback() {
+        // A choice with only `value`, and one exposing `label` instead of
+        // NetBox's `display`.
+        let body = json!({
+            "actions": {"POST": {"body": {"status": {"choices": [
+                {"value": "active"},
+                {"value": "offline", "label": "Offline"}
+            ]}}}}
+        });
+        let opts = extract_choices(&body, "status");
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].value, "active");
+        assert!(opts[0].label.is_none());
+        assert_eq!(opts[1].label.as_deref(), Some("Offline"));
+    }
+}

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -238,6 +238,39 @@ impl NetBoxClient {
         Ok((body, etag))
     }
 
+    /// Issue an authenticated `OPTIONS` (read-only metadata; DRF field schemas
+    /// and choice enumerations). Reuses the read path's auth, timeout, URL
+    /// scoping, and token redaction. Used by the write foundation to enumerate a
+    /// choice field's allowed values *before* sending a `PATCH` (ADR-0001 §6),
+    /// e.g. a device's `status`. `OPTIONS` is read-only (no body is sent and none
+    /// is expected beyond DRF's metadata), so it shares the `GET`-style status
+    /// mapping — a non-2xx is the standard read [`status_error`].
+    pub(crate) async fn options(&self, path: &str) -> Result<serde_json::Value> {
+        let url = self.url_for(path)?;
+        match self.masked_authorization() {
+            Some(auth) => tracing::debug!(url = %url, auth = %auth, "OPTIONS"),
+            None => tracing::debug!(url = %url, "OPTIONS (unauthenticated)"),
+        }
+        let res = self
+            .http
+            .request(reqwest::Method::OPTIONS, url)
+            .send()
+            .await?;
+        let status = res.status();
+        let text = res.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(status_error(status, &text).into());
+        }
+        // DRF's OPTIONS body is JSON metadata; tolerate an empty body (some
+        // proxies strip it) by falling back to an empty object, which the choice
+        // extractor treats as "couldn't enumerate" (a usage error, never an
+        // unvalidated PATCH).
+        if text.is_empty() {
+            return Ok(json!({}));
+        }
+        serde_json::from_str(&text).context("decoding NetBox OPTIONS metadata")
+    }
+
     /// Perform an authenticated `PATCH` (partial update) and deserialize the
     /// response. The single v1 write transport (ADR-0001 §2): reuses the read
     /// path's auth, timeout, 429 retry, URL scoping, status mapping, and token

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -251,24 +251,39 @@ impl NetBoxClient {
             Some(auth) => tracing::debug!(url = %url, auth = %auth, "OPTIONS"),
             None => tracing::debug!(url = %url, "OPTIONS (unauthenticated)"),
         }
-        let res = self
-            .http
-            .request(reqwest::Method::OPTIONS, url)
-            .send()
-            .await?;
-        let status = res.status();
-        let text = res.text().await.unwrap_or_default();
-        if !status.is_success() {
-            return Err(status_error(status, &text).into());
+        let mut attempt = 0;
+        loop {
+            // Attach the token (and Accept) exactly like `send`/`patch`: a
+            // secured NetBox returns 403 to an unauthenticated OPTIONS, so the
+            // choice enumeration must carry the same auth as every other call.
+            let mut req = self
+                .http
+                .request(reqwest::Method::OPTIONS, url.clone())
+                .header(ACCEPT, "application/json");
+            if let Some(token) = &self.token {
+                req = req.header(AUTHORIZATION, self.auth_scheme.header_value(token));
+            }
+
+            let res = req.send().await.context("sending OPTIONS to NetBox")?;
+            if retry_on_rate_limit(&res, attempt, "NetBox OPTIONS").await {
+                attempt += 1;
+                continue;
+            }
+
+            let status = res.status();
+            let text = res.text().await.unwrap_or_default();
+            if !status.is_success() {
+                return Err(status_error(status, &text).into());
+            }
+            // DRF's OPTIONS body is JSON metadata; tolerate an empty body (some
+            // proxies strip it) by falling back to an empty object, which the
+            // choice extractor treats as "couldn't enumerate" (a usage error,
+            // never an unvalidated PATCH).
+            if text.is_empty() {
+                return Ok(json!({}));
+            }
+            return serde_json::from_str(&text).context("decoding NetBox OPTIONS metadata");
         }
-        // DRF's OPTIONS body is JSON metadata; tolerate an empty body (some
-        // proxies strip it) by falling back to an empty object, which the choice
-        // extractor treats as "couldn't enumerate" (a usage error, never an
-        // unvalidated PATCH).
-        if text.is_empty() {
-            return Ok(json!({}));
-        }
-        serde_json::from_str(&text).context("decoding NetBox OPTIONS metadata")
     }
 
     /// Perform an authenticated `PATCH` (partial update) and deserialize the

--- a/src/netbox/mod.rs
+++ b/src/netbox/mod.rs
@@ -7,6 +7,7 @@
 pub mod auth;
 pub mod browse;
 pub mod capabilities;
+pub mod choices;
 pub mod client;
 pub mod dashboard;
 pub mod endpoints;

--- a/src/netbox/models/dcim.rs
+++ b/src/netbox/models/dcim.rs
@@ -39,6 +39,14 @@ pub struct Device {
     #[serde(default)]
     pub description: Option<String>,
 
+    /// When the object was last modified (ISO 8601). Carried on detail responses;
+    /// the write foundation uses it as the pre-4.6 optimistic-concurrency
+    /// precondition when no `ETag` header is present (ADR-0001 §3), e.g. for
+    /// `nbox device <name> set status <value>`. `#[serde(default)]` so it is
+    /// simply `None` on a partial list shape that omits it.
+    #[serde(default)]
+    pub last_updated: Option<String>,
+
     /// The native owner (NetBox 4.5+); a user/group brief. `None` on older
     /// releases or when unset.
     #[serde(default)]

--- a/src/netbox/query.rs
+++ b/src/netbox/query.rs
@@ -124,6 +124,18 @@ impl NetBoxClient {
         ambiguous_or_first("device", value, contains.results, |d| d.name.clone())
     }
 
+    /// Enumerate the canonical values for a device's `status` field, via a
+    /// read-only `OPTIONS` on the devices list endpoint (DRF metadata; ADR-0001
+    /// §6). The write foundation validates an operator's `set status` input
+    /// against this *before* sending a `PATCH`, so an unknown or ambiguous value
+    /// is a usage error naming the input and listing the allowed values. Returns
+    /// an empty `Vec` if NetBox didn't surface choices for the field (the planner
+    /// treats that as a usage error so no unvalidated value is ever sent).
+    pub async fn device_status_choices(&self) -> Result<Vec<crate::netbox::choices::ChoiceOption>> {
+        let body = self.options("/api/dcim/devices/").await?;
+        Ok(crate::netbox::choices::extract_choices(&body, "status"))
+    }
+
     /// All interfaces on a device (up to `max`).
     pub async fn device_interfaces(&self, device_id: u64, max: usize) -> Result<Vec<Interface>> {
         self.list_all(

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -690,3 +690,652 @@ async fn interface_read_still_works_with_no_action() {
     );
     assert_eq!(patch_count(&server).await, 0, "a read never PATCHes");
 }
+
+// ===== device `set status` (ADR-0001 follow-on) ==========================
+//
+// The second write command reuses the same planner/diff/confirm/concurrency/
+// audit contracts as the interface pilot. The new piece is choice validation:
+// `status` is a server-enumerated field, so the planner asks NetBox (read-only
+// `OPTIONS`) for the allowed values and normalizes the operator's input to the
+// canonical wire value BEFORE building the plan.
+
+/// NetBox's standard device status choices, as DRF surfaces them via OPTIONS.
+fn device_options_body() -> Value {
+    json!({
+        "name": "Device",
+        "actions": {
+            "POST": {
+                "body": {
+                    "status": {
+                        "type": "choice",
+                        "label": "Status",
+                        "choices": [
+                            {"value": "active", "display": "Active"},
+                            {"value": "planned", "display": "Planned"},
+                            {"value": "offline", "display": "Offline"},
+                            {"value": "failed", "display": "Failed"},
+                            {"value": "decommissioning", "display": "Decommissioning"}
+                        ]
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Mount the read-only `OPTIONS /api/dcim/devices/` that the planner uses to
+/// enumerate allowed `status` values. Read-only — never mutates.
+async fn mount_device_options(server: &MockServer) {
+    Mock::given(method("OPTIONS"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(device_options_body()))
+        .mount(server)
+        .await;
+}
+
+/// Device-by-name resolution (GET `/api/dcim/devices/?name__ie=…`). The planner
+/// re-fetches the authoritative detail (with ETag/last_updated) separately per
+/// test, so this only needs to return the id.
+async fn mount_device_resolution(server: &MockServer, device_id: u64, name: &str) {
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": device_id,
+                "url": format!("{}/api/dcim/devices/{}/", server.uri(), device_id),
+                "name": name
+            }]
+        })))
+        .mount(server)
+        .await;
+}
+
+/// The authoritative device detail (GET `/api/dcim/devices/{id}/`), with an
+/// optional `ETag` response header and a configurable current `status` value.
+async fn mount_device_detail(
+    server: &MockServer,
+    device_id: u64,
+    etag: Option<&str>,
+    status_value: &str,
+    last_updated: &str,
+) {
+    let mut resp = ResponseTemplate::new(200).set_body_json(json!({
+        "id": device_id,
+        "url": format!("{}/api/dcim/devices/{}/", server.uri(), device_id),
+        "name": "edge01",
+        "status": {"value": status_value, "label": status_value},
+        "last_updated": last_updated
+    }));
+    if let Some(e) = etag {
+        resp = resp.insert_header("ETag", e);
+    }
+    Mock::given(method("GET"))
+        .and(path(format!("/api/dcim/devices/{device_id}/")))
+        .respond_with(resp)
+        .mount(server)
+        .await;
+}
+
+fn run_device_set<'a>(config: &NamedTempFile, extra: &'a [&'a str]) -> CommandOutput {
+    let mut args: Vec<&str> = vec!["--config", config.path().to_str().unwrap()];
+    args.push("--no-tui");
+    args.extend_from_slice(&["device", "edge01", "set", "status"]);
+    args.extend_from_slice(extra);
+    run_nbox(args)
+}
+
+#[tokio::test]
+async fn device_dry_run_sends_no_patch_and_shows_status_before_after() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["offline", "--dry-run", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0, "dry-run must not PATCH");
+    let plan: Value = serde_json::from_str(&out.stdout).expect("plan JSON");
+    assert_eq!(plan["schema_version"], json!(1));
+    assert_eq!(plan["target"]["kind"], json!("device"));
+    assert_eq!(plan["target"]["id"], json!(7));
+    assert_eq!(plan["target"]["endpoint"], json!("/api/dcim/devices/7/"));
+    // Minimal patch: only the scoped field, normalized to the canonical value.
+    assert_eq!(plan["patch"], json!({"status": "offline"}));
+    assert_eq!(plan["fields"].as_array().unwrap().len(), 1);
+    assert_eq!(plan["fields"][0]["field"], json!("status"));
+    assert_eq!(plan["fields"][0]["before"], json!("active"));
+    assert_eq!(plan["fields"][0]["after"], json!("offline"));
+    assert_eq!(plan["no_op"], json!(false));
+    // No ETag → pre-4.6 precondition (last_updated + before_hash).
+    assert_eq!(plan["precondition"]["type"], json!("last_updated"));
+}
+
+#[tokio::test]
+async fn device_dry_run_plain_renders_status_diff_to_stdout() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["offline", "--dry-run"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0);
+    // The plain diff names the field + before/after; the status line is stderr.
+    assert!(out.stdout.contains("status"), "stdout: {}", out.stdout);
+    assert!(
+        out.stdout.contains("active → offline"),
+        "stdout diff: {}",
+        out.stdout
+    );
+    assert!(out.stderr.contains("planned, no changes sent"));
+}
+
+#[tokio::test]
+async fn device_confirm_sends_one_minimal_patch_with_normalized_status() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .and(body_partial_json(json!({"status": "offline"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": format!("{}/api/dcim/devices/7/", server.uri()),
+            "name": "edge01", "status": {"value": "offline", "label": "Offline"},
+            "last_updated": "2026-06-26T10:30:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 1, "exactly one PATCH");
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(true));
+    assert_eq!(receipt["no_op"], json!(false));
+    assert_eq!(receipt["status"], json!(200));
+    assert_eq!(receipt["fields"][0]["after"], json!("offline"));
+    assert!(
+        receipt["message"]
+            .as_str()
+            .unwrap()
+            .contains("applied: device"),
+        "receipt message: {}",
+        receipt["message"]
+    );
+}
+
+#[tokio::test]
+async fn device_label_normalizes_to_canonical_value_case_insensitively() {
+    // The operator typed the label "Offline" (NetBox's display). The planner
+    // matches it case-insensitively to the canonical value `offline` and the
+    // PATCH carries the normalized value, not the label.
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .and(body_partial_json(json!({"status": "offline"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "status": {"value": "offline", "label": "Offline"}
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["Offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 1);
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(true));
+    // Confirm the wire body actually carried the canonical value, not the label.
+    let patch_reqs: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method.as_str() == "PATCH")
+        .collect();
+    let body: Value = serde_json::from_slice(&patch_reqs[0].body).unwrap();
+    assert_eq!(body, json!({"status": "offline"}));
+}
+
+#[tokio::test]
+async fn device_noop_status_sends_no_patch() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    // Current value already `offline` → no-op. No PATCH mock mounted.
+    mount_device_detail(&server, 7, None, "offline", "2026-06-26T10:00:00Z").await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0, "no-op sends no PATCH");
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(false));
+    assert_eq!(receipt["no_op"], json!(true));
+    assert_eq!(receipt["status"], json!(0));
+    assert!(receipt["message"].as_str().unwrap().contains("no change"));
+}
+
+#[tokio::test]
+async fn device_unknown_status_is_a_usage_error_before_any_patch() {
+    // OPTIONS enumerates the allowed values; `bogus` matches none → usage error
+    // (exit 2) naming the input and listing the allowed values, with no PATCH.
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["bogus", "--dry-run", "--json"]);
+
+    assert_error_contract(&out, 2, "invalid status \"bogus\"");
+    assert!(
+        out.stderr
+            .contains("active, planned, offline, failed, decommissioning"),
+        "stderr should list allowed values: {}",
+        out.stderr
+    );
+    assert_eq!(
+        patch_count(&server).await,
+        0,
+        "unknown status sends no PATCH"
+    );
+}
+
+#[tokio::test]
+async fn device_ambiguous_label_is_a_usage_error() {
+    // Two choices whose labels collide case-insensitively → ambiguous.
+    let server = MockServer::start().await;
+    Mock::given(method("OPTIONS"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "actions": {
+                "POST": {
+                    "body": {
+                        "status": {
+                            "choices": [
+                                {"value": "active", "display": "Up"},
+                                {"value": "online", "display": "up"}
+                            ]
+                        }
+                    }
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["UP", "--dry-run", "--json"]);
+
+    assert_error_contract(&out, 2, "ambiguous");
+    assert_eq!(patch_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn device_unsupported_field_is_a_usage_error_before_any_network() {
+    // No mocks mounted: a usage error must not reach the network. `set role …`
+    // fails closed at the field check before connect/resolve.
+    let config = write_config("http://unused.example/");
+    let out = run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "device".as_ref(),
+        "edge01".as_ref(),
+        "set".as_ref(),
+        "role".as_ref(),
+        "something".as_ref(),
+        "--dry-run".as_ref(),
+    ]);
+    assert_error_contract(&out, 2, "only `status` is writable");
+}
+
+#[tokio::test]
+async fn device_confirm_without_allow_writes_is_a_usage_error() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["offline", "--confirm", "--json"]);
+    assert_error_contract(&out, 2, "writes are not enabled");
+    assert!(
+        out.stderr.contains("--allow-writes"),
+        "stderr: {}",
+        out.stderr
+    );
+    assert_eq!(patch_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn device_allow_writes_without_confirm_is_usage_in_non_tty() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["offline", "--allow-writes", "--json"]);
+    assert_error_contract(&out, 2, "non-interactive write requires confirmation");
+    assert!(out.stderr.contains("--confirm"), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn device_etag_sends_if_match_on_apply() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    // 4.6+ detail carries an ETag; the plan records it and the apply sends
+    // `If-Match: <etag>` (ADR-0001 §3).
+    mount_device_detail(
+        &server,
+        7,
+        Some("\"etag-v1\""),
+        "active",
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        // The PATCH mock ONLY matches when If-Match is sent — proving the
+        // header is present. Without it, wiremock returns 404 and the test fails.
+        .and(header("if-match", "\"etag-v1\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "status": {"value": "offline", "label": "Offline"}
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 1);
+    let patch_reqs: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method.as_str() == "PATCH")
+        .collect();
+    assert_eq!(
+        patch_reqs[0].headers.get("if-match").unwrap(),
+        "\"etag-v1\""
+    );
+}
+
+#[tokio::test]
+async fn device_stale_412_is_a_stale_precondition_refusal() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(
+        &server,
+        7,
+        Some("\"etag-v1\""),
+        "active",
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(412).set_body_string("Precondition Failed"))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_error_contract(&out, 1, "object changed in NetBox");
+    assert!(
+        out.stderr.contains("re-run dry-run"),
+        "stderr: {}",
+        out.stderr
+    );
+}
+
+#[tokio::test]
+async fn device_stale_pre46_fallback_re_reads_and_refuses_on_last_updated_change() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    // No ETag → pre-4.6 path. The plan reads last_updated T1; the apply re-read
+    // must return a DIFFERENT last_updated so the read-before-write check
+    // refuses before any PATCH.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "status": {"value": "active", "label": "Active"},
+            "last_updated": "2026-06-26T10:00:00Z"
+        })))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "status": {"value": "active", "label": "Active"},
+            "last_updated": "2026-06-26T11:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_error_contract(&out, 1, "object changed in NetBox");
+    assert_eq!(
+        patch_count(&server).await,
+        0,
+        "stale pre-4.6 sends no PATCH"
+    );
+}
+
+#[tokio::test]
+async fn device_validation_400_surfaces_netbox_field_error_cleanly() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(json!({"status": ["Invalid status."]})),
+        )
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(
+        &config,
+        &["offline", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_error_contract(&out, 1, "NetBox rejected the patch");
+    assert!(out.stderr.contains("status"), "stderr: {}", out.stderr);
+}
+
+#[tokio::test]
+async fn device_audit_logs_status_name_only_never_values_token_or_message_body() {
+    let server = MockServer::start().await;
+    mount_device_options(&server).await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "status": {"value": "offline", "label": "Offline"}
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let log = NamedTempFile::new().expect("log file");
+    let log_path = log.path().to_path_buf();
+    drop(log);
+
+    // Distinctive old/new values, a secret token, and a message body — none of
+    // which may appear in the audit log (only the field NAME `status`, a
+    // message_present flag + length, and the outcome).
+    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
+        .arg("--config")
+        .arg(config.path())
+        .arg("--no-tui")
+        .arg("--log-file")
+        .arg(&log_path)
+        .arg("--log-level")
+        .arg("nbox::write_audit=info")
+        .args([
+            "device",
+            "edge01",
+            "set",
+            "status",
+            "offline",
+            "--allow-writes",
+            "--confirm",
+            "--message",
+            "draining-edge01-secret",
+            "--json",
+        ])
+        .env("NBOX_TOKEN", "secret-nbox-token-12345")
+        .env_remove("NBOX_LOG")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn nbox");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let log_text = std::fs::read_to_string(&log_path).expect("read log file");
+    // Allow-list fields that MUST appear.
+    assert!(log_text.contains("nbox::write_audit"), "log: {log_text}");
+    assert!(
+        log_text.contains("fields=\"status\"") || log_text.contains("fields=status"),
+        "field NAME recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("outcome=\"applied\"") || log_text.contains("outcome=applied"),
+        "outcome recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("message_present=true"),
+        "message_present flag: {log_text}"
+    );
+    // Redaction: none of the old/new status values, the message body, or the
+    // token may leak into the audit log.
+    assert!(
+        !log_text.contains("active"),
+        "old status value leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("offline"),
+        "new status value leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("draining-edge01-secret"),
+        "message body leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("secret-nbox-token-12345"),
+        "token leaked: {log_text}"
+    );
+}
+
+#[tokio::test]
+async fn device_read_still_works_with_no_action() {
+    // The `device` command gained an optional `set` subcommand; omitting it
+    // must keep the read path byte-identical. Mount the device detail + its
+    // interfaces/IPs/services (the read view) and assert a normal read result.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": 7, "url": "u", "name": "edge01"}]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "status": {"value": "active", "label": "Active"}
+        })))
+        .mount(&server)
+        .await;
+    // The read view fans out to interfaces/IPs/services; mount empty pages.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/interfaces/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 0, "next": null, "previous": null, "results": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/ip-addresses/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 0, "next": null, "previous": null, "results": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/services/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 0, "next": null, "previous": null, "results": []
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "device".as_ref(),
+        "edge01".as_ref(),
+    ]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert!(out.stdout.contains("edge01"), "read output: {}", out.stdout);
+    assert_eq!(patch_count(&server).await, 0, "a read never PATCHes");
+}

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -24,7 +24,7 @@ use std::process::{Command, Stdio};
 use serde_json::{Value, json};
 use support::binary::{CommandOutput, run_nbox, temp_config};
 use tempfile::NamedTempFile;
-use wiremock::matchers::{body_partial_json, header, method, path};
+use wiremock::matchers::{body_partial_json, header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// A config whose profile carries a token_env that is never set, so the client
@@ -700,23 +700,23 @@ async fn interface_read_still_works_with_no_action() {
 // canonical wire value BEFORE building the plan.
 
 /// NetBox's standard device status choices, as DRF surfaces them via OPTIONS.
+/// The real NetBox `OPTIONS` shape (verified against 4.6.2): writable-field
+/// schemas sit **directly** under `actions.POST.<field>` — no `body` wrapper.
 fn device_options_body() -> Value {
     json!({
         "name": "Device",
         "actions": {
             "POST": {
-                "body": {
-                    "status": {
-                        "type": "choice",
-                        "label": "Status",
-                        "choices": [
-                            {"value": "active", "display": "Active"},
-                            {"value": "planned", "display": "Planned"},
-                            {"value": "offline", "display": "Offline"},
-                            {"value": "failed", "display": "Failed"},
-                            {"value": "decommissioning", "display": "Decommissioning"}
-                        ]
-                    }
+                "status": {
+                    "type": "choice",
+                    "label": "Status",
+                    "choices": [
+                        {"value": "active", "display": "Active"},
+                        {"value": "planned", "display": "Planned"},
+                        {"value": "offline", "display": "Offline"},
+                        {"value": "failed", "display": "Failed"},
+                        {"value": "decommissioning", "display": "Decommissioning"}
+                    ]
                 }
             }
         }
@@ -783,6 +783,75 @@ fn run_device_set<'a>(config: &NamedTempFile, extra: &'a [&'a str]) -> CommandOu
     args.extend_from_slice(&["device", "edge01", "set", "status"]);
     args.extend_from_slice(extra);
     run_nbox(args)
+}
+
+#[tokio::test]
+async fn device_options_enumeration_is_authenticated() {
+    // A secured NetBox 403s an unauthenticated OPTIONS, so the choice
+    // enumeration must carry the same auth as every other call. Requiring the
+    // Authorization header on the OPTIONS mock fails a missing-auth regression
+    // (the request would no-match → the choice fetch errors).
+    let server = MockServer::start().await;
+    Mock::given(method("OPTIONS"))
+        .and(path("/api/dcim/devices/"))
+        .and(header_exists("authorization"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(device_options_body()))
+        .mount(&server)
+        .await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail(&server, 7, None, "active", "2026-06-26T10:00:00Z").await;
+
+    let config = write_config(&server.uri());
+    // A token must be present for an Authorization header to exist; set it
+    // explicitly (the test profile's `token_env` is intentionally unset).
+    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
+        .args([
+            "--config",
+            config.path().to_str().unwrap(),
+            "--no-tui",
+            "device",
+            "edge01",
+            "set",
+            "status",
+            "offline",
+            "--dry-run",
+            "--json",
+        ])
+        .env("NBOX_TOKEN", "testtoken")
+        .env_remove("NBOX_LOG")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .output()
+        .expect("spawn nbox");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "OPTIONS must be authenticated; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let plan: Value = serde_json::from_slice(&out.stdout).expect("plan JSON");
+    assert_eq!(plan["patch"], json!({"status": "offline"}));
+}
+
+#[tokio::test]
+async fn empty_status_choices_is_a_could_not_enumerate_usage_error() {
+    // OPTIONS came back without `status` choices (an unexpected schema, a
+    // permission-stripped `actions`, or a body-dropping proxy). The planner
+    // must fail with a clear "could not enumerate" cause — never report the
+    // input as invalid against an empty allow-list, never send an unvalidated
+    // write. This refusal is pre-resolution, so no device mocks are needed.
+    let server = MockServer::start().await;
+    Mock::given(method("OPTIONS"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "actions": {"POST": {"name": {"type": "string"}}}
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_device_set(&config, &["offline", "--dry-run"]);
+    assert_error_contract(&out, 2, "could not enumerate allowed values");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

The second safe-write pilot (after `interface … set description`): `nbox device <ref> set status <value>`, on the same ADR-0001 contracts — `--allow-writes` gate ⟂ confirmation, minimal `PATCH`, ETag/`If-Match` (with pre-4.6 fallback), before/after diff, names-only audit. Adds shared **choice validation**: the operator's status is validated against NetBox's own allowed values (enumerated via read-only `OPTIONS`) *before* any plan is built — an unknown/ambiguous value is a usage error (exit 2), never an unvalidated write.

## Review found three issues in the choice enumeration — all fixed

Two of these broke the feature against a **real, secured NetBox** while the wiremock tests passed (the mock used the same wrong shape the extractor assumed). Confirmed against a live 4.6.2 fixture, not just by reasoning.

1. **OPTIONS sent without auth (High).** `client.options()` logged the masked auth but never attached `Authorization`/`Accept`, so a secured NetBox 403s the enumeration before planning. Now attaches the token + Accept and the 429 retry, exactly like `send`/`patch`. New test requires the auth header on the OPTIONS mock.
2. **Wrong choices shape (High).** `extract_choices` read `actions.<verb>.body.<field>`, but DRF's `SimpleMetadata` nests field schemas **directly** under the verb — verified against live 4.6.2: `actions.POST.status.choices`, **no `body` wrapper**. It returned empty → every status rejected. Now reads the direct shape first, keeps the body-wrapped form as a fallback; tests cover direct POST/PUT + the fallback, and the device OPTIONS mock uses the real shape.
3. **Empty enum mis-reported (Minor).** Empty metadata flowed into `resolve_choice` as "invalid status …; allowed values:" (empty). Now fails closed first: "could not enumerate allowed values … refusing to send an unvalidated write".

## Verification

- **Live 4.6.2:** `device <dev> set status offline --dry-run` authenticates the OPTIONS, validates "offline" against the real choices, and builds the plan (`active → offline`, **`etag`** precondition — confirming 4.6.2 returns an ETag, so the `If-Match` path is real).
- **Gate:** fmt clean; clippy `-D warnings` clean on `--all-features` and `--no-default-features`; **1239** all-features / **1144** no-default tests pass (incl. the new auth-required OPTIONS test, the empty-enum usage-error test, and direct/fallback choice-shape unit tests).
- The 4.6 live lane (now gating PRs) will exercise reads against the same fixture here.