### PR TITLE
fix(write): audit real HTTP status on apply errors + no-op TTY short-circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same short-lived `nbox_get` cache entry, so an attached resource and the
   matching tool call do not re-fetch the same object graph within the cache TTL.
   `nbox_cache_clear` clears both paths.
+- **Write audit records the real HTTP status on apply errors.** The write
+  audit (target `nbox::write_audit`) now records the actual HTTP status code
+  on apply failures — `412` for a stale precondition, `400` for a NetBox
+  validation rejection, or the `Api` status for other HTTP failures — instead
+  of the placeholder `0`. Non-HTTP errors (network, pre-4.6 re-read refusal)
+  still record `0` since no HTTP response was received. `NboxError::http_status`
+  is the new accessor (ADR-0001 §8).
+- **TTY no-op short-circuit.** When a write plan is a no-op (e.g. adding a tag
+  the object already carries, or setting a status to its current value) and the
+  operator is on a TTY without `--confirm`, the plan now short-circuits to a
+  "no change — nothing to apply" receipt without prompting for confirmation.
 
 ## [0.13.0] - 2026-06-25
 

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -417,7 +417,7 @@ pub(crate) async fn apply_interface_description_update(
 
 /// Build a no-op receipt: the current value already matches, so no `PATCH` is
 /// sent. ADR-0001 §8 wording: "no change: current value already matches".
-fn no_op_receipt(plan: &MutationPlan) -> MutationReceipt {
+pub(crate) fn no_op_receipt(plan: &MutationPlan) -> MutationReceipt {
     MutationReceipt {
         schema_version: PLAN_SCHEMA_VERSION,
         operation: plan.operation,

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,21 @@ impl NboxError {
         }
     }
 
+    /// The HTTP status code for a write-apply error, if it can be determined.
+    /// `StalePrecondition` → 412, `WriteValidation` → 400, `Api { status, .. }`
+    /// → that status. Other variants (usage, not-found, network) return `None`.
+    /// Used by the write audit to record the real HTTP status on apply errors
+    /// instead of the placeholder `0` (ADR-0001 §8).
+    #[must_use]
+    pub fn http_status(&self) -> Option<u16> {
+        match self {
+            NboxError::StalePrecondition(_) => Some(412),
+            NboxError::WriteValidation(_) => Some(400),
+            NboxError::Api { status, .. } => Some(*status),
+            _ => None,
+        }
+    }
+
     /// The exit code for any error: the most specific [`NboxError`] in the chain,
     /// else `1`.
     pub fn exit_code_for(err: &anyhow::Error) -> i32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1404,13 +1404,34 @@ async fn apply_or_preview(
     }
 
     // 5) confirm. On a plain TTY without `--confirm`, show the diff then prompt.
+    //    A no-op short-circuits before the prompt — nothing to confirm.
     if action == WriteAction::Prompt {
+        if plan.no_op {
+            // A no-op sends no PATCH and needs no confirmation. Emit the
+            // no-op receipt directly (same as the apply path's short-circuit).
+            render_plan_plain(plan);
+            eprintln!("\nno change — nothing to apply.");
+            let receipt = detail::no_op_receipt(plan);
+            audit_event(
+                Surface::Cli,
+                profile,
+                host,
+                plan,
+                &field_names,
+                Outcome::NoOp,
+                plan.operation.http_method(),
+                &plan.target.endpoint,
+                0,
+                0, // no network round-trip — short-circuited before apply
+                message_present,
+                message_len,
+            )
+            .emit();
+            let _ = emit(ctx, &receipt, || render_receipt_plain(&receipt));
+            return Ok(());
+        }
         // The diff goes to stdout (the operator's review); the prompt to stderr.
         render_plan_plain(plan);
-        if plan.no_op {
-            // A no-op needs no confirmation — nothing would change. Still emit
-            // the dry-plan-style line and let the apply path short-circuit.
-        }
         eprintln!();
         eprint!("Apply this change to NetBox? [y/N] ");
         let _ = std::io::stderr().flush();
@@ -1474,11 +1495,13 @@ async fn apply_or_preview(
         Err(e) => {
             // Classify the error for the audit outcome (ADR §8), then return the
             // error so the stable exit code + stderr message reach the process.
-            let outcome = classify_apply_error(&e);
+            let (outcome, http_status) = classify_apply_error(&e);
             // For the pre-4.6 stale path the refusal happens on the re-read
-            // (no PATCH sent); the 4.6+ 412 happens on the PATCH. Either way the
-            // attempt targeted the PATCH endpoint — record it, status 0 since
-            // the error variants don't surface the HTTP status.
+            // (no PATCH sent); the 4.6+ 412 happens on the PATCH. Either way
+            // the attempt targeted the PATCH endpoint. `http_status` carries
+            // the real HTTP status when it can be determined (412 for stale,
+            // 400 for validation, the Api status for other HTTP failures);
+            // 0 when the error has no HTTP status (network, pre-4.6 re-read).
             audit_event(
                 Surface::Cli,
                 profile,
@@ -1488,7 +1511,7 @@ async fn apply_or_preview(
                 outcome,
                 plan.operation.http_method(),
                 &plan.target.endpoint,
-                0,
+                http_status,
                 sw.elapsed_ms(),
                 message_present,
                 message_len,
@@ -1697,21 +1720,24 @@ async fn run_tag_add(
 /// (412 or pre-4.6 before-hash mismatch) is a recoverable refusal; a 400 is a
 /// NetBox validation rejection; anything else (network, auth, 5xx) is a plain
 /// error. Walks the chain so a `.context(...)`-wrapped typed error still maps.
-fn classify_apply_error(e: &anyhow::Error) -> write_audit::Outcome {
+fn classify_apply_error(e: &anyhow::Error) -> (write_audit::Outcome, u16) {
     use crate::netbox::write_audit::Outcome;
-    if e.chain().any(|c| {
-        c.downcast_ref::<error::NboxError>()
-            .is_some_and(|n| matches!(n, error::NboxError::StalePrecondition(_)))
-    }) {
-        Outcome::Stale
-    } else if e.chain().any(|c| {
-        c.downcast_ref::<error::NboxError>()
-            .is_some_and(|n| matches!(n, error::NboxError::WriteValidation(_)))
-    }) {
-        Outcome::Validation
-    } else {
-        Outcome::Error
+    // Walk the chain for the most specific typed error. The first NboxError
+    // that maps to an outcome wins; its HTTP status (if any) is recorded in
+    // the audit so a 400 validation rejection or a 412 stale precondition
+    // logs the real status, not the placeholder 0 (ADR-0001 §8, P3 fix).
+    for cause in e.chain() {
+        if let Some(n) = cause.downcast_ref::<error::NboxError>() {
+            let status = n.http_status().unwrap_or(0);
+            let outcome = match n {
+                error::NboxError::StalePrecondition(_) => Outcome::Stale,
+                error::NboxError::WriteValidation(_) => Outcome::Validation,
+                _ => Outcome::Error,
+            };
+            return (outcome, status);
+        }
     }
+    (Outcome::Error, 0)
 }
 
 /// Build a [`WriteAuditEvent`] from a plan's target + the resolved outcome.


### PR DESCRIPTION
## What

Two P3 audit findings from the independent write-foundation audit, now fixed:

### 1. Audit records real HTTP status on apply errors

The write audit (target `nbox::write_audit`) recorded `status: 0` for **all** apply failures, losing signal. A 412 stale precondition and a 400 validation rejection both looked the same in the audit log.

**Fix:** `classify_apply_error` now walks the error chain and extracts the real HTTP status via the new `NboxError::http_status()` accessor — 412 for `StalePrecondition`, 400 for `WriteValidation`, or the `Api { status, .. }` value for other HTTP failures. Non-HTTP errors (network, pre-4.6 re-read refusal) still record 0 since no HTTP response was received.

### 2. TTY no-op prompt short-circuit

When a write plan was a no-op (e.g. adding a tag the object already carries, or setting a status to its current value) and the operator was on a TTY without `--confirm`, the code displayed the diff, then prompted "Apply this change to NetBox? [y/N]" — asking for confirmation of nothing.

**Fix:** The no-op case now short-circuits before the prompt, emitting a "no change — nothing to apply" receipt directly.

## Changes (4 files)

| File | Change |
|---|---|
| `src/error.rs` | `NboxError::http_status()` accessor (412/400/Api status) |
| `src/lib.rs` | `classify_apply_error` returns `(Outcome, u16)`; no-op TTY short-circuit before prompt |
| `src/domain/detail.rs` | `no_op_receipt` made `pub(crate)` (used by the short-circuit) |
| `CHANGELOG.md` | Both fixes documented |

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --all-targets` — **1273 tests pass**, 23 ignored, 0 failures
- Pre-commit hooks: `cargo fmt` + `cargo clippy` passed
