### PR TITLE
ci: build only linux-musl on PRs, full platform matrix on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,25 +166,43 @@ jobs:
       - name: Run security audit
         run: cargo audit
 
+  # Decide the cross-compile matrix by event. On a PR, build ONLY linux-musl (the
+  # release-critical static target, and the leg that runs on a fast, never-queued
+  # ubuntu runner) so the PR gate isn't gated on the slow macOS/Windows runners —
+  # the matrix legs run in parallel, so PR wall-clock is the slowest leg, and
+  # those are it. The FULL 4-target matrix runs on every push to master (i.e.
+  # right after each squash-merge), and release.yml's 6-target build is the final
+  # pre-tag gate. So every platform is still compiled before any release ships;
+  # only per-PR latency drops. (Branch protection should require the PR check
+  # `platform-build (x86_64-unknown-linux-musl)` — the macOS/Windows legs only
+  # exist on master pushes.)
+  platform-matrix:
+    name: platform-matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set.outputs.include }}
+    steps:
+      - id: set
+        shell: bash
+        run: |
+          musl='{"target":"x86_64-unknown-linux-musl","os":"ubuntu-latest","install_musl":true}'
+          mac_arm='{"target":"aarch64-apple-darwin","os":"macos-latest","install_musl":false}'
+          mac_x86='{"target":"x86_64-apple-darwin","os":"macos-latest","install_musl":false}'
+          win='{"target":"x86_64-pc-windows-msvc","os":"windows-latest","install_musl":false}'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "include=[$musl]" >> "$GITHUB_OUTPUT"
+          else
+            echo "include=[$musl,$mac_arm,$mac_x86,$win]" >> "$GITHUB_OUTPUT"
+          fi
+
   platform-build:
+    needs: platform-matrix
     name: platform-build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            install_musl: true
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            install_musl: false
-          - target: x86_64-apple-darwin
-            os: macos-latest
-            install_musl: false
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-            install_musl: false
+        include: ${{ fromJSON(needs.platform-matrix.outputs.include) }}
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Why

`platform-build` cross-compiles 4 targets (linux-musl, both macOS arches, Windows) on every code PR. It's a **build-only compile check** — no artifacts, no packaging (that's release.yml, tag-gated). The legs run in **parallel**, so PR wall-clock ≈ the *slowest* leg, which is always the queued macOS/Windows runners. That's the "PRs take a while" cost, for a check that produces nothing shippable.

## What changed

A tiny `platform-matrix` job picks the target list by event:

- **pull_request** → `x86_64-unknown-linux-musl` only (the release-critical static target, on a fast never-queued ubuntu runner).
- **push: master** → the full 4-target matrix.

`platform-build` consumes it via `matrix.include: ${{ fromJSON(needs.platform-matrix.outputs.include) }}`.

Since merges squash to master immediately, every platform is still compiled right after each merge, and release.yml's 6-target build is the final pre-tag gate. So platform coverage still lands before any release — only **per-PR latency** drops. The trade-off is that a platform-only break could land red on master briefly (cheap to spot/fix); it can never reach a release.

## Note for branch protection

The PR check name `platform-build (x86_64-unknown-linux-musl)` is **unchanged**, so a required-status-check on it keeps working. The macOS/Windows leg names (`platform-build (aarch64-apple-darwin)`, etc.) now appear **only on master pushes** — if any of those are currently *required* on PRs, drop them from required checks (or this and future PRs will wait on a check that never reports).

## Self-verifying

This PR is itself a `pull_request` event, so its checks should show `platform-matrix` + **only** `platform-build (x86_64-unknown-linux-musl)` — no macOS/Windows legs. After merge, the master push run should show all four.