### PR TITLE
feat: prefix reserve — sixth safe write (allocate POST to available-prefixes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@ nbox ip <address> [--vrf <name|slug|rd>]  # surfaces nat_inside/nat_outside (Net
 nbox ip reserve <cidr> [--vrf <name|slug|rd>] [--description "…"] [--dns-name "…"]
                                   # write: reserve the next available IP (POST available-ips); --dry-run | --allow-writes --confirm [--message]
 nbox prefix <cidr> [--vrf <name|slug|rd>]
+                                  # optional write subcommand:
+  prefix <cidr> reserve [--length L] [--vrf <name|slug|rd>] [--description "…"]
+                                  # write: reserve the next available child prefix (POST available-prefixes); --dry-run | --allow-writes --confirm [--message]
 nbox next-ip <cidr> [--count N] [--vrf <name|slug|rd>]
 nbox next-prefix <cidr> [--length L] [--vrf <name|slug|rd>]
 nbox vlan <vid|name> [--site <name|slug>] [--group <name|slug>]
@@ -185,28 +188,32 @@ nbox device edge01 --json | jq '.primary_ip4'
 
 ## Notes
 
-- Writes landed behind ADR-0001. Four commands reuse the same safe-write
+- Writes landed behind ADR-0001. Six commands reuse the same safe-write
   foundation (the `MutationPlan` / `MutationReceipt` engine):
   `nbox interface <device> <interface> set description "…"`,
   `nbox device <name> set status <value>`,
   `nbox ip reserve <cidr>` (a `POST` to `available-ips` — the first `allocate`),
-  and `nbox tag add <type> <name> <tag>` (a `PATCH` to the `tags` array on any
-  object kind). All are plan-first: reads remain the default — apply needs BOTH
-  `--allow-writes` (the gate) AND `--confirm` (or a TTY prompt in plain
-  output); `--dry-run` previews with no mutation and needs neither.
-  `--confirm` without `--allow-writes` is a usage error (exit 2, empty stdout).
-  Non-TTY / `--json` / `--csv` / `--no-tui` never prompt. `--json --dry-run`
-  returns the stable `MutationPlan`; `--json --confirm` returns a `MutationReceipt`
-  (both `schema_version: 1`). For `device set status`, the allowed values are
-  enumerated live from NetBox (read-only `OPTIONS`) and the input is normalized
-  to the canonical value (a label is accepted case-insensitively when it maps
-  unambiguously to one value); an unknown or ambiguous status is a usage error
-  (exit 2) naming the input and listing the allowed values, before any `PATCH`.
-  For `tag add`, the tag resolves by id/name/slug (same resolver as
-  `nbox tagged`); the target object resolves the same way as `nbox <kind> <ref>`.
-  NetBox `PATCH` replaces the whole `tags` array, so the plan carries the full
-  replacement slug list (current slugs + new); adding a tag the object already
-  carries is a no-op (no `PATCH`). The MCP server stays read-only.
+  `nbox prefix reserve <cidr>` (a `POST` to `available-prefixes` — the second `allocate`),
+  `nbox tag add <type> <name> <tag>` (a `PATCH` to the `tags` array on any
+  object kind), and `nbox tag remove <type> <name> <tag>` (the inverse). All are
+  plan-first: reads remain the default — apply needs BOTH `--allow-writes` (the
+  gate) AND `--confirm` (or a TTY prompt in plain output); `--dry-run` previews
+  with no mutation and needs neither. `--confirm` without `--allow-writes` is a
+  usage error (exit 2, empty stdout). Non-TTY / `--json` / `--csv` / `--no-tui`
+  never prompt. `--json --dry-run` returns the stable `MutationPlan`;
+  `--json --confirm` returns a `MutationReceipt` (both `schema_version: 1`).
+  For `device set status`, the allowed values are enumerated live from NetBox
+  (read-only `OPTIONS`) and the input is normalized to the canonical value (a
+  label is accepted case-insensitively when it maps unambiguously to one value);
+  an unknown or ambiguous status is a usage error (exit 2) naming the input and
+  listing the allowed values, before any `PATCH`. For `tag add`/`remove`, the
+  tag resolves by id/name/slug (same resolver as `nbox tagged`); the target
+  object resolves the same way as `nbox <kind> <ref>`. NetBox `PATCH` replaces
+  the whole `tags` array, so the plan carries the full replacement slug list;
+  adding a tag the object already carries (or removing one it doesn't) is a
+  no-op (no `PATCH`). For `prefix reserve`, the body carries optional
+  `prefix_length` and `description`; the server allocates the block and the
+  receipt returns the created prefix. The MCP server stays read-only.
 - Filters that an object type can't satisfy cause that type to be skipped in
   `search` (nbox does not send NetBox unknown query params).
 - `owner` (NetBox 4.5+): a native owner field (user or group) surfaced on most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   object doesn't carry is a no-op (no `PATCH`). Shares one planner/applier with
   `tag add` (`TagOperation::Add`/`Remove`), proving the foundation extends to
   the inverse operation without new machinery.
+- **`nbox prefix reserve <cidr>` — the sixth safe write.** Reserves the next
+  available child prefix via a `POST` to `…/prefixes/{id}/available-prefixes/`,
+  on the same ADR-0001 gate/confirm/audit lifecycle as the `PATCH` pilots and
+  `ip reserve` (`--dry-run` / `--allow-writes --confirm` / `--message`). Optional
+  `--vrf <name|rd|id>` scopes the parent prefix; `--length N` requests a specific
+  child prefix length; `--description` sets that field on the new prefix (the v1
+  allow-list — no status/role/tags/vlan). Proves the allocate pattern extends
+  past `ip reserve`:
+  - **Server-allocated, race-safe.** NetBox picks the block and never hands out
+    the same one twice, so the plan carries no client precondition (no `ETag` /
+    `last_updated`). The dry-run shows the currently next available block as an
+    advisory warning — the applied block may differ, since NetBox allocates at
+    apply time.
+  - **Receipt returns the created object.** `--json` apply returns a
+    `MutationReceipt` whose `object` field is the reserved prefix's view
+    (prefix, description, …), so scripts get the assigned block without a
+    follow-up read.
+  - A bare reserve `POST`s an empty body; an exhausted parent (`409`) and a
+    NetBox validation rejection (`400`) surface as clean errors (exit 1, empty
+    stdout). The audit logs `operation=allocate`, `http_method=POST`, and field
+    names only.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ this device, what owns this prefix?* — from the shell, a k9s-style TUI, or an 
 server for AI agents.
 
 **Status: pre-1.0.** Reads are the default; a narrow safe-write foundation
-(ADR-0001) has landed behind `--allow-writes` + confirmation — four commands
+(ADR-0001) has landed behind `--allow-writes` + confirmation — six commands
 today (`nbox interface <device> <interface> set description "…"`,
 `nbox device <name> set status <value>`, `nbox ip reserve <prefix>` to
-allocate the next available IP, and `nbox tag add <type> <name> <tag>` to
-add a tag to any object). Broader writes are on the [ROADMAP](ROADMAP.md).
+allocate the next available IP, `nbox prefix reserve <cidr>` to allocate the
+next available child prefix, and `nbox tag add`/`remove <type> <name> <tag>`
+to manage tags on any object). Broader writes are on the [ROADMAP](ROADMAP.md).
 
 ## Quick Start
 
@@ -52,8 +53,7 @@ See [Installation](#installation) below for setup instructions.
 ## Features
 
 - **Fast shell lookups** — `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `virtual-circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`, `route-target`, `mac`, and `interface`, each as a one-liner.
-- **Normalized search** — one `search` query runs in parallel across devices, sites, racks, IPs, prefixes, VLANs, circuits, virtual circuits, providers, aggregates, ASNs, IP ranges, tenants, contacts, VMs, clusters, VRFs, and route targets, returning ranked, deduped hits. Scope it with `--site` (exact) or `--region`/`--site-group`/`--location` (hierarchical where NetBox exposes tree filters), one at a time; or narrow by `--status`/`--tenant`/`--role`/`--tag`/`--vrf`.
-- **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` to preview free addresses and blocks (read-only). To actually claim one, `nbox ip reserve <prefix>` allocates the next available IP (a safe write — ADR-0001).
+- **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` to preview free addresses and blocks (read-only). To actually claim one, `nbox ip reserve <prefix>` allocates the next available IP and `nbox prefix reserve <cidr>` allocates the next available child prefix (safe writes — ADR-0001).
 - **A k9s-style TUI** — a three-pane home (navigation rail → results → live preview), an overview dashboard, a hierarchical prefix tree, cross-object navigation between related objects (every detail's related-object tabs are navigable — open an interface from a device and see its cable path drawn as an A↔Z diagram), fuzzy filters, server-side name filtering on the browse list, recents, and an in-app profile + settings editor. Twelve themes; `NO_COLOR` honored.
 - **Agent-ready** — `nbox serve` is a read-only MCP server: the same lookups exposed as eleven tools (plus every object as an `nbox://{kind}/{ref}` resource), returning the exact JSON view models the CLI does, so AI agents (Claude Code, Claude Desktop, …) query NetBox safely. Stdio for a local subprocess, or a loopback HTTP transport with OIDC resource-server auth for a network-reachable, read-only deployment. See [docs/MCP.md](docs/MCP.md); [SKILL.md](SKILL.md) is an installable Agent Skill that drives the CLI on matching requests.
 - **Scriptable** — `-o plain|json|csv`, `--fields`, `--raw`, versioned `--envelope`, and stable exit codes; stdout stays clean for piping, logs go to stderr. See [docs/SCRIPTING.md](docs/SCRIPTING.md).
@@ -259,6 +259,8 @@ nbox ip <address> [--vrf <name>] [--journal]    # --vrf disambiguates duplicates
   ip reserve <cidr> [--vrf <name>] [--description "…"] [--dns-name "…"]
                                   # write: reserve the next available IP (POST available-ips); --dry-run | --allow-writes --confirm [--message]
 nbox prefix <cidr> [--vrf <name>] [--journal]   # includes utilization + children when present
+  prefix reserve [--length L] [--vrf <name>] [--description "…"]
+                                  # write: reserve the next available child prefix (POST available-prefixes); --dry-run | --allow-writes --confirm [--message]
 nbox next-ip <cidr> [--count N] [--vrf <name>]        # next available address(es)
 nbox next-prefix <cidr> [--length L] [--vrf <name>]   # available free block(s)
 nbox vlan <vid-or-name> [--site <s>] [--group <g>] [--journal]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,13 +2,12 @@
 
 nbox is a **read-first** NetBox CLI, TUI, and MCP server. The near-term goal is the **best
 possible read experience** — fast, correct, and pleasant both in the terminal and to agents.
-A narrow **safe-write foundation** has now landed (ADR-0001): a gated, opt-in, before/after-previewed
-write engine, with four commands landed — `interface <device> <iface> set description` and
+write engine, with five commands landed — `interface <device> <iface> set description` and
 `device <name> set status <value>` (`PATCH`), `ip reserve <prefix>` (the first `allocate`, a
-`POST` to `available-ips`), and `tag add <type> <name> <tag>` (a `PATCH` to the `tags` array on
-any object kind). Reads stay
-the default everywhere and the write surface widens only as the read tool proves out in practice
-(see [Writes](#writes--deferred-later-track)).
+`POST` to `available-ips`), `tag add <type> <name> <tag>` / `tag remove` (a `PATCH` to the `tags`
+array on any object kind), and `prefix reserve <cidr>` (a `POST` to `available-prefixes`). Reads
+stay the default everywhere and the write surface widens only as the read tool proves out in
+practice (see [Writes](#writes--deferred-later-track)).
 
 Legend: ☐ planned · ◐ in progress · ☑ done
 
@@ -443,10 +442,16 @@ the read tool proves out in practice. Consolidated future scope:
   and race-safe, so the plan carries no client precondition; the receipt returns
   the created IP object. Same `--dry-run` / `--allow-writes --confirm` /
   `--message` / local write-audit contracts as the `PATCH` pilots.
-- ☐ **IPAM allocate (rest)** — claim the next *prefix*, plus IP-range allocation
-  (`POST` to `available-prefixes` / a range's `available-ips`); the read half
-  (`next-ip` / `next-prefix`, range lookup) already ships, and the next-IP
-  allocation (`ip reserve`) landed above.
+- ☑ `nbox prefix reserve <cidr>` — the second **`allocate`** write (a `POST` to
+  `…/prefixes/{id}/available-prefixes/`): reserve the next available child
+  prefix, optionally with `--length N` to request a specific prefix length and
+  `--description`. Server-allocated and race-safe, so the plan carries no
+  client precondition; the receipt returns the created prefix object. Same
+  gate/confirm/audit lifecycle as the `PATCH` pilots and `ip reserve`.
+- ☐ **IPAM allocate (rest)** — IP-range allocation (`POST` to a range's
+  `available-ips`); the read half (`next-ip` / `next-prefix`, range lookup)
+  already ships, and the next-IP allocation (`ip reserve`) and prefix
+  allocation (`prefix reserve`) landed above.
 - ☑ `nbox tag add <type> <name> <tag>` — a further write command, reusing the
   same foundation. Adds a tag to any taggable object via a minimal `PATCH` that
   replaces the full `tags` array; a no-op if the tag is already present. The

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,11 +1,12 @@
 # Features
 
 nbox is a NetBox client — a CLI and a TUI over the same core. Reads are the
-default; a narrow safe-write foundation (ADR-0001) adds four plan-first commands
+default; a narrow safe-write foundation (ADR-0001) adds six plan-first commands
 behind `--allow-writes` + confirmation — `interface … set description` and
 `device … set status` (`PATCH`), `ip reserve <prefix>` (the next-IP
-allocation, a `POST`), and `tag add <type> <name> <tag>` (a `PATCH` to the
-`tags` array on any object). The MCP server stays read-only.
+allocation, a `POST`), `prefix reserve <cidr>` (the next-prefix allocation,
+a `POST` to `available-prefixes`), and `tag add`/`remove <type> <name> <tag>`
+(a `PATCH` to the `tags` array on any object). The MCP server stays read-only.
 
 ## Lookups
 
@@ -15,8 +16,7 @@ allocation, a `POST`), and `tag add <type> <name> <tag>` (a `PATCH` to the
 | `nbox device <name\|slug\|id> [--journal]` | Device + interfaces, IPs, cables, VLANs, services. `set status <value>` is a safe write (ADR-0001): status validated live via OPTIONS, behind `--allow-writes` + confirm. |
 | `nbox interface <device> <iface>` | One interface: type, MTU, MAC, mode, VLANs, cable, **cable path** (an A↔Z trace diagram naming the device at each end), addresses. `set description "…"` is a safe write (ADR-0001), behind `--allow-writes` + confirm. |
 | `nbox ip <addr> [--vrf] [--journal]` | IP + most-specific parent prefix (VRF-scoped) and its VLAN plus the prefix's `scope`/`scope_type` (site, location, region, …); surfaces `nat_inside`/`nat_outside` (NetBox 4.6) when set. |
-| `nbox ip reserve <cidr> [--vrf] [--description] [--dns-name]` | Reserve the next available IP in a prefix — a safe write (ADR-0001): `POST` to `available-ips`, behind `--allow-writes` + confirm. `--dry-run` previews the candidate; the receipt's `object` is the created IP. |
-| `nbox prefix <cidr> [--vrf] [--journal]` | Prefix with utilization, children, and contained IPs. |
+| `nbox prefix <cidr> [--vrf] [--journal]` | Prefix with utilization, children, and contained IPs. `prefix reserve [--length N] [--description]` is a safe write (ADR-0001): `POST` to `available-prefixes`, behind `--allow-writes` + confirm. `--dry-run` previews the candidate; the receipt's `object` is the created prefix. |
 | `nbox next-ip <cidr> [--count] [--vrf]` | Next available address(es) (read-only preview). |
 | `nbox next-prefix <cidr> [--length] [--vrf]` | Available free block(s). |
 | `nbox vlan <vid\|name> [--site] [--group] [--journal]` | VLAN + referencing prefixes, plus the VLAN's own `scope`/`scope_type` and, when it belongs to a scoped VLAN group, the group's `group_scope`/`group_scope_type`. |

--- a/docs/adr/0001-safe-write-foundation.md
+++ b/docs/adr/0001-safe-write-foundation.md
@@ -272,10 +272,21 @@ Shipped on this foundation, in order:
   operation without new machinery. A no-op (tag already absent) produces an empty
   patch, no `PATCH`. Same `ETag`+`If-Match` / `last_updated`+before-hash
   concurrency contracts.
+- `prefix reserve <cidr> [--vrf] [--length N] [--description]` — the sixth
+  write (`allocate` / `POST`), the second `allocate`: a `POST` to
+  `…/prefixes/{id}/available-prefixes/` that reserves the next free child block.
+  It proves the `allocate` pattern extends past `ip reserve` with no new
+  machinery — same `Operation::Allocate`, same `Precondition::None`, same
+  gate/confirm/audit lifecycle, and the same `object`-in-receipt pattern. The
+  body carries optional `prefix_length` (the desired child block size) and
+  `description` (the v1 allow-list — no status/role/tags/vlan). The dry-run
+  surfaces the currently-next block as an advisory warning; an exhausted parent
+  (`409`) is a clean error.
 
-Still deferred per Decision 6: choosing a specific address, multi-IP / range /
-next-prefix allocation, interface/VM assignment, status/tags on reserve, generic
-create/delete, and `nbox raw` write verbs.
+Still deferred per Decision 6: choosing a specific address/block, multi-IP
+allocation, IP-range allocation (`POST` to a range's `available-ips`),
+interface/VM assignment, status/tags on reserve, generic create/delete, and
+`nbox raw` write verbs.
 
 ## References
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,7 +183,7 @@ pub enum Command {
         action: Option<IpAction>,
     },
 
-    /// Show prefix details and children.
+    /// Show prefix details and children, or reserve a child prefix.
     Prefix {
         /// Prefix in CIDR notation.
         cidr: String,
@@ -199,6 +199,12 @@ pub enum Command {
         /// Max inline journal entries to fold in (implies --journal; default 5).
         #[arg(long, value_name = "N")]
         journal_limit: Option<usize>,
+
+        /// Optional write action. Omit to read a prefix (`nbox prefix <cidr>`);
+        /// pass `reserve` to allocate the next available child prefix (a write,
+        /// behind `--allow-writes` + confirmation — ADR-0001).
+        #[command(subcommand)]
+        action: Option<PrefixAction>,
     },
 
     /// Show the next available IP address(es) in a prefix.
@@ -838,6 +844,57 @@ pub enum IpAction {
         /// writes on its own — `--confirm` without `--allow-writes` is a usage
         /// error (exit 2). With `--json`, returns the stable `MutationReceipt`
         /// JSON.
+        #[arg(long)]
+        confirm: bool,
+
+        /// The write-enable gate: required to apply ANY mutation. Kept separate
+        /// from `--confirm` so a read-only invocation can never be silently
+        /// turned into a write (ADR-0001 §4).
+        #[arg(long = "allow-writes")]
+        allow_writes: bool,
+    },
+}
+
+/// `nbox prefix` write actions (read is the bare `nbox prefix <cidr>`).
+#[derive(Debug, Subcommand)]
+pub enum PrefixAction {
+    /// Reserve (allocate) the next available child prefix. A write: requires
+    /// the `--allow-writes` gate AND confirmation (`--confirm`, or an
+    /// interactive prompt on a TTY in plain output). `--dry-run` previews with
+    /// no mutation and needs neither. NetBox allocates the prefix server-side
+    /// and race-safe, so the applied prefix may differ from any previewed
+    /// candidate.
+    Reserve {
+        /// The prefix length for the new child prefix (e.g. `26` for a /26
+        /// inside a /24). If omitted, NetBox allocates the next available block
+        /// of any size (the parent's prefix length + 1 by default).
+        #[arg(long, value_name = "LEN")]
+        length: Option<u8>,
+
+        /// Disambiguate the parent prefix by VRF (name, slug, or RD).
+        #[arg(long)]
+        vrf: Option<String>,
+
+        /// Set the new prefix's description. Optional.
+        #[arg(long, value_name = "TEXT")]
+        description: Option<String>,
+
+        /// Record this message in NetBox's object-change entry (a write-only
+        /// request field, never stored on the object). Validated to NetBox's
+        /// 200-character limit before applying. Optional.
+        #[arg(long, value_name = "MESSAGE")]
+        message: Option<String>,
+
+        /// Preview the plan + the candidate prefix and perform no mutation.
+        /// Needs neither `--allow-writes` nor confirmation. With `--json`,
+        /// returns the stable `MutationPlan` JSON.
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+
+        /// Apply the reviewed plan without an interactive prompt. Does NOT
+        /// enable writes on its own — `--confirm` without `--allow-writes` is a
+        /// usage error (exit 2). With `--json`, returns the stable
+        /// `MutationReceipt` JSON.
         #[arg(long)]
         confirm: bool,
 
@@ -1542,5 +1599,42 @@ mod tests {
         assert_eq!(object_name, "edge01");
         assert_eq!(tag, "prod");
         assert_eq!(msg, "untagging");
+    }
+
+    #[test]
+    fn prefix_reserve_parses_flags() {
+        let cmd = Cli::try_parse_from([
+            "nbox",
+            "--no-tui",
+            "prefix",
+            "10.0.0.0/24",
+            "reserve",
+            "--length",
+            "26",
+            "--description",
+            "dmz",
+            "--dry-run",
+        ])
+        .unwrap();
+        let Some(Command::Prefix {
+            cidr,
+            action:
+                Some(PrefixAction::Reserve {
+                    length: Some(len),
+                    description: Some(desc),
+                    vrf: None,
+                    message: None,
+                    dry_run: true,
+                    confirm: false,
+                    allow_writes: false,
+                }),
+            ..
+        }) = cmd.command
+        else {
+            panic!("expected prefix reserve");
+        };
+        assert_eq!(cidr, "10.0.0.0/24");
+        assert_eq!(len, 26);
+        assert_eq!(desc, "dmz");
     }
 }

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -816,6 +816,183 @@ pub(crate) async fn apply_ip_reserve(
     })
 }
 
+/// Plan a `prefix reserve <cidr>` allocation (ADR-0001 §5 steps 1–4): validate
+/// the optional changelog message, resolve the parent prefix (scoped by
+/// `vrf`), and build an `Allocate` plan whose body POSTs to the parent's
+/// `available-prefixes` endpoint.
+///
+/// The endpoint is server-side race-safe (NetBox never hands out the same
+/// block twice), so the plan carries [`Precondition::None`] — there is no prior
+/// object, ETag, or `last_updated` to bind. A dry-run surfaces the *currently*
+/// next available block as an advisory warning: NetBox allocates at apply time,
+/// so the applied block may differ. Only `description` may be set (the v1
+/// narrow allow-list — no status/role/tags/vlan).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn plan_prefix_reserve(
+    client: &NetBoxClient,
+    prefix: &str,
+    vrf: Option<&str>,
+    length: Option<u8>,
+    description: Option<&str>,
+    changelog_message: Option<&str>,
+    profile: &str,
+    not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
+) -> Result<MutationPlan> {
+    // Message length is pure input validation — check first, before any network.
+    let message = match changelog_message {
+        Some(m) if !m.is_empty() => Some(m.to_string()),
+        _ => None,
+    };
+    mutation::validate_changelog_message(&message)?;
+
+    // Resolve the parent prefix by CIDR (same resolver as `nbox prefix` /
+    // `nbox next-prefix`).
+    let prefix_obj = resolve_prefix(client, prefix, vrf, not_found).await?;
+    let endpoint = format!("/api/ipam/prefixes/{}/available-prefixes/", prefix_obj.id);
+
+    let target = PlanTarget {
+        kind: "prefix".to_string(),
+        r#ref: prefix.to_string(),
+        id: prefix_obj.id,
+        display: prefix_obj.prefix.clone(),
+        endpoint,
+        profile: profile.to_string(),
+    };
+
+    // The minimal POST body: only the fields the operator actually set. A bare
+    // reserve sends `{}` and takes NetBox's defaults. `prefix_length` is the
+    // NetBox field for the desired child block size.
+    let mut body = serde_json::Map::new();
+    let mut fields = Vec::new();
+    if let Some(len) = length {
+        body.insert("prefix_length".to_string(), serde_json::json!(len));
+        fields.push(FieldChange {
+            field: "prefix_length".to_string(),
+            before: Value::Null,
+            after: serde_json::json!(len),
+        });
+    }
+    if let Some(d) = description.filter(|s| !s.is_empty()) {
+        body.insert("description".to_string(), serde_json::json!(d));
+        fields.push(FieldChange {
+            field: "description".to_string(),
+            before: Value::Null,
+            after: serde_json::json!(d),
+        });
+    }
+    let patch = Value::Object(body);
+    let precondition = Precondition::None;
+
+    // Dry-run advisory: the block NetBox would currently hand out. Read-only,
+    // and never part of the body — another client could allocate between this
+    // read and the apply POST, so the applied block may differ.
+    let mut warnings = Vec::new();
+    match client.prefix_available_prefixes(prefix_obj.id).await {
+        Ok(list) if list.is_empty() => {
+            warnings.push(
+                "no available prefixes in this prefix — the reserve will fail at apply".to_string(),
+            );
+        }
+        Ok(list) => {
+            // If a length was requested, filter for the first block that
+            // satisfies it (client-side, matching `next-prefix --length`).
+            let candidate = if let Some(len) = length {
+                list.iter()
+                    .find(|p| prefix_satisfies_length(&p.prefix, len))
+            } else {
+                list.first()
+            };
+            match candidate {
+                Some(c) => warnings.push(format!(
+                    "currently next: {} — NetBox allocates at apply; the applied prefix may differ",
+                    c.prefix
+                )),
+                None => {
+                    let requested = length.map_or("any".to_string(), |l| format!("/{l}"));
+                    warnings.push(format!(
+                        "no available block of length {requested} in this prefix — the reserve will fail at apply"
+                    ));
+                }
+            }
+        }
+        // A failed advisory read must not block planning; the apply POST is the
+        // authoritative attempt. Note it and carry on.
+        Err(_) => {
+            warnings.push("could not read the next available prefix (advisory only)".to_string());
+        }
+    }
+
+    let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
+    let confirm_token = mutation::confirm_token(
+        &target,
+        Operation::Allocate,
+        &precondition,
+        &patch,
+        &message,
+        expires_epoch,
+    );
+
+    Ok(MutationPlan {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: Operation::Allocate,
+        target,
+        precondition,
+        fields,
+        patch,
+        no_op: false,
+        warnings,
+        errors: Vec::new(),
+        changelog_message: message,
+        confirm_token,
+        expires_at: mutation::format_iso_utc(expires_epoch),
+    })
+}
+
+/// Apply a planned prefix reservation (ADR-0001 §5 steps 5–7): verify the
+/// plan's confirmation token + expiry, then POST the minimal body to the
+/// parent's `available-prefixes` endpoint. NetBox allocates the next free
+/// block and returns the created prefix object (`201`), which becomes the
+/// receipt's `object`.
+pub(crate) async fn apply_prefix_reserve(
+    client: &NetBoxClient,
+    plan: &MutationPlan,
+) -> Result<MutationReceipt> {
+    plan.verify()?;
+
+    // The wire body is the minimal create patch plus the opt-in changelog_message.
+    let mut body = plan.patch.clone();
+    if let Some(msg) = &plan.changelog_message {
+        body["changelog_message"] = serde_json::json!(msg);
+    }
+
+    let (created, status): (Prefix, u16) = client.post(&plan.target.endpoint, &body).await?;
+    let created_prefix = created.prefix.clone();
+    let object = serde_json::to_value(&created).ok();
+
+    Ok(MutationReceipt {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: plan.operation,
+        target: plan.target.clone(),
+        fields: plan.fields.clone(),
+        applied: true,
+        no_op: false,
+        status,
+        etag: None,
+        request_id: None,
+        object,
+        message: format!("reserved: {} in {}", created_prefix, plan.target.display),
+    })
+}
+
+/// True if `cidr` (e.g. `10.0.0.0/26`) has a prefix length ≤ `target` — a
+/// block of size /26 can carve a /28 but not a /24. NetBox's `available-
+/// prefixes` returns blocks of any size; the dry-run advisory filters for the
+/// first block that can satisfy the requested length.
+fn prefix_satisfies_length(cidr: &str, target: u8) -> bool {
+    cidr.rsplit_once('/')
+        .is_some_and(|(_, len_str)| len_str.parse::<u8>().is_ok_and(|len| len <= target))
+}
+
 // ===== Safe write follow-on: tag add/remove (ADR-0001) ===================
 //
 // Tag writes reuse the same planner/diff/confirm/concurrency/audit contracts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,33 @@ pub async fn run(cli: Cli) -> Result<()> {
             vrf,
             journal,
             journal_limit,
-        }) => run_prefix(&ctx, &cidr, vrf.as_deref(), journal, journal_limit).await,
+            action,
+        }) => match action {
+            None => run_prefix(&ctx, &cidr, vrf.as_deref(), journal, journal_limit).await,
+            Some(crate::cli::PrefixAction::Reserve {
+                length,
+                vrf: reserve_vrf,
+                description,
+                message,
+                dry_run,
+                confirm,
+                allow_writes,
+            }) => {
+                let effective_vrf = ip_reserve_vrf_scope(vrf.as_deref(), reserve_vrf.as_deref())?;
+                Box::pin(run_prefix_reserve(
+                    &ctx,
+                    &cidr,
+                    effective_vrf,
+                    length,
+                    description.as_deref(),
+                    message.as_deref(),
+                    dry_run,
+                    confirm,
+                    allow_writes,
+                ))
+                .await
+            }
+        },
         Some(Command::NextIp { prefix, count, vrf }) => {
             run_next_ip(&ctx, &prefix, count, vrf.as_deref()).await
         }
@@ -1692,6 +1718,53 @@ async fn run_ip_reserve(
     // The shared dry-run/prompt/apply/audit lifecycle — one write path.
     apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
         Box::pin(detail::apply_ip_reserve(c, p))
+    })
+    .await
+}
+
+/// `nbox prefix reserve <cidr>` — the second Allocate write (ADR-0001
+/// follow-on): reserve the next available child prefix via a POST to its
+/// `available-prefixes` endpoint, on the same gate/lifecycle/audit path as
+/// `ip reserve`. NetBox allocates the block server-side and race-safe (no
+/// client precondition), so the receipt carries the created prefix object.
+/// Only `description` may be set in v1 (the narrow allow-list).
+#[allow(clippy::too_many_arguments)] // the CLI flag set; collapsing loses clarity
+async fn run_prefix_reserve(
+    ctx: &Ctx,
+    prefix: &str,
+    vrf: Option<&str>,
+    length: Option<u8>,
+    description: Option<&str>,
+    message: Option<&str>,
+    dry_run: bool,
+    confirm: bool,
+    allow_writes: bool,
+) -> Result<()> {
+    // Gate decision BEFORE any plan/network (shared with the PATCH pilots): a
+    // read-only invocation can never become a write (ADR-0001 §4/§5).
+    let action = gate_write(ctx, dry_run, confirm, allow_writes)?;
+
+    let (client, profile) = connect_named(ctx)?;
+    let host = audit_origin(client.base_url());
+
+    // 2–4) resolve the parent prefix + build the Allocate plan. (The
+    // read-only candidate GET for the dry-run advisory happens inside the
+    // planner.)
+    let plan = detail::plan_prefix_reserve(
+        &client,
+        prefix,
+        vrf,
+        length,
+        description,
+        message,
+        &profile,
+        &not_found,
+    )
+    .await?;
+
+    // The shared dry-run/prompt/apply/audit lifecycle — one write path.
+    apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
+        Box::pin(detail::apply_prefix_reserve(c, p))
     })
     .await
 }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -1951,6 +1951,161 @@ async fn ip_bare_without_address_is_a_usage_error() {
     assert_error_contract(&out, 2, "missing IP address");
 }
 
+// ===== prefix reserve (ADR-0001 follow-on) ================================
+//
+// `prefix reserve` mirrors `ip reserve`: same Allocate/POST pattern, same
+// server-side race-safe `Precondition::None`, same gate/confirm/audit
+// lifecycle. The POST targets `available-prefixes` instead of `available-ips`.
+
+/// Mount the available-prefixes advisory GET: returns a bare JSON array of
+/// free blocks.
+async fn mount_available_prefixes_get(server: &MockServer, prefix_id: u64, blocks: &[&str]) {
+    let results: Vec<Value> = blocks.iter().map(|b| json!({"prefix": b})).collect();
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/api/ipam/prefixes/{prefix_id}/available-prefixes/"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!(results)))
+        .mount(server)
+        .await;
+}
+
+fn run_prefix_reserve<'a>(config: &NamedTempFile, extra: &'a [&'a str]) -> CommandOutput {
+    let mut args: Vec<&str> = vec!["--config", config.path().to_str().unwrap()];
+    args.push("--no-tui");
+    args.extend_from_slice(&["prefix", "10.0.0.0/24", "reserve"]);
+    args.extend_from_slice(extra);
+    run_nbox(args)
+}
+
+#[tokio::test]
+async fn prefix_reserve_dry_run_sends_no_post_and_shows_candidate() {
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "10.0.0.0/24").await;
+    mount_available_prefixes_get(&server, 1, &["10.0.0.0/25", "10.0.128.0/25"]).await;
+
+    let config = write_config(&server.uri());
+    let out = run_prefix_reserve(&config, &["--dry-run", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(post_count(&server).await, 0, "dry-run must not POST");
+    let plan: Value = serde_json::from_str(&out.stdout).expect("plan JSON");
+    assert_eq!(plan["operation"], json!("allocate"));
+    assert_eq!(plan["target"]["kind"], json!("prefix"));
+    assert_eq!(plan["target"]["id"], json!(1));
+    assert_eq!(plan["patch"], json!({}));
+    assert_eq!(plan["precondition"]["type"], json!("none"));
+    // Advisory candidate in warnings.
+    let warnings = plan["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or_default().contains("10.0.0.0/25")),
+        "candidate surfaced as a warning: {plan}"
+    );
+}
+
+#[tokio::test]
+async fn prefix_reserve_with_length_sends_prefix_length_in_body() {
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "10.0.0.0/24").await;
+    mount_available_prefixes_get(&server, 1, &["10.0.0.0/26", "10.0.64.0/26"]).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-prefixes/"))
+        .and(body_partial_json(json!({"prefix_length": 26})))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 42,
+            "url": "u",
+            "prefix": "10.0.0.0/26"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_prefix_reserve(
+        &config,
+        &["--length", "26", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(post_count(&server).await, 1, "exactly one POST");
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(true));
+    assert_eq!(receipt["status"], json!(201));
+    // The receipt carries the created prefix.
+    assert_eq!(receipt["object"]["prefix"], json!("10.0.0.0/26"));
+    assert!(
+        receipt["message"]
+            .as_str()
+            .unwrap()
+            .contains("reserved: 10.0.0.0/26")
+    );
+}
+
+#[tokio::test]
+async fn prefix_reserve_with_description_includes_it_in_body() {
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "10.0.0.0/24").await;
+    mount_available_prefixes_get(&server, 1, &["10.0.0.0/25"]).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-prefixes/"))
+        .and(body_partial_json(json!({"description": "dmz block"})))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 42,
+            "url": "u",
+            "prefix": "10.0.0.0/25"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_prefix_reserve(
+        &config,
+        &[
+            "--description",
+            "dmz block",
+            "--allow-writes",
+            "--confirm",
+            "--json",
+        ],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(post_count(&server).await, 1);
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["object"]["prefix"], json!("10.0.0.0/25"));
+}
+
+#[tokio::test]
+async fn prefix_reserve_confirm_without_allow_writes_is_a_usage_error() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_prefix_reserve(&config, &["--confirm", "--json"]);
+    assert_error_contract(&out, 2, "writes are not enabled");
+    assert_eq!(post_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn prefix_reserve_409_exhaustion_is_a_clean_error() {
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "10.0.0.0/24").await;
+    mount_available_prefixes_get(&server, 1, &[]).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-prefixes/"))
+        .respond_with(
+            ResponseTemplate::new(409)
+                .set_body_json(json!({"detail": "Insufficient space in 10.0.0.0/24"})),
+        )
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_prefix_reserve(&config, &["--allow-writes", "--confirm", "--json"]);
+
+    assert_error_contract(&out, 1, "Insufficient space");
+    assert_eq!(post_count(&server).await, 1, "exactly one POST attempt");
+}
+
 // ===== tag add (ADR-0001 follow-on) =====================================
 //
 // The fourth write command reuses the same planner/diff/confirm/concurrency/


### PR DESCRIPTION
## Summary

Adds `nbox prefix reserve <cidr>` — the sixth safe-write command and the second `allocate` write, proving the ADR-0001 allocate pattern extends past `ip reserve` with no new machinery.

POSTs to `…/prefixes/{id}/available-prefixes/` with optional `prefix_length` and `description` (the v1 allow-list — no status/role/tags/vlan). Server-allocated and race-safe, so `Precondition::None` and the receipt carries the created prefix object.

## CLI

```
nbox prefix <cidr> reserve [--length N] [--vrf <name|rd|id>] [--description "…"]
                           [--dry-run | --allow-writes --confirm] [--message "…"]
```

- `--dry-run` previews the currently-next block as an advisory warning (NetBox allocates at apply, so the block may differ)
- `--allow-writes --confirm` to apply; bare `--confirm` is exit 2
- `--vrf` scopes the parent prefix (same resolver as `nbox prefix` / `nbox next-prefix`)
- `--length N` requests a specific child prefix length
- `--description` sets that field on the new prefix
- exhausted parent (409) and validation rejection (400) are clean errors (exit 1, empty stdout)

## Implementation

- `plan_prefix_reserve` / `apply_prefix_reserve` in `src/domain/detail.rs` — mirrors `plan_ip_reserve` / `apply_ip_reserve`: resolve parent prefix, build minimal POST body, advisory dry-run candidate, verify token + POST on apply
- `PrefixAction::Reserve` CLI variant in `src/cli.rs` — mirrors `IpAction::Reserve` but uses `length: Option<u8>` (parent CIDR comes from `Command::Prefix.cidr`)
- `run_prefix_reserve` handler + `Command::Prefix` dispatch arm in `src/lib.rs` — reuses `gate_write` / `apply_or_preview` / `connect_named` / audit
- `prefix_satisfies_length` helper for dry-run candidate filtering
- 5 integration tests (dry-run no-POST, length in body, description in body, gate refusal, 409 exhaustion) + 1 CLI parse test

## Verification

- 1287 tests pass (6 new: 5 integration + 1 CLI parse)
- clippy clean (`-D warnings`)
- `cargo fmt` clean (pre-commit hook)

## Docs

Updated ROADMAP, CHANGELOG, AGENTS, README, FEATURES, and ADR-0001 for the new command.