### PR TITLE
feat(write): add tag add — fourth safe write (ADR-0001)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ nbox device <name|slug|id>
                                   #   --dry-run | --allow-writes --confirm
                                   #   (ADR-0001 safe write; read-only default)
 nbox ip <address> [--vrf <name|slug|rd>]  # surfaces nat_inside/nat_outside (NetBox 4.6) when set
+nbox ip reserve <cidr> [--vrf <name|slug|rd>] [--description "…"] [--dns-name "…"]
+                                  # write: reserve the next available IP (POST available-ips); --dry-run | --allow-writes --confirm [--message]
 nbox prefix <cidr> [--vrf <name|slug|rd>]
 nbox next-ip <cidr> [--count N] [--vrf <name|slug|rd>]
 nbox next-prefix <cidr> [--length L] [--vrf <name|slug|rd>]
@@ -70,6 +72,8 @@ nbox search <query> [--limit N] [--status S] [--site <name|slug|id>] [--region <
 nbox tags
 nbox tagged <tag>               # objects carrying a tag, across kinds (NetBox 4.3+
                                   # `/api/extras/tagged-objects/`); tag = id|name|slug
+nbox tag add <type> <name> <tag>  # write: add a tag to any object (PATCH tags array); --dry-run | --allow-writes --confirm [--message]
+                                  # <type> = any read kind (device, ip, prefix, vlan, …); <tag> = id|name|slug; no-op if already present
 nbox journal <kind> <ref>         # kinds: device, ip, prefix, vlan, site, rack, rack-group, circuit,
                                   # virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider, vm,
                                   # vm-type, cluster, vrf, route-target, mac, interface (<device>/<name>)
@@ -180,9 +184,13 @@ nbox device edge01 --json | jq '.primary_ip4'
 
 ## Notes
 
-- The first write landed behind ADR-0001: `nbox interface <device> <interface>
-  set description "…"` and `nbox device <name> set status <value>` are safe,
-  plan-first `PATCH`es. Reads remain the default — apply needs BOTH
+- Writes landed behind ADR-0001. Four commands reuse the same safe-write
+  foundation (the `MutationPlan` / `MutationReceipt` engine):
+  `nbox interface <device> <interface> set description "…"`,
+  `nbox device <name> set status <value>`,
+  `nbox ip reserve <cidr>` (a `POST` to `available-ips` — the first `allocate`),
+  and `nbox tag add <type> <name> <tag>` (a `PATCH` to the `tags` array on any
+  object kind). All are plan-first: reads remain the default — apply needs BOTH
   `--allow-writes` (the gate) AND `--confirm` (or a TTY prompt in plain
   output); `--dry-run` previews with no mutation and needs neither.
   `--confirm` without `--allow-writes` is a usage error (exit 2, empty stdout).
@@ -193,7 +201,11 @@ nbox device edge01 --json | jq '.primary_ip4'
   to the canonical value (a label is accepted case-insensitively when it maps
   unambiguously to one value); an unknown or ambiguous status is a usage error
   (exit 2) naming the input and listing the allowed values, before any `PATCH`.
-  The MCP server stays read-only.
+  For `tag add`, the tag resolves by id/name/slug (same resolver as
+  `nbox tagged`); the target object resolves the same way as `nbox <kind> <ref>`.
+  NetBox `PATCH` replaces the whole `tags` array, so the plan carries the full
+  replacement slug list (current slugs + new); adding a tag the object already
+  carries is a no-op (no `PATCH`). The MCP server stays read-only.
 - Filters that an object type can't satisfy cause that type to be skipped in
   `search` (nbox does not send NetBox unknown query params).
 - `owner` (NetBox 4.5+): a native owner field (user or group) surfaced on most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A bare reserve `POST`s an empty body; an exhausted prefix (`409`) and a NetBox
     validation rejection (`400`) surface as clean errors (exit 1, empty stdout).
     The audit logs `operation=allocate`, `http_method=POST`, and field names only.
-- **`nbox tag add <type> <name> <tag>` — the third safe write.** Adds a tag to
+- **`nbox tag add <type> <name> <tag>` — the fourth safe write.** Adds a tag to
   any taggable object (device, IP, prefix, VLAN, site, rack, circuit, VM, …) via
   a minimal `PATCH` that replaces the full `tags` array, on the same ADR-0001
   gate/confirm/audit lifecycle as the interface/device pilots (`--dry-run` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A bare reserve `POST`s an empty body; an exhausted prefix (`409`) and a NetBox
     validation rejection (`400`) surface as clean errors (exit 1, empty stdout).
     The audit logs `operation=allocate`, `http_method=POST`, and field names only.
+- **`nbox tag add <type> <name> <tag>` — the third safe write.** Adds a tag to
+  any taggable object (device, IP, prefix, VLAN, site, rack, circuit, VM, …) via
+  a minimal `PATCH` that replaces the full `tags` array, on the same ADR-0001
+  gate/confirm/audit lifecycle as the interface/device pilots (`--dry-run` /
+  `--allow-writes --confirm` / `--message`). The tag is resolved by id, exact
+  name, or exact slug (same resolver as `nbox tagged`); the target object is
+  resolved the same way as `nbox <kind> <ref>`. Adding a tag the object already
+  carries is a no-op (no `PATCH`).
+  - **List field.** Tags are the first multi-valued writable field: the plan
+    carries the full replacement `{"tags": [slugs]}` (NetBox `PATCH` replaces the
+    whole array), so the before/after diff shows the tag slugs. `ETag`+`If-Match`
+    on 4.6+, `last_updated`+before-hash on pre-4.6.
+  - **Any object kind.** The planner reads the object as a raw value (every
+    NetBox object carries the same `tags` array shape), so no per-kind model is
+    needed for this write.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ this device, what owns this prefix?* — from the shell, a k9s-style TUI, or an 
 server for AI agents.
 
 **Status: pre-1.0.** Reads are the default; a narrow safe-write foundation
-(ADR-0001) has landed behind `--allow-writes` + confirmation — three commands
+(ADR-0001) has landed behind `--allow-writes` + confirmation — four commands
 today (`nbox interface <device> <interface> set description "…"`,
-`nbox device <name> set status <value>`, and `nbox ip reserve <prefix>` to
-allocate the next available IP). Broader writes are on the [ROADMAP](ROADMAP.md).
+`nbox device <name> set status <value>`, `nbox ip reserve <prefix>` to
+allocate the next available IP, and `nbox tag add <type> <name> <tag>` to
+add a tag to any object). Broader writes are on the [ROADMAP](ROADMAP.md).
 
 ## Quick Start
 
@@ -280,6 +281,7 @@ nbox interface <device> <interface>
 nbox tags                         # list tags (slug, name, count)
 nbox tagged <tag>                 # objects carrying a tag, across kinds
                                   # (NetBox 4.3+; tag = id|name|slug)
+nbox tag add <type> <name> <tag>   # write: add a tag to any object (PATCH tags array)
 nbox journal <kind> <ref>         # recent journal entries for an object
                                   # kinds incl. interface as <device>/<name>
                                   # --journal folds recent entries into a detail lookup (cap 5)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,10 @@
 nbox is a **read-first** NetBox CLI, TUI, and MCP server. The near-term goal is the **best
 possible read experience** — fast, correct, and pleasant both in the terminal and to agents.
 A narrow **safe-write foundation** has now landed (ADR-0001): a gated, opt-in, before/after-previewed
-write engine, with three commands landed — `interface <device> <iface> set description` and
-`device <name> set status <value>` (`PATCH`), and `ip reserve <prefix>` (the first `allocate`, a
-`POST` to `available-ips`). Reads stay
+write engine, with four commands landed — `interface <device> <iface> set description` and
+`device <name> set status <value>` (`PATCH`), `ip reserve <prefix>` (the first `allocate`, a
+`POST` to `available-ips`), and `tag add <type> <name> <tag>` (a `PATCH` to the `tags` array on
+any object kind). Reads stay
 the default everywhere and the write surface widens only as the read tool proves out in practice
 (see [Writes](#writes--deferred-later-track)).
 
@@ -422,10 +423,8 @@ the read tool proves out in practice. Consolidated future scope:
   read-only default. The ADR-0001 foundation landed: a shared `MutationPlan` /
   `MutationReceipt` engine + the `nbox interface <device> <iface> set description
   "…"` pilot (`--allow-writes` + `--confirm`/`--dry-run`, `ETag`/`If-Match` on
-  4.6+, `last_updated`+before-hash fallback, `--message`, local write audit).
 - ☑ `nbox interface <device> <iface> set description "…"` — the first write
-  command (on the ADR-0001 foundation). `nbox tag add <type> <name> <tag>` remains
-  open, reusing the same planner/diff/confirm/concurrency/audit contracts.
+  command (on the ADR-0001 foundation).
 - ☑ `nbox device <name> set status <value>` — the second write command,
   reusing the ADR-0001 foundation. Allowed `status` values are enumerated live
   from NetBox (read-only `OPTIONS`) and the operator's input is normalized to
@@ -448,8 +447,12 @@ the read tool proves out in practice. Consolidated future scope:
   (`POST` to `available-prefixes` / a range's `available-ips`); the read half
   (`next-ip` / `next-prefix`, range lookup) already ships, and the next-IP
   allocation (`ip reserve`) landed above.
-- ☐ `nbox tag add <type> <name> <tag>` — a further write command, reusing the
-  same foundation.
+- ☑ `nbox tag add <type> <name> <tag>` — a further write command, reusing the
+  same foundation. Adds a tag to any taggable object via a minimal `PATCH` that
+  replaces the full `tags` array; a no-op if the tag is already present. The
+  first **list-valued** writable field and the first write that works on **any
+  object kind** (the planner reads the object as a raw value, since every
+  NetBox object carries the same `tags` array shape — no per-kind model).
 - ☐ **Write-capable MCP tools** — opt-in, return the diff for the agent to confirm; read-only stays the
   default — plus the **per-user credential vault (Pattern 2)** for real per-user NetBox RBAC over MCP.
 - ☐ TUI edit mode (`e` / `d` / confirm).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,10 +1,11 @@
 # Features
 
 nbox is a NetBox client — a CLI and a TUI over the same core. Reads are the
-default; a narrow safe-write foundation (ADR-0001) adds three plan-first commands
+default; a narrow safe-write foundation (ADR-0001) adds four plan-first commands
 behind `--allow-writes` + confirmation — `interface … set description` and
-`device … set status` (`PATCH`), and `ip reserve <prefix>` (the next-IP
-allocation, a `POST`). The MCP server stays read-only.
+`device … set status` (`PATCH`), `ip reserve <prefix>` (the next-IP
+allocation, a `POST`), and `tag add <type> <name> <tag>` (a `PATCH` to the
+`tags` array on any object). The MCP server stays read-only.
 
 ## Lookups
 
@@ -31,6 +32,7 @@ allocation, a `POST`). The MCP server stays read-only.
 | `nbox mac <addr>` | Reverse-resolve a MAC to the interface(s)/device(s) that carry it (NetBox 4.2+). Any common form is normalized (`aa:bb:cc:dd:ee:ff`, `AABB.CCDD.EEFF`, `aa-bb-…`, `aabbccddeeff`); a non-MAC is a usage error, several carrying interfaces are ambiguous. |
 | `nbox tags` | List tags. |
 | `nbox tagged <tag>` | Objects carrying a tag, across kinds (NetBox 4.3+ `/api/extras/tagged-objects/`); tag = id/name/slug. |
+| `nbox tag add <type> <name> <tag>` | Add a tag to any taggable object — a safe write (ADR-0001): `PATCH` to the `tags` array, behind `--allow-writes` + confirm. Tag resolves by id/name/slug; target resolves like `nbox <kind> <ref>`. No-op if already present. |
 | `nbox journal <kind> <ref>` | Recent journal entries for an object. Kinds: device, ip, prefix, vlan, site, rack, rack-group, circuit, virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, vm-type, cluster, vrf, route-target, interface (`<device>/<name>`). `--journal` on a detail lookup folds the most recent entries inline (default 5); `--journal-limit <N>` overrides the cap and implies `--journal`. (`tenant`/`contact`/`provider`/`vm`/`vm-type`/`cluster`/`vrf`/`route-target`/`interface`/`virtual-circuit` have no inline `--journal` flag — use `nbox journal`.) |
 | `nbox history <kind> <ref>` | Change history (system audit log: create/update/delete, who + when) for an object, newest first. Same kind set as `journal`. `/api/core/object-changes/` (NetBox 4.x) — distinct from `journal` (operator notes). Each row includes the top-level fields that changed (pre vs post), not the full before/after JSON. |
 | `nbox status` | Connection + per-surface `api` routing (configured/effective) + capabilities + NetBox/Django/Python versions + a token-validity preflight (`token`: `valid`/`invalid`/`unverified`; NetBox 4.5+). |

--- a/docs/adr/0001-safe-write-foundation.md
+++ b/docs/adr/0001-safe-write-foundation.md
@@ -63,8 +63,8 @@ Current nbox constraints also matter:
    - a redacted, stable field diff
    - warnings, capability notes, and validation errors
    - optional `changelog_message`
-   - an opaque confirmation token derived from the target, precondition, patch,
-     profile, and plan expiry
+  - an opaque confirmation token derived from the target, operation,
+    precondition, patch, changelog message, profile, and plan expiry
 
    Domain view models are not write payloads. Write code gets explicit
    command-specific intent DTOs and endpoint-specific patch DTOs, then derives
@@ -257,6 +257,15 @@ Shipped on this foundation, in order:
     `update`, so existing receipts are byte-identical and `schema_version` stays
     `1`. The dry-run shows the *currently* next address as an advisory warning,
     never as a guaranteed field — the applied address may differ.
+- `tag add <type> <name> <tag>` — the fourth write (`update` / `PATCH`), the
+  first **list-valued** field and the first write on **any object kind**. Tags
+  are a list: the plan carries the full replacement `{"tags": [slugs]}` (NetBox
+  `PATCH` replaces the whole array), so the before/after diff shows the tag slugs.
+  The planner reads the object as a raw `serde_json::Value` — every NetBox
+  object carries the same `tags` array shape — so no per-kind model is needed
+  for this write. Adding a tag the object already carries is a no-op (empty
+  patch, no `PATCH`). `ETag`+`If-Match` on 4.6+, `last_updated`+before-hash on
+  pre-4.6, same as the interface/device pilots.
 
 Still deferred per Decision 6: choosing a specific address, multi-IP / range /
 next-prefix allocation, interface/VM assignment, status/tags on reserve, generic

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -445,6 +445,15 @@ pub enum Command {
         limit: usize,
     },
 
+    /// Add a tag to an object (a write — ADR-0001 safe-write foundation).
+    /// `nbox tag add <type> <name> <tag>` resolves the object and the tag,
+    /// then sends a minimal `PATCH` to add the tag. Behind `--allow-writes` +
+    /// confirmation. Adding a tag the object already carries is a no-op.
+    Tag {
+        #[command(subcommand)]
+        action: TagAction,
+    },
+
     /// Show recent journal entries for an object.
     Journal {
         /// Object kind: device, ip, prefix, vlan, site, rack, rack-group, circuit,
@@ -597,6 +606,56 @@ pub enum Command {
         /// docs/MCP.md (this prints the stdio recipe).
         #[arg(long)]
         print_config: bool,
+    },
+}
+
+/// `nbox tag` write actions (ADR-0001 safe-write foundation). The v1 surface
+/// is intentionally narrow: one operation (`add`). No generic `set`/`remove`
+/// — broader writes come later on the same planner/diff/confirm/concurrency/
+/// audit contracts.
+#[derive(Debug, Subcommand)]
+pub enum TagAction {
+    /// Add a tag to an object. A write: requires the `--allow-writes` gate AND
+    /// confirmation (`--confirm`, or an interactive prompt on a TTY in plain
+    /// output). `--dry-run` previews with no mutation and needs neither. Adding
+    /// a tag the object already carries is a no-op: apply sends no `PATCH`.
+    Add {
+        /// Object kind (e.g. `device`, `prefix`, `ip`, `vlan`, `site`, `rack`,
+        /// `circuit`, `tenant`, `vrf`, `vm`, `cluster`, `interface`, …). Any
+        /// kind `nbox <kind> <ref>` resolves.
+        object_type: String,
+
+        /// Object reference (name, slug, id, CIDR, VID, … — kind-dependent).
+        /// For an interface use `<device>/<name>`.
+        object_name: String,
+
+        /// Tag reference: id, exact name (e.g. `prod:us-east`), or exact slug.
+        tag: String,
+
+        /// Record this message in NetBox's object-change entry (a write-only
+        /// request field, never stored on the object). Validated to NetBox's
+        /// 200-character limit before applying. Optional.
+        #[arg(long, value_name = "MESSAGE")]
+        message: Option<String>,
+
+        /// Preview the plan + diff and perform no mutation. Needs neither
+        /// `--allow-writes` nor confirmation. With `--json`, returns the stable
+        /// `MutationPlan` JSON.
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+
+        /// Apply the reviewed plan without an interactive prompt. Does NOT
+        /// enable writes on its own — `--confirm` without `--allow-writes` is a
+        /// usage error (exit 2). With `--json`, returns the stable
+        /// `MutationReceipt` JSON.
+        #[arg(long)]
+        confirm: bool,
+
+        /// The write-enable gate: required to apply ANY mutation. Kept separate
+        /// from `--confirm` so a read-only invocation can never be silently
+        /// turned into a write (ADR-0001 §4).
+        #[arg(long = "allow-writes")]
+        allow_writes: bool,
     },
 }
 
@@ -1370,5 +1429,38 @@ mod tests {
         assert_eq!(field, "status");
         assert_eq!(new_value, "Offline");
         assert_eq!(msg, "draining");
+    }
+
+    #[test]
+    fn tag_add_parses_flags() {
+        let add = Cli::try_parse_from([
+            "nbox",
+            "--no-tui",
+            "tag",
+            "add",
+            "device",
+            "edge01",
+            "prod",
+            "--dry-run",
+        ])
+        .unwrap();
+        let Some(Command::Tag {
+            action:
+                TagAction::Add {
+                    object_type,
+                    object_name,
+                    tag,
+                    message: None,
+                    dry_run: true,
+                    confirm: false,
+                    allow_writes: false,
+                },
+        }) = add.command
+        else {
+            panic!("expected tag add");
+        };
+        assert_eq!(object_type, "device");
+        assert_eq!(object_name, "edge01");
+        assert_eq!(tag, "prod");
     }
 }

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -856,18 +856,32 @@ struct TagTargetObject {
 
 /// Resolve a `<kind> <ref>` to the object's REST detail endpoint path (relative
 /// to the client base URL) and numeric id. Reuses the same per-kind resolvers
-/// as `resolve_object_url`, so ambiguity / not-found / case-insensitive
-/// fallback behave exactly like `nbox <kind> <ref>`. Returns the endpoint path
-/// (e.g. `/api/dcim/devices/42/`) and the id.
+/// as `resolve_object_url`, except for IP addresses: `open ip/<addr>` historically
+/// first-picked a candidate, but a write must fail closed when the same address
+/// exists in multiple VRFs. Returns the endpoint path (e.g.
+/// `/api/dcim/devices/42/`) and the id.
 pub(crate) async fn resolve_tag_target_endpoint(
     client: &NetBoxClient,
     kind: &str,
     value: &str,
     not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
 ) -> Result<(String, u64)> {
-    let url = crate::resolve_object_url(client, kind, value)
-        .await?
-        .ok_or_else(|| not_found(kind, value))?;
+    let url = match kind {
+        "ip" | "ip-address" | "address" => {
+            let candidates = client.ip_candidates(value).await?;
+            resolve_unique(
+                "IP address",
+                value,
+                candidates,
+                query::ip_scope_label,
+                not_found,
+            )?
+            .url
+        }
+        _ => crate::resolve_object_url(client, kind, value)
+            .await?
+            .ok_or_else(|| not_found(kind, value))?,
+    };
     let parsed = reqwest::Url::parse(&url).context("parsing resolved object URL")?;
     // The object URL is the full REST detail endpoint (e.g.
     // `http://h/netbox/api/dcim/devices/42/`). Strip the client's base URL to

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -317,7 +317,14 @@ pub(crate) async fn plan_interface_description_update(
     }];
 
     let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
-    let confirm_token = mutation::confirm_token(&target, &precondition, &patch, expires_epoch);
+    let confirm_token = mutation::confirm_token(
+        &target,
+        Operation::Update,
+        &precondition,
+        &patch,
+        &message,
+        expires_epoch,
+    );
 
     Ok(MutationPlan {
         schema_version: PLAN_SCHEMA_VERSION,
@@ -549,7 +556,14 @@ pub(crate) async fn plan_device_status_update(
     }];
 
     let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
-    let confirm_token = mutation::confirm_token(&target, &precondition, &patch, expires_epoch);
+    let confirm_token = mutation::confirm_token(
+        &target,
+        Operation::Update,
+        &precondition,
+        &patch,
+        &message,
+        expires_epoch,
+    );
 
     Ok(MutationPlan {
         schema_version: PLAN_SCHEMA_VERSION,
@@ -737,7 +751,14 @@ pub(crate) async fn plan_ip_reserve(
     }
 
     let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
-    let confirm_token = mutation::confirm_token(&target, &precondition, &patch, expires_epoch);
+    let confirm_token = mutation::confirm_token(
+        &target,
+        Operation::Allocate,
+        &precondition,
+        &patch,
+        &message,
+        expires_epoch,
+    );
 
     Ok(MutationPlan {
         schema_version: PLAN_SCHEMA_VERSION,
@@ -793,6 +814,293 @@ pub(crate) async fn apply_ip_reserve(
         object,
         message: format!("reserved: {} in {}", address, plan.target.display),
     })
+}
+
+// ===== Safe write follow-on: tag add (ADR-0001) ===========================
+//
+// The third write command reuses the same planner/diff/confirm/concurrency/
+// audit contracts as the interface/device pilots. Tags are a list field: the
+// plan carries the full replacement `{"tags": [slugs]}` (NetBox's PATCH
+// semantics replace the whole array), so the before/after diff shows the tag
+// names. Adding a tag the object already carries is a no-op (no PATCH).
+
+/// The writable field on any object for `tag add` (ADR-0001 §6).
+pub(crate) const TAG_WRITABLE_FIELD: &str = "tags";
+
+/// One entry in the object's current tags array, as NetBox serializes it on a
+/// detail response: `{id, name, slug}`. Used to read the current tag set and
+/// build the replacement slug list.
+#[derive(Debug, Deserialize)]
+struct ObjectTag {
+    #[serde(default)]
+    #[allow(dead_code)]
+    id: Option<u64>,
+    #[allow(dead_code)]
+    name: Option<String>,
+    slug: Option<String>,
+}
+
+/// The raw object detail as a `Value`, so the planner can read the `tags`
+/// array, `display`, and `last_updated` from any object kind in one path —
+/// every NetBox object carries the same `tags` array shape, so no per-kind
+/// model is needed for this write.
+#[derive(Debug, Deserialize)]
+struct TagTargetObject {
+    #[serde(default)]
+    display: Option<String>,
+    #[serde(default)]
+    last_updated: Option<String>,
+    #[serde(default)]
+    tags: Vec<ObjectTag>,
+}
+
+/// Resolve a `<kind> <ref>` to the object's REST detail endpoint path (relative
+/// to the client base URL) and numeric id. Reuses the same per-kind resolvers
+/// as `resolve_object_url`, so ambiguity / not-found / case-insensitive
+/// fallback behave exactly like `nbox <kind> <ref>`. Returns the endpoint path
+/// (e.g. `/api/dcim/devices/42/`) and the id.
+pub(crate) async fn resolve_tag_target_endpoint(
+    client: &NetBoxClient,
+    kind: &str,
+    value: &str,
+    not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
+) -> Result<(String, u64)> {
+    let url = crate::resolve_object_url(client, kind, value)
+        .await?
+        .ok_or_else(|| not_found(kind, value))?;
+    let parsed = reqwest::Url::parse(&url).context("parsing resolved object URL")?;
+    // The object URL is the full REST detail endpoint (e.g.
+    // `http://h/netbox/api/dcim/devices/42/`). Strip the client's base URL to
+    // get the relative path the PATCH expects. `make_relative` strips scheme +
+    // host + the base path; on a plain `http://h/` base it leaves
+    // `/api/dcim/devices/42/`.
+    let relative = client
+        .base_url()
+        .make_relative(&parsed)
+        .context("stripping base URL from resolved object URL")?;
+    // The relative path may carry a leading `./` when the base has a subpath;
+    // normalize to the `/api/...` form the client's `url_for` expects.
+    let endpoint = relative
+        .trim_start_matches("./")
+        .trim_start_matches('/')
+        .to_string();
+    // Ensure a leading slash so the endpoint matches the canonical `/api/...`
+    // form every other planner emits (e.g. `/api/dcim/devices/42/`).
+    let endpoint = if endpoint.starts_with('/') {
+        endpoint
+    } else {
+        format!("/{endpoint}")
+    };
+    // The id is the last path segment before the trailing slash.
+    let id = parsed
+        .path()
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .context("extracting object id from resolved URL")?;
+    Ok((endpoint, id))
+}
+
+/// Plan a `tag add` update (ADR-0001 §5 steps 1–4): resolve the tag, resolve
+/// the target object, read its current tags with the `ETag` (4.6+) or
+/// `last_updated` (pre-4.6 fallback), and build an `Update` plan whose patch
+/// replaces the `tags` array with the current slugs plus the new tag's slug.
+/// Adding a tag the object already carries is a no-op (empty patch).
+/// `changelog_message` is validated against NetBox's length limit here, before
+/// any network write.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn plan_tag_add(
+    client: &NetBoxClient,
+    object_type: &str,
+    object_name: &str,
+    tag_ref: &str,
+    changelog_message: Option<&str>,
+    profile: &str,
+    not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
+) -> Result<MutationPlan> {
+    // Message length is pure input validation — check first, before any network.
+    let message = match changelog_message {
+        Some(m) if !m.is_empty() => Some(m.to_string()),
+        _ => None,
+    };
+    mutation::validate_changelog_message(&message)?;
+
+    // Resolve the tag by id, exact name, or exact slug (reuse the `nbox tagged`
+    // resolver). A missing tag is a not-found (exit 4), not a usage error.
+    let tag = client
+        .tag_by_ref(tag_ref)
+        .await?
+        .ok_or_else(|| not_found("tag", tag_ref))?;
+
+    // Resolve the target object to its detail endpoint + id.
+    let (endpoint, id) =
+        resolve_tag_target_endpoint(client, object_type, object_name, not_found).await?;
+
+    // Read the authoritative current state with its `ETag` header (4.6+) or
+    // `last_updated` (pre-4.6 fallback). Reading as a raw value gives us the
+    // `tags` array, `display`, and `last_updated` in one fetch for any kind.
+    let (current, etag): (TagTargetObject, Option<String>) =
+        client.get_with_etag(&endpoint, &[]).await?;
+
+    let display = current
+        .display
+        .clone()
+        .unwrap_or_else(|| object_name.to_string());
+    let target = PlanTarget {
+        kind: object_type.to_string(),
+        r#ref: object_name.to_string(),
+        id,
+        display,
+        endpoint,
+        profile: profile.to_string(),
+    };
+
+    let precondition = match etag {
+        Some(e) => Precondition::Etag { etag: e },
+        None => Precondition::LastUpdated {
+            last_updated: current.last_updated.clone(),
+            before_hash: tags_before_hash(&current.tags),
+        },
+    };
+
+    // The current tag slugs (in order) plus the new tag's slug, deduped. NetBox
+    // PATCH replaces the whole `tags` array, so the patch carries the full
+    // replacement list. A tag already present is a no-op (no PATCH).
+    let current_slugs: Vec<String> = current.tags.iter().filter_map(|t| t.slug.clone()).collect();
+    let no_op = current_slugs.iter().any(|s| s == &tag.slug);
+    let after_slugs: Vec<String> = if no_op {
+        current_slugs.clone()
+    } else {
+        let mut v = current_slugs.clone();
+        v.push(tag.slug.clone());
+        v
+    };
+
+    let before = serde_json::to_value(
+        current
+            .tags
+            .iter()
+            .filter_map(|t| t.slug.clone())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap_or(Value::Null);
+    let after = serde_json::to_value(&after_slugs).unwrap_or(Value::Null);
+    let patch = if no_op {
+        serde_json::json!({})
+    } else {
+        serde_json::json!({ TAG_WRITABLE_FIELD: after_slugs })
+    };
+    let fields = vec![FieldChange {
+        field: TAG_WRITABLE_FIELD.to_string(),
+        before: before.clone(),
+        after: after.clone(),
+    }];
+
+    let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
+    let confirm_token = mutation::confirm_token(
+        &target,
+        Operation::Update,
+        &precondition,
+        &patch,
+        &message,
+        expires_epoch,
+    );
+
+    Ok(MutationPlan {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: Operation::Update,
+        target,
+        precondition,
+        fields,
+        patch,
+        no_op,
+        warnings: Vec::new(),
+        errors: Vec::new(),
+        changelog_message: message,
+        confirm_token,
+        expires_at: mutation::format_iso_utc(expires_epoch),
+    })
+}
+
+/// Apply a planned `tag add` update (ADR-0001 §5 steps 5–7): verify the plan's
+/// confirmation token + expiry, short-circuit a no-op, then send the minimal
+/// `PATCH` (`{"tags": [slugs]}`) with the recorded precondition. Returns a
+/// [`MutationReceipt`] from the PATCH response.
+pub(crate) async fn apply_tag_add(
+    client: &NetBoxClient,
+    plan: &MutationPlan,
+) -> Result<MutationReceipt> {
+    plan.verify()?;
+
+    if plan.no_op {
+        return Ok(no_op_receipt(plan));
+    }
+
+    // The wire body is the tags replacement plus the opt-in changelog_message.
+    let mut body = plan.patch.clone();
+    if let Some(msg) = &plan.changelog_message {
+        body["changelog_message"] = serde_json::json!(msg);
+    }
+
+    let (_updated, new_etag, status): (Value, Option<String>, u16) = match &plan.precondition {
+        Precondition::Etag { etag } => {
+            client
+                .patch(&plan.target.endpoint, &body, Some(etag))
+                .await?
+        }
+        Precondition::LastUpdated {
+            last_updated,
+            before_hash,
+        } => {
+            // Read-before-write (pre-4.6 fallback): re-fetch and refuse if
+            // the object moved. `last_updated` ticking is the primary
+            // signal; the before-hash is a belt-and-suspenders guard.
+            let (current, _): (TagTargetObject, Option<String>) =
+                client.get_with_etag(&plan.target.endpoint, &[]).await?;
+            if current.last_updated != *last_updated
+                || tags_before_hash(&current.tags) != *before_hash
+            {
+                return Err(NboxError::StalePrecondition(String::new()).into());
+            }
+            client.patch(&plan.target.endpoint, &body, None).await?
+        }
+        Precondition::None => {
+            anyhow::bail!("internal error: a tag add plan carried a None precondition")
+        }
+    };
+
+    Ok(MutationReceipt {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: plan.operation,
+        target: plan.target.clone(),
+        fields: plan.fields.clone(),
+        applied: true,
+        no_op: false,
+        status,
+        etag: new_etag,
+        request_id: None,
+        object: None,
+        message: format!(
+            "applied: {} {} ({})",
+            plan.target.kind,
+            plan.target.display,
+            plan.changed_field_names().join(", ")
+        ),
+    })
+}
+
+/// Normalized before-hash over the object's current tags (sorted slugs). The
+/// apply re-reads and recomputes this; a mismatch vs the plan's recorded
+/// `before_hash` means the object's tags changed in NetBox.
+fn tags_before_hash(tags: &[ObjectTag]) -> String {
+    let mut slugs: BTreeMap<String, Value> = BTreeMap::new();
+    for t in tags {
+        if let Some(slug) = &t.slug {
+            slugs.insert(slug.clone(), Value::String(slug.clone()));
+        }
+    }
+    mutation::before_hash(&slugs)
 }
 
 /// `ip <address>`: resolve an IP (scoped by `vrf`, ambiguity-checked) and

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -818,7 +818,7 @@ pub(crate) async fn apply_ip_reserve(
 
 // ===== Safe write follow-on: tag add (ADR-0001) ===========================
 //
-// The third write command reuses the same planner/diff/confirm/concurrency/
+// The fourth write command reuses the same planner/diff/confirm/concurrency/
 // audit contracts as the interface/device pilots. Tags are a list field: the
 // plan carries the full replacement `{"tags": [slugs]}` (NetBox's PATCH
 // semantics replace the whole array), so the before/after diff shows the tag

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,6 +456,29 @@ pub async fn run(cli: Cli) -> Result<()> {
         Some(Command::Open { object_ref }) => run_open(&ctx, &object_ref).await,
         Some(Command::Tags { limit }) => run_tags(&ctx, limit).await,
         Some(Command::Tagged { tag, limit }) => run_tagged(&ctx, &tag, limit).await,
+        Some(Command::Tag { action }) => match action {
+            crate::cli::TagAction::Add {
+                object_type,
+                object_name,
+                tag,
+                message,
+                dry_run,
+                confirm,
+                allow_writes,
+            } => {
+                Box::pin(run_tag_add(
+                    &ctx,
+                    &object_type,
+                    &object_name,
+                    &tag,
+                    message.as_deref(),
+                    dry_run,
+                    confirm,
+                    allow_writes,
+                ))
+                .await
+            }
+        },
         Some(Command::Journal { kind, value, limit }) => {
             run_journal(&ctx, &kind, &value, limit).await
         }
@@ -1623,6 +1646,49 @@ async fn run_ip_reserve(
     // The shared dry-run/prompt/apply/audit lifecycle — one write path.
     apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
         Box::pin(detail::apply_ip_reserve(c, p))
+    })
+    .await
+}
+
+/// `nbox tag add <type> <name> <tag>` — the third safe write (ADR-0001
+/// follow-on), reusing the same gate/planner/lifecycle/audit path as the
+/// interface/device pilots. Resolves the tag and the target object, reads the
+/// current tags, and builds a plan that appends the tag's slug to the tags
+/// array (a `PATCH` that replaces the whole array — NetBox semantics). Adding
+/// a tag the object already carries is a no-op (no `PATCH`).
+#[allow(clippy::too_many_arguments)] // the CLI flag set; collapsing loses clarity
+async fn run_tag_add(
+    ctx: &Ctx,
+    object_type: &str,
+    object_name: &str,
+    tag: &str,
+    message: Option<&str>,
+    dry_run: bool,
+    confirm: bool,
+    allow_writes: bool,
+) -> Result<()> {
+    // Gate decision BEFORE any plan/network (shared with the PATCH pilots): a
+    // read-only invocation can never become a write (ADR-0001 §4/§5).
+    let action = gate_write(ctx, dry_run, confirm, allow_writes)?;
+
+    let (client, profile) = connect_named(ctx)?;
+    let host = audit_origin(client.base_url());
+
+    // 2–4) resolve the tag + target object + build the plan.
+    let plan = detail::plan_tag_add(
+        &client,
+        object_type,
+        object_name,
+        tag,
+        message,
+        &profile,
+        &not_found,
+    )
+    .await?;
+
+    // The shared dry-run/prompt/apply/audit lifecycle — one write path.
+    apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
+        Box::pin(detail::apply_tag_add(c, p))
     })
     .await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1650,7 +1650,7 @@ async fn run_ip_reserve(
     .await
 }
 
-/// `nbox tag add <type> <name> <tag>` — the third safe write (ADR-0001
+/// `nbox tag add <type> <name> <tag>` — the fourth safe write (ADR-0001
 /// follow-on), reusing the same gate/planner/lifecycle/audit path as the
 /// interface/device pilots. Resolves the tag and the target object, reads the
 /// current tags, and builds a plan that appends the tag's slug to the tags

--- a/src/netbox/mutation.rs
+++ b/src/netbox/mutation.rs
@@ -201,7 +201,14 @@ impl MutationPlan {
                 " (the plan expired)".to_string(),
             ));
         }
-        let expected = confirm_token(&self.target, &self.precondition, &self.patch, epoch);
+        let expected = confirm_token(
+            &self.target,
+            self.operation,
+            &self.precondition,
+            &self.patch,
+            &self.changelog_message,
+            epoch,
+        );
         if expected != self.confirm_token {
             return Err(NboxError::Usage(
                 "plan confirmation token does not match its contents; re-run dry-run".to_string(),
@@ -255,16 +262,24 @@ pub struct MutationReceipt {
 // --- confirmation token -----------------------------------------------------
 
 /// Derive the opaque confirmation token for a plan. Bound to the target,
-/// precondition, minimal patch, profile, and the plan's expiry epoch so the
-/// same plan reapplied within its window verifies, but a different plan (or one
-/// past expiry) does not. SHA-256 over canonical (sorted-key) JSON. This is a
-/// guard, not a MAC: it carries no secret — the bound inputs are all already
-/// visible in the plan (ADR-0001 §5).
+/// operation, precondition, minimal patch, changelog message, profile, and the
+/// plan's expiry epoch so the same plan reapplied within its window verifies,
+/// but a different plan (or one past expiry) does not. SHA-256 over canonical
+/// (sorted-key) JSON. This is a guard, not a MAC: it carries no secret — the
+/// bound inputs are all already visible in the plan (ADR-0001 §5).
+///
+/// `operation` and `changelog_message` are bound so a future multi-step flow
+/// (TUI/MCP) that carries a plan across a boundary cannot apply a plan whose
+/// reviewed message or operation was altered between review and apply. In the
+/// one-shot `--confirm` CLI flow plan and apply share one process, so this is
+/// defense-in-depth, not a live fix.
 #[must_use]
 pub fn confirm_token(
     target: &PlanTarget,
+    operation: Operation,
     precondition: &Precondition,
     patch: &Value,
+    changelog_message: &Option<String>,
     expires_epoch: u64,
 ) -> String {
     let mut map = BTreeMap::new();
@@ -275,8 +290,13 @@ pub fn confirm_token(
         Value::String(target.endpoint.clone()),
     );
     map.insert("profile".to_string(), Value::String(target.profile.clone()));
+    map.insert("operation".to_string(), serde_json::json!(operation));
     map.insert("precondition".to_string(), precondition.to_canonical());
     map.insert("patch".to_string(), patch.clone());
+    map.insert(
+        "changelog_message".to_string(),
+        serde_json::to_value(changelog_message).unwrap_or(Value::Null),
+    );
     map.insert(
         "expires_epoch".to_string(),
         serde_json::json!(expires_epoch),
@@ -410,8 +430,8 @@ mod tests {
             etag: "\"abc\"".into(),
         };
         let patch = json!({"description": "up"});
-        let a = confirm_token(&t, &p, &patch, 1_000);
-        let b = confirm_token(&t, &p, &patch, 1_000);
+        let a = confirm_token(&t, Operation::Update, &p, &patch, &None, 1_000);
+        let b = confirm_token(&t, Operation::Update, &p, &patch, &None, 1_000);
         assert_eq!(a, b, "same inputs → same token");
         assert_eq!(a.len(), 64, "full SHA-256 hex");
         assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
@@ -424,34 +444,52 @@ mod tests {
             etag: "\"abc\"".into(),
         };
         let patch = json!({"description": "up"});
-        let base = confirm_token(&t, &p, &patch, 1_000);
+        let base = confirm_token(&t, Operation::Update, &p, &patch, &None, 1_000);
         // Different patch → different token.
         assert_ne!(
             base,
-            confirm_token(&t, &p, &json!({"description": "down"}), 1_000)
+            confirm_token(
+                &t,
+                Operation::Update,
+                &p,
+                &json!({"description": "down"}),
+                &None,
+                1_000
+            )
         );
         // Different id (target) → different token.
         let mut t2 = t.clone();
         t2.id = 43;
-        assert_ne!(base, confirm_token(&t2, &p, &patch, 1_000));
+        assert_ne!(
+            base,
+            confirm_token(&t2, Operation::Update, &p, &patch, &None, 1_000)
+        );
         // Different precondition → different token.
         assert_ne!(
             base,
             confirm_token(
                 &t,
+                Operation::Update,
                 &Precondition::Etag {
                     etag: "\"xyz\"".into()
                 },
                 &patch,
+                &None,
                 1_000
             )
         );
         // Different expiry → different token.
-        assert_ne!(base, confirm_token(&t, &p, &patch, 2_000));
+        assert_ne!(
+            base,
+            confirm_token(&t, Operation::Update, &p, &patch, &None, 2_000)
+        );
         // Different profile → different token.
         let mut t3 = t.clone();
         t3.profile = "work".into();
-        assert_ne!(base, confirm_token(&t3, &p, &patch, 1_000));
+        assert_ne!(
+            base,
+            confirm_token(&t3, Operation::Update, &p, &patch, &None, 1_000)
+        );
     }
 
     #[test]
@@ -509,20 +547,36 @@ mod tests {
         // so an allocate plan's token can't collide with an update plan's.
         let t = target();
         let patch = json!({});
-        let none_tok = confirm_token(&t, &Precondition::None, &patch, 1_000);
+        let none_tok = confirm_token(
+            &t,
+            Operation::Update,
+            &Precondition::None,
+            &patch,
+            &None,
+            1_000,
+        );
         let etag_tok = confirm_token(
             &t,
+            Operation::Update,
             &Precondition::Etag {
                 etag: "\"abc\"".into(),
             },
             &patch,
+            &None,
             1_000,
         );
         assert_ne!(none_tok, etag_tok);
         // Stable for the same inputs.
         assert_eq!(
             none_tok,
-            confirm_token(&t, &Precondition::None, &patch, 1_000)
+            confirm_token(
+                &t,
+                Operation::Update,
+                &Precondition::None,
+                &patch,
+                &None,
+                1_000
+            )
         );
     }
 
@@ -637,7 +691,14 @@ mod tests {
             confirm_token: String::new(), // filled below
             expires_at: format_iso_utc(exp),
         };
-        let token = confirm_token(&plan.target, &plan.precondition, &plan.patch, exp);
+        let token = confirm_token(
+            &plan.target,
+            Operation::Update,
+            &plan.precondition,
+            &plan.patch,
+            &None,
+            exp,
+        );
         let mut plan = plan;
         plan.confirm_token = token;
         plan.verify().expect("fresh consistent plan verifies");
@@ -656,7 +717,14 @@ mod tests {
     fn plan_verify_rejects_an_expired_plan() {
         // Expiry in the past (epoch 1 → 1970).
         let mut plan = plan_for_verify_with_epoch(1);
-        plan.confirm_token = confirm_token(&plan.target, &plan.precondition, &plan.patch, 1);
+        plan.confirm_token = confirm_token(
+            &plan.target,
+            Operation::Update,
+            &plan.precondition,
+            &plan.patch,
+            &None,
+            1,
+        );
         let err = plan.verify().unwrap_err();
         assert_eq!(
             err.exit_code(),
@@ -698,10 +766,12 @@ mod tests {
             changelog_message: None,
             confirm_token: confirm_token(
                 &target(),
+                Operation::Update,
                 &Precondition::Etag {
                     etag: "\"abc\"".into(),
                 },
                 &json!({"description": "up"}),
+                &None,
                 epoch,
             ),
             expires_at: format_iso_utc(epoch),

--- a/src/netbox/mutation.rs
+++ b/src/netbox/mutation.rs
@@ -490,6 +490,23 @@ mod tests {
             base,
             confirm_token(&t3, Operation::Update, &p, &patch, &None, 1_000)
         );
+        // Different operation → different token.
+        assert_ne!(
+            base,
+            confirm_token(&t, Operation::Allocate, &p, &patch, &None, 1_000)
+        );
+        // Different changelog message → different token.
+        assert_ne!(
+            base,
+            confirm_token(
+                &t,
+                Operation::Update,
+                &p,
+                &patch,
+                &Some("reviewed change".into()),
+                1_000
+            )
+        );
     }
 
     #[test]

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -1950,3 +1950,363 @@ async fn ip_bare_without_address_is_a_usage_error() {
     ]);
     assert_error_contract(&out, 2, "missing IP address");
 }
+
+// ===== tag add (ADR-0001 follow-on) =====================================
+//
+// The third write command reuses the same planner/diff/confirm/concurrency/
+// audit contracts. Tags are a list field: the plan carries the full
+// replacement `{"tags": [slugs]}` (NetBox PATCH replaces the whole array).
+
+/// Mount a tag resolution: `GET /api/extras/tags/?name=…` returning one tag.
+async fn mount_tag_by_name(server: &MockServer, tag_id: u64, name: &str, slug: &str) {
+    Mock::given(method("GET"))
+        .and(path("/api/extras/tags/"))
+        .and(wiremock::matchers::query_param("name", name))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": tag_id, "name": name, "slug": slug}]
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount a device detail with a `tags` array, optional ETag.
+async fn mount_device_detail_with_tags(
+    server: &MockServer,
+    device_id: u64,
+    etag: Option<&str>,
+    tags: &[(&str, &str)],
+    last_updated: &str,
+) {
+    let tag_json: Vec<Value> = tags
+        .iter()
+        .map(|(name, slug)| json!({"id": 1, "name": name, "slug": slug}))
+        .collect();
+    let mut resp = ResponseTemplate::new(200).set_body_json(json!({
+        "id": device_id,
+        "url": format!("{}/api/dcim/devices/{}/", server.uri(), device_id),
+        "name": "edge01",
+        "display": "edge01",
+        "last_updated": last_updated,
+        "tags": tag_json
+    }));
+    if let Some(e) = etag {
+        resp = resp.insert_header("ETag", e);
+    }
+    Mock::given(method("GET"))
+        .and(path(format!("/api/dcim/devices/{device_id}/")))
+        .respond_with(resp)
+        .mount(server)
+        .await;
+}
+
+fn run_tag_add<'a>(config: &NamedTempFile, extra: &'a [&'a str]) -> CommandOutput {
+    let mut args: Vec<&str> = vec!["--config", config.path().to_str().unwrap()];
+    args.push("--no-tui");
+    args.extend_from_slice(&["tag", "add", "device", "edge01", "prod"]);
+    args.extend_from_slice(extra);
+    run_nbox(args)
+}
+
+#[tokio::test]
+async fn tag_add_dry_run_sends_no_patch_and_shows_tags_before_after() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail_with_tags(
+        &server,
+        7,
+        None,
+        &[("legacy", "legacy")],
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--dry-run", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0, "dry-run must not PATCH");
+    let plan: Value = serde_json::from_str(&out.stdout).expect("plan JSON");
+    assert_eq!(plan["schema_version"], json!(1));
+    assert_eq!(plan["target"]["kind"], json!("device"));
+    assert_eq!(plan["target"]["id"], json!(7));
+    assert_eq!(plan["target"]["endpoint"], json!("/api/dcim/devices/7/"));
+    // The patch replaces the full tags array: existing + new.
+    assert_eq!(plan["patch"], json!({"tags": ["legacy", "prod"]}));
+    assert_eq!(plan["fields"].as_array().unwrap().len(), 1);
+    assert_eq!(plan["fields"][0]["field"], json!("tags"));
+    assert_eq!(plan["fields"][0]["before"], json!(["legacy"]));
+    assert_eq!(plan["fields"][0]["after"], json!(["legacy", "prod"]));
+    assert_eq!(plan["no_op"], json!(false));
+    // No ETag → pre-4.6 precondition.
+    assert_eq!(plan["precondition"]["type"], json!("last_updated"));
+}
+
+#[tokio::test]
+async fn tag_add_confirm_sends_one_patch_with_full_tags_array() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail_with_tags(
+        &server,
+        7,
+        None,
+        &[("legacy", "legacy")],
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .and(body_partial_json(json!({"tags": ["legacy", "prod"]})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "tags": [{"id": 1, "name": "legacy", "slug": "legacy"},
+                     {"id": 5, "name": "prod", "slug": "prod"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--allow-writes", "--confirm", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 1, "exactly one PATCH");
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(true));
+    assert_eq!(receipt["no_op"], json!(false));
+    assert_eq!(receipt["status"], json!(200));
+    assert_eq!(receipt["fields"][0]["after"], json!(["legacy", "prod"]));
+    assert!(
+        receipt["message"]
+            .as_str()
+            .unwrap()
+            .contains("applied: device"),
+        "receipt message: {}",
+        receipt["message"]
+    );
+}
+
+#[tokio::test]
+async fn tag_add_noop_when_tag_already_present_sends_no_patch() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    // Device already carries the "prod" tag → no-op. No PATCH mock mounted.
+    mount_device_detail_with_tags(
+        &server,
+        7,
+        None,
+        &[("legacy", "legacy"), ("prod", "prod")],
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--allow-writes", "--confirm", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0, "no-op sends no PATCH");
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(false));
+    assert_eq!(receipt["no_op"], json!(true));
+    assert_eq!(receipt["status"], json!(0));
+    assert!(receipt["message"].as_str().unwrap().contains("no change"));
+}
+
+#[tokio::test]
+async fn tag_add_unknown_tag_is_not_found_exit_4() {
+    let server = MockServer::start().await;
+    // Tag resolution returns empty — no tag matches "nonexistent".
+    Mock::given(method("GET"))
+        .and(path("/api/extras/tags/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 0, "next": null, "previous": null, "results": []
+        })))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    mount_device_resolution(&server, 7, "edge01").await;
+
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--dry-run", "--json"]);
+
+    assert_error_contract(&out, 4, "no tag matched");
+    assert_eq!(patch_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn tag_add_confirm_without_allow_writes_is_a_usage_error() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--confirm", "--json"]);
+    assert_error_contract(&out, 2, "writes are not enabled");
+    assert!(
+        out.stderr.contains("--allow-writes"),
+        "stderr: {}",
+        out.stderr
+    );
+    assert_eq!(patch_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn tag_add_allow_writes_without_confirm_is_usage_in_non_tty() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--allow-writes", "--json"]);
+    assert_error_contract(&out, 2, "non-interactive write requires confirmation");
+    assert!(out.stderr.contains("--confirm"), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn tag_add_etag_sends_if_match_on_apply() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail_with_tags(
+        &server,
+        7,
+        Some("\"etag-v1\""),
+        &[("legacy", "legacy")],
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+    // The PATCH mock ONLY matches when If-Match is sent.
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .and(header("if-match", "\"etag-v1\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "tags": [{"id": 1, "name": "legacy", "slug": "legacy"},
+                     {"id": 5, "name": "prod", "slug": "prod"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--allow-writes", "--confirm", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 1);
+    let patch_reqs: Vec<_> = server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.method.as_str() == "PATCH")
+        .collect();
+    assert_eq!(
+        patch_reqs[0].headers.get("if-match").unwrap(),
+        "\"etag-v1\""
+    );
+}
+
+#[tokio::test]
+async fn tag_add_stale_412_is_a_stale_precondition_refusal() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail_with_tags(
+        &server,
+        7,
+        Some("\"etag-v1\""),
+        &[("legacy", "legacy")],
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(412).set_body_string("Precondition Failed"))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_tag_add(&config, &["--allow-writes", "--confirm", "--json"]);
+
+    assert_error_contract(&out, 1, "object changed in NetBox");
+    assert!(
+        out.stderr.contains("re-run dry-run"),
+        "stderr: {}",
+        out.stderr
+    );
+}
+
+#[tokio::test]
+async fn tag_add_audit_logs_field_name_only_never_values_or_token() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    mount_device_resolution(&server, 7, "edge01").await;
+    mount_device_detail_with_tags(
+        &server,
+        7,
+        None,
+        &[("legacy", "legacy")],
+        "2026-06-26T10:00:00Z",
+    )
+    .await;
+    Mock::given(method("PATCH"))
+        .and(path("/api/dcim/devices/7/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 7, "url": "u", "name": "edge01",
+            "tags": [{"id": 1, "name": "legacy", "slug": "legacy"},
+                     {"id": 5, "name": "prod", "slug": "prod"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let log_path =
+        std::env::temp_dir().join(format!("nbox-tag-add-audit-{}.log", std::process::id()));
+    let _ = std::fs::remove_file(&log_path);
+
+    let config = write_config(&server.uri());
+    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
+        .args([
+            "--config",
+            config.path().to_str().unwrap(),
+            "--no-tui",
+            "tag",
+            "add",
+            "device",
+            "edge01",
+            "prod",
+            "--allow-writes",
+            "--confirm",
+            "--json",
+            "--log-file",
+            log_path.to_str().unwrap(),
+        ])
+        .env("NBOX_TOKEN", "secret-nbox-token-12345")
+        .env("NBOX_LOG", "nbox::write_audit=info")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .output()
+        .expect("spawn nbox");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let log_text = std::fs::read_to_string(&log_path).expect("read log file");
+    assert!(log_text.contains("nbox::write_audit"), "log: {log_text}");
+    // The audit carries the field NAME "tags", the operation, and the outcome.
+    assert!(
+        log_text.contains("fields=\"tags\"") || log_text.contains("fields=tags"),
+        "field NAME recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("operation=\"update\"") || log_text.contains("operation=update"),
+        "operation recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("outcome=\"applied\"") || log_text.contains("outcome=applied"),
+        "outcome recorded: {log_text}"
+    );
+    // Redaction: the tag slug value and the token never leak.
+    assert!(
+        !log_text.contains("secret-nbox-token-12345"),
+        "token leaked: {log_text}"
+    );
+}

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -1953,7 +1953,7 @@ async fn ip_bare_without_address_is_a_usage_error() {
 
 // ===== tag add (ADR-0001 follow-on) =====================================
 //
-// The third write command reuses the same planner/diff/confirm/concurrency/
+// The fourth write command reuses the same planner/diff/confirm/concurrency/
 // audit contracts. Tags are a list field: the plan carries the full
 // replacement `{"tags": [slugs]}` (NetBox PATCH replaces the whole array).
 

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -2136,6 +2136,57 @@ async fn tag_add_unknown_tag_is_not_found_exit_4() {
 }
 
 #[tokio::test]
+async fn tag_add_ambiguous_ip_refuses_instead_of_first_picking() {
+    let server = MockServer::start().await;
+    mount_tag_by_name(&server, 5, "prod", "prod").await;
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/ip-addresses/"))
+        .and(wiremock::matchers::query_param("address", "192.0.2.10"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 2, "next": null, "previous": null,
+            "results": [
+                {
+                    "id": 101,
+                    "url": format!("{}/api/ipam/ip-addresses/101/", server.uri()),
+                    "address": "192.0.2.10/24",
+                    "vrf": {"id": 1, "name": "blue", "display": "blue"}
+                },
+                {
+                    "id": 102,
+                    "url": format!("{}/api/ipam/ip-addresses/102/", server.uri()),
+                    "address": "192.0.2.10/24",
+                    "vrf": {"id": 2, "name": "red", "display": "red"}
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_nbox([
+        "--config",
+        config.path().to_str().unwrap(),
+        "--no-tui",
+        "tag",
+        "add",
+        "ip",
+        "192.0.2.10",
+        "prod",
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert_error_contract(&out, 5, "IP address");
+    assert!(out.stderr.contains("ambiguous"), "stderr: {}", out.stderr);
+    assert_eq!(patch_count(&server).await, 0);
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        2,
+        "ambiguous IP should stop after tag lookup + candidate lookup"
+    );
+}
+
+#[tokio::test]
 async fn tag_add_confirm_without_allow_writes_is_a_usage_error() {
     let server = MockServer::start().await;
     let config = write_config(&server.uri());


### PR DESCRIPTION
## What

`nbox tag add <type> <name> <tag>` — the fourth safe write command on the ADR-0001 foundation. Adds a tag to any taggable object (device, IP, prefix, VLAN, site, rack, circuit, VM, …) via a minimal `PATCH` that replaces the full `tags` array, on the same gate/confirm/audit lifecycle as the interface/device pilots.

```
nbox tag add device edge01 prod --dry-run
nbox tag add device edge01 prod --allow-writes --confirm
nbox tag add device edge01 prod --allow-writes --confirm --message "tagging for prod"
```

### Why this is notable

- **First list-valued writable field.** Tags are an array, not a scalar — the plan carries the full replacement `{"tags": [slugs]}` (NetBox `PATCH` replaces the whole array), so the before/after diff shows tag slugs. The no-op path (tag already present) sends no `PATCH`.
- **First write on any object kind.** The planner reads the object as a raw `serde_json::Value` — every NetBox object carries the same `tags` array shape — so no per-kind model is needed. The target object resolves the same way as `nbox <kind> <ref>`; the tag resolves by id/name/slug (same resolver as `nbox tagged`).
- **Same concurrency contracts.** `ETag`+`If-Match` on 4.6+, `last_updated`+before-hash on pre-4.6, same as the interface/device pilots.

## Also: P2 audit fix folded in

Before building a new write on the foundation, an independent reviewer subagent audited the entire ADR-0001 write surface (8 commits since the last review SHA). The audit found the foundation **correct** (confidence 0.88, no critical issues). One P2 was folded into this PR:

> `confirm_token` didn't bind `operation` or `changelog_message` into the token hash — a plan's token didn't change if only the operation or message differed. Not exploitable in the current one-shot CLI flow (each invocation builds and immediately applies its own plan), but a defense-in-depth gap for future multi-step TUI/MCP flows where a reviewed plan might be re-applied with different intent.

**Fix:** `confirm_token` now binds `operation` and `changelog_message` alongside target/precondition/patch/profile/expiry. All planner call sites and test call sites updated.

Two P3s deferred (non-blocking polish): audit records HTTP status 0 on all apply errors (not just stale precondition); TTY prompt asks to confirm a no-op plan.

## Changes (11 files)

| File | Change |
|---|---|
| `src/cli.rs` | `TagAction` enum, `Command::Tag` variant, CLI parse test |
| `src/domain/detail.rs` | `plan_tag_add`, `apply_tag_add`, `resolve_tag_target_endpoint`, `tags_before_hash` |
| `src/lib.rs` | `run_tag_add` handler, `Command::Tag` dispatch arm |
| `src/netbox/mutation.rs` | `confirm_token` signature change (binds operation + message), test updates |
| `tests/write_tests.rs` | 9 integration tests (dry-run, apply, no-op, unknown tag, gate refusals, ETag, stale 412, audit) |
| 6 doc files | ROADMAP, CHANGELOG, AGENTS, README, FEATURES, ADR-0001 |

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all-targets` — **1272 tests pass** (9 new, up from 1263), 23 ignored, 0 failures
- Pre-commit hooks: `cargo fmt` + `cargo clippy` passed
