### PR TITLE
fix(ip): honor parent --vrf for `ip reserve`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,10 +338,11 @@ pub async fn run(cli: Cli) -> Result<()> {
                 confirm,
                 allow_writes,
             }) => {
+                let effective_vrf = ip_reserve_vrf_scope(vrf.as_deref(), reserve_vrf.as_deref())?;
                 Box::pin(run_ip_reserve(
                     &ctx,
                     &prefix,
-                    reserve_vrf.as_deref(),
+                    effective_vrf,
                     description.as_deref(),
                     dns_name.as_deref(),
                     message.as_deref(),
@@ -513,6 +514,30 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
+    }
+}
+
+/// `nbox ip` has a read-path `--vrf`, and `ip reserve` repeats it so the write
+/// reads naturally as `nbox ip reserve <prefix> --vrf <name>`. Clap accepts the
+/// parent spelling too (`nbox ip --vrf <name> reserve <prefix>`), so fold both
+/// placements into one effective scope and reject conflicting duplicate input
+/// before any network/write work.
+fn ip_reserve_vrf_scope<'a>(
+    parent_vrf: Option<&'a str>,
+    reserve_vrf: Option<&'a str>,
+) -> Result<Option<&'a str>> {
+    match (parent_vrf, reserve_vrf) {
+        (Some(parent), Some(reserve)) if !parent.eq_ignore_ascii_case(reserve) => {
+            Err(error::NboxError::Usage(
+                "conflicting --vrf values for `ip reserve`; pass --vrf once, either before or \
+                 after `reserve`"
+                    .to_string(),
+            )
+            .into())
+        }
+        (Some(parent), Some(_) | None) => Ok(Some(parent)),
+        (None, Some(reserve)) => Ok(Some(reserve)),
+        (None, None) => Ok(None),
     }
 }
 
@@ -2490,9 +2515,9 @@ fn not_found(noun: &str, value: &str) -> anyhow::Error {
 mod tests {
     use super::{
         Cli, CommandFactory, WriteAction, audit_origin, build_mcp_config, check_raw_method, error,
-        first_subnet_of_length, init_logging, message_audit_len, no_tui_refusal,
-        normalize_raw_path, not_found, parse_object_ref, resolve_content_type_id, resolve_logging,
-        run_man, tui_startup_status, wants_journal, write_action,
+        first_subnet_of_length, init_logging, ip_reserve_vrf_scope, message_audit_len,
+        no_tui_refusal, normalize_raw_path, not_found, parse_object_ref, resolve_content_type_id,
+        resolve_logging, run_man, tui_startup_status, wants_journal, write_action,
     };
     use crate::domain::detail::resolve_unique;
     use crate::netbox::models::ipam::AvailablePrefix;
@@ -3342,6 +3367,27 @@ mod tests {
             write_action(false, false, true, false),
             WriteAction::RefuseNeedsConfirm
         );
+    }
+
+    #[test]
+    fn ip_reserve_vrf_scope_accepts_either_cli_placement_and_rejects_conflict() {
+        assert_eq!(
+            ip_reserve_vrf_scope(Some("blue"), None).unwrap(),
+            Some("blue")
+        );
+        assert_eq!(
+            ip_reserve_vrf_scope(None, Some("blue")).unwrap(),
+            Some("blue")
+        );
+        assert_eq!(
+            ip_reserve_vrf_scope(Some("blue"), Some("BLUE")).unwrap(),
+            Some("blue")
+        );
+        assert!(ip_reserve_vrf_scope(None, None).unwrap().is_none());
+
+        let err = ip_reserve_vrf_scope(Some("blue"), Some("red")).unwrap_err();
+        let nbox = err.downcast_ref::<error::NboxError>().expect("usage error");
+        assert!(matches!(nbox, error::NboxError::Usage(msg) if msg.contains("conflicting --vrf")));
     }
 
     // --- write audit host origin (scheme + host [+ port], no path) ---------

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -1445,6 +1445,44 @@ async fn mount_prefix_resolution(server: &MockServer, prefix_id: u64, cidr: &str
         .await;
 }
 
+/// Prefix-by-CIDR resolution with the same CIDR in two VRFs. Used to pin that
+/// every accepted `ip reserve --vrf` spelling actually reaches the resolver.
+async fn mount_prefix_resolution_in_two_vrfs(server: &MockServer, cidr: &str) {
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 2, "next": null, "previous": null,
+            "results": [
+                {
+                    "id": 1,
+                    "url": format!("{}/api/ipam/prefixes/1/", server.uri()),
+                    "prefix": cidr,
+                    "vrf": {
+                        "id": 11,
+                        "url": format!("{}/api/ipam/vrfs/11/", server.uri()),
+                        "display": "red (65000:11)",
+                        "name": "red",
+                        "rd": "65000:11"
+                    }
+                },
+                {
+                    "id": 2,
+                    "url": format!("{}/api/ipam/prefixes/2/", server.uri()),
+                    "prefix": cidr,
+                    "vrf": {
+                        "id": 12,
+                        "url": format!("{}/api/ipam/vrfs/12/", server.uri()),
+                        "display": "blue (65000:12)",
+                        "name": "blue",
+                        "rd": "65000:12"
+                    }
+                }
+            ]
+        })))
+        .mount(server)
+        .await;
+}
+
 /// The read-only candidate GET the planner uses for the dry-run advisory:
 /// GET `/api/ipam/prefixes/{id}/available-ips/` → a bare JSON array.
 async fn mount_available_ips_get(server: &MockServer, prefix_id: u64, addr: &str) {
@@ -1522,6 +1560,63 @@ async fn ip_reserve_dry_run_plain_renders_candidate_note() {
         out.stdout
     );
     assert!(out.stderr.contains("planned, no changes sent"));
+}
+
+#[tokio::test]
+async fn ip_reserve_parent_vrf_before_subcommand_scopes_the_write() {
+    let server = MockServer::start().await;
+    mount_prefix_resolution_in_two_vrfs(&server, "203.0.113.0/24").await;
+    mount_available_ips_get(&server, 2, "203.0.113.5/24").await;
+
+    let config = write_config(&server.uri());
+    let out = run_nbox([
+        "--config",
+        config.path().to_str().unwrap(),
+        "--no-tui",
+        "ip",
+        "--vrf",
+        "blue",
+        "reserve",
+        "203.0.113.0/24",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    let plan: Value = serde_json::from_str(&out.stdout).expect("plan JSON");
+    assert_eq!(plan["target"]["id"], json!(2), "blue VRF prefix selected");
+    assert_eq!(
+        plan["target"]["endpoint"],
+        json!("/api/ipam/prefixes/2/available-ips/")
+    );
+}
+
+#[tokio::test]
+async fn ip_reserve_conflicting_parent_and_subcommand_vrfs_refuse_before_network() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+
+    let out = run_nbox([
+        "--config",
+        config.path().to_str().unwrap(),
+        "--no-tui",
+        "ip",
+        "--vrf",
+        "blue",
+        "reserve",
+        "203.0.113.0/24",
+        "--vrf",
+        "red",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert_error_contract(&out, 2, "conflicting --vrf values");
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0,
+        "conflicting scope should fail before any NetBox request"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes a scoping bug in `ip reserve` (from #101). Clap accepts the `--vrf` scope flag in **two** placements:

- `nbox ip reserve <prefix> --vrf <name>` (the subcommand's flag — worked), and
- `nbox ip --vrf <name> reserve <prefix>` (the parent `ip` read flag — **was silently ignored**).

The reserve dispatch only threaded the subcommand's `--vrf`, so the parent spelling fell through to `None` and a CIDR that exists in multiple VRFs could resolve to the wrong prefix (or be reported ambiguous) instead of being scoped.

## Fix

`ip_reserve_vrf_scope(parent_vrf, reserve_vrf)` (src/lib.rs) folds both placements into one effective scope:

- either placement alone → that value;
- both with the **same** value (case-insensitive) → use it;
- both with **conflicting** values → usage error (exit 2, empty stdout) **before any network/write work**;
- neither → unscoped.

## Tests

- Unit test for `ip_reserve_vrf_scope` covering all four arms + the conflict.
- Process test: `nbox ip --vrf blue reserve <cidr>` against a CIDR seeded in two VRFs (red/blue) selects the **blue** prefix (`target.id = 2`) — proving the parent flag reaches the resolver.
- Process test: conflicting `--vrf blue … --vrf red` refuses with exit 2 and **zero** NetBox requests.

## Gate

`cargo fmt --all -- --check`; `cargo clippy --all-targets {--all-features,--no-default-features} --locked -- -D warnings`; `cargo test {--all-features,--no-default-features} --locked` — all green (run serially; the all-features and no-default test binaries share `target/debug/nbox`, so a parallel run can clobber the HTTP subprocess tests' binary).