### PR TITLE
feat: ip-range reserve — seventh safe write (allocate POST to range available-ips)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,9 @@ nbox vm-type <slug|name|id>          # NetBox 4.6+
 nbox aggregate <cidr|id>
 nbox asn <number>
 nbox ip-range <start|id>
+                                  # optional write subcommand:
+  ip-range <start|id> reserve [--description "…"] [--dns-name "…"]
+                                  # write: reserve the next available IP in an IP range (POST available-ips); --dry-run | --allow-writes --confirm [--message]
 nbox tenant <slug|name|id>
 nbox contact <name|id>
 nbox vm <name|id>
@@ -185,15 +188,13 @@ nbox ip 10.44.208.55 --json --fields address,parent_prefix,scope,scope_type,assi
 nbox search edge --status active --site dc1 -o csv --cols kind,display,url
 nbox device edge01 --json | jq '.primary_ip4'
 ```
-
-## Notes
-
-- Writes landed behind ADR-0001. Six commands reuse the same safe-write
+- Writes landed behind ADR-0001. Seven commands reuse the same safe-write
   foundation (the `MutationPlan` / `MutationReceipt` engine):
   `nbox interface <device> <interface> set description "…"`,
   `nbox device <name> set status <value>`,
   `nbox ip reserve <cidr>` (a `POST` to `available-ips` — the first `allocate`),
   `nbox prefix reserve <cidr>` (a `POST` to `available-prefixes` — the second `allocate`),
+  `nbox ip-range reserve <start|id>` (a `POST` to a range's `available-ips` — the third `allocate`),
   `nbox tag add <type> <name> <tag>` (a `PATCH` to the `tags` array on any
   object kind), and `nbox tag remove <type> <name> <tag>` (the inverse). All are
   plan-first: reads remain the default — apply needs BOTH `--allow-writes` (the
@@ -213,7 +214,9 @@ nbox device edge01 --json | jq '.primary_ip4'
   adding a tag the object already carries (or removing one it doesn't) is a
   no-op (no `PATCH`). For `prefix reserve`, the body carries optional
   `prefix_length` and `description`; the server allocates the block and the
-  receipt returns the created prefix. The MCP server stays read-only.
+  receipt returns the created prefix. For `ip-range reserve`, the body carries
+  optional `description` and `dns_name`; the server allocates the address and
+  the receipt returns the created IP. The MCP server stays read-only.
 - Filters that an object type can't satisfy cause that type to be skipped in
   `search` (nbox does not send NetBox unknown query params).
 - `owner` (NetBox 4.5+): a native owner field (user or group) surfaced on most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     NetBox validation rejection (`400`) surface as clean errors (exit 1, empty
     stdout). The audit logs `operation=allocate`, `http_method=POST`, and field
     names only.
+- **`nbox ip-range reserve <start|id>` — the seventh safe write.** Reserves
+  the next available IP address within an IP range via a `POST` to
+  `…/ip-ranges/{id}/available-ips/`, on the same ADR-0001 gate/confirm/audit
+  lifecycle as `ip reserve` and `prefix reserve` (`--dry-run` / `--allow-writes
+  --confirm` / `--message`). Optional `--description` and `--dns-name` set
+  those fields on the new IP (the v1 allow-list — no status/role/tags/
+  assignment). Proves the allocate pattern extends to IP ranges:
+  - **Server-allocated, race-safe.** NetBox picks the address and never hands
+    out the same one twice, so the plan carries no client precondition. The
+    dry-run shows the currently next address as an advisory warning — the
+    applied address may differ, since NetBox allocates at apply time.
+  - **Receipt returns the created object.** `--json` apply returns a
+    `MutationReceipt` whose `object` field is the reserved IP's view.
+  - A bare reserve `POST`s an empty body; an exhausted range (`409`) and a
+    NetBox validation rejection (`400`) surface as clean errors (exit 1, empty
+    stdout). The audit logs `operation=allocate`, `http_method=POST`, and field
+    names only.
 
 ### Changed
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -3,14 +3,17 @@
 Known limitations and edge cases — documented, not yet addressed. See ROADMAP.md
 for where they're headed.
 
-### Read-only (no writes yet)
+### Writes are narrow and opt-in (ADR-0001)
 
-**Issue:** nbox is read-only. There is no way to create, edit, or delete objects.
+**Status:** Seven safe-write commands have landed (`interface set description`,
+`device set status`, `ip reserve`, `prefix reserve`, `ip-range reserve`,
+`tag add`, `tag remove`), behind `--allow-writes` + `--confirm` (or `--dry-run`
+to preview). Reads remain the default everywhere.
 
-**Impact:** Allocation (`next-ip`/`next-prefix`) shows candidates but doesn't
-claim them; `tags`/`journal` are list-only.
-
-**Mitigation:** Safe, diff-confirmed `PATCH` writes are planned for a later release.
+**Remaining limitations:** Multi-IP allocation (`--count N`), choosing a
+specific address/block, interface/VM assignment, status/tags on reserve, and
+generic create/delete are still deferred (ADR-0001 Decision 6). The MCP server
+stays read-only.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ this device, what owns this prefix?* — from the shell, a k9s-style TUI, or an 
 server for AI agents.
 
 **Status: pre-1.0.** Reads are the default; a narrow safe-write foundation
-(ADR-0001) has landed behind `--allow-writes` + confirmation — six commands
+(ADR-0001) has landed behind `--allow-writes` + confirmation — seven commands
 today (`nbox interface <device> <interface> set description "…"`,
-`nbox device <name> set status <value>`, `nbox ip reserve <prefix>` to
-allocate the next available IP, `nbox prefix reserve <cidr>` to allocate the
-next available child prefix, and `nbox tag add`/`remove <type> <name> <tag>`
-to manage tags on any object). Broader writes are on the [ROADMAP](ROADMAP.md).
+`nbox device <name> set status <value>`, `nbox ip reserve <prefix>` /
+`nbox prefix reserve <cidr>` / `nbox ip-range reserve <start|id>` to allocate
+the next available IP or child prefix, and `nbox tag add`/`remove <type> <name>
+<tag>` to manage tags on any object). Broader writes are on the
+[ROADMAP](ROADMAP.md).
 
 ## Quick Start
 
@@ -52,8 +53,7 @@ See [Installation](#installation) below for setup instructions.
 
 ## Features
 
-- **Fast shell lookups** — `device`, `ip`, `prefix`, `vlan`, `site`, `rack`, `circuit`, `virtual-circuit`, `provider`, `aggregate`, `asn`, `ip-range`, `tenant`, `contact`, `vm`, `cluster`, `vrf`, `route-target`, `mac`, and `interface`, each as a one-liner.
-- **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` to preview free addresses and blocks (read-only). To actually claim one, `nbox ip reserve <prefix>` allocates the next available IP and `nbox prefix reserve <cidr>` allocates the next available child prefix (safe writes — ADR-0001).
+- **IPAM-aware** — IP → most-specific parent prefix → VLAN → scope resolution, prefix utilization and children, a navigable prefix tree, and `next-ip` / `next-prefix` to preview free addresses and blocks (read-only). To actually claim one, `nbox ip reserve <prefix>` allocates the next available IP from a prefix, `nbox prefix reserve <cidr>` allocates the next available child prefix, and `nbox ip-range reserve <start|id>` allocates the next available IP from an IP range (safe writes — ADR-0001).
 - **A k9s-style TUI** — a three-pane home (navigation rail → results → live preview), an overview dashboard, a hierarchical prefix tree, cross-object navigation between related objects (every detail's related-object tabs are navigable — open an interface from a device and see its cable path drawn as an A↔Z diagram), fuzzy filters, server-side name filtering on the browse list, recents, and an in-app profile + settings editor. Twelve themes; `NO_COLOR` honored.
 - **Agent-ready** — `nbox serve` is a read-only MCP server: the same lookups exposed as eleven tools (plus every object as an `nbox://{kind}/{ref}` resource), returning the exact JSON view models the CLI does, so AI agents (Claude Code, Claude Desktop, …) query NetBox safely. Stdio for a local subprocess, or a loopback HTTP transport with OIDC resource-server auth for a network-reachable, read-only deployment. See [docs/MCP.md](docs/MCP.md); [SKILL.md](SKILL.md) is an installable Agent Skill that drives the CLI on matching requests.
 - **Scriptable** — `-o plain|json|csv`, `--fields`, `--raw`, versioned `--envelope`, and stable exit codes; stdout stays clean for piping, logs go to stderr. See [docs/SCRIPTING.md](docs/SCRIPTING.md).
@@ -273,6 +273,8 @@ nbox provider <slug-or-name-or-id>
 nbox aggregate <cidr-or-id> [--journal]
 nbox asn <number> [--journal]
 nbox ip-range <start-or-id> [--journal]
+  ip-range reserve [--description "…"] [--dns-name "…"]
+                                  # write: reserve the next available IP in an IP range (POST available-ips); --dry-run | --allow-writes --confirm [--message]
 nbox tenant <slug-or-name-or-id>
 nbox contact <name-or-id>
 nbox vm <name-or-id>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,12 +2,14 @@
 
 nbox is a **read-first** NetBox CLI, TUI, and MCP server. The near-term goal is the **best
 possible read experience** — fast, correct, and pleasant both in the terminal and to agents.
-write engine, with five commands landed — `interface <device> <iface> set description` and
-`device <name> set status <value>` (`PATCH`), `ip reserve <prefix>` (the first `allocate`, a
-`POST` to `available-ips`), `tag add <type> <name> <tag>` / `tag remove` (a `PATCH` to the `tags`
-array on any object kind), and `prefix reserve <cidr>` (a `POST` to `available-prefixes`). Reads
-stay the default everywhere and the write surface widens only as the read tool proves out in
-practice (see [Writes](#writes--deferred-later-track)).
+write engine, with seven commands landed — `interface <device> <iface> set
+description` and `device <name> set status <value>` (`PATCH`), `ip reserve
+<prefix>` / `prefix reserve <cidr>` / `ip-range reserve <start|id>` (three
+`allocate` `POST`s to `available-ips` / `available-prefixes`), and `tag add` /
+`tag remove <type> <name> <tag>` (a `PATCH` to the `tags` array on any object
+kind). Reads stay the default everywhere and the write surface widens only as
+the read tool proves out in practice (see
+[Writes](#writes--deferred-later-track)).
 
 Legend: ☐ planned · ◐ in progress · ☑ done
 
@@ -448,10 +450,16 @@ the read tool proves out in practice. Consolidated future scope:
   `--description`. Server-allocated and race-safe, so the plan carries no
   client precondition; the receipt returns the created prefix object. Same
   gate/confirm/audit lifecycle as the `PATCH` pilots and `ip reserve`.
-- ☐ **IPAM allocate (rest)** — IP-range allocation (`POST` to a range's
-  `available-ips`); the read half (`next-ip` / `next-prefix`, range lookup)
-  already ships, and the next-IP allocation (`ip reserve`) and prefix
-  allocation (`prefix reserve`) landed above.
+- ☑ `nbox ip-range reserve <start|id>` — the third **`allocate`** write (a
+  `POST` to `…/ip-ranges/{id}/available-ips/`): reserve the next available IP
+  address within an IP range, with optional `--description` / `--dns-name`.
+  Server-allocated and race-safe, so the plan carries no client precondition;
+  the receipt returns the created IP object. Same gate/confirm/audit lifecycle
+  as `ip reserve` and `prefix reserve`.
+- ☐ **IPAM allocate (rest)** — multi-IP allocation (`--count N` on `ip reserve`
+  / `ip-range reserve`), and choosing a specific address/block. The read half
+  (`next-ip` / `next-prefix`, range lookup) and all three allocate writes (`ip
+  reserve`, `prefix reserve`, `ip-range reserve`) landed above.
 - ☑ `nbox tag add <type> <name> <tag>` — a further write command, reusing the
   same foundation. Adds a tag to any taggable object via a minimal `PATCH` that
   replaces the full `tags` array; a no-op if the tag is already present. The

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,12 +1,12 @@
 # Features
 
 nbox is a NetBox client — a CLI and a TUI over the same core. Reads are the
-default; a narrow safe-write foundation (ADR-0001) adds six plan-first commands
-behind `--allow-writes` + confirmation — `interface … set description` and
-`device … set status` (`PATCH`), `ip reserve <prefix>` (the next-IP
-allocation, a `POST`), `prefix reserve <cidr>` (the next-prefix allocation,
-a `POST` to `available-prefixes`), and `tag add`/`remove <type> <name> <tag>`
-(a `PATCH` to the `tags` array on any object). The MCP server stays read-only.
+default; a narrow safe-write foundation (ADR-0001) adds seven plan-first
+commands behind `--allow-writes` + confirmation — `interface … set
+description` and `device … set status` (`PATCH`), `ip reserve <prefix>` /
+`prefix reserve <cidr>` / `ip-range reserve <start|id>` (three `allocate`
+`POST`s), and `tag add`/`remove <type> <name> <tag>` (a `PATCH` to the `tags`
+array on any object). The MCP server stays read-only.
 
 ## Lookups
 
@@ -20,7 +20,7 @@ a `POST` to `available-prefixes`), and `tag add`/`remove <type> <name> <tag>`
 | `nbox next-ip <cidr> [--count] [--vrf]` | Next available address(es) (read-only preview). |
 | `nbox next-prefix <cidr> [--length] [--vrf]` | Available free block(s). |
 | `nbox vlan <vid\|name> [--site] [--group] [--journal]` | VLAN + referencing prefixes, plus the VLAN's own `scope`/`scope_type` and, when it belongs to a scoped VLAN group, the group's `group_scope`/`group_scope_type`. |
-| `nbox site` / `rack` / `rack-group` / `circuit` / `virtual-circuit` / `aggregate` / `asn` / `ip-range` `[--journal]` | Object lookups. |
+| `nbox ip-range <start\|id>` | IP range. `reserve [--description] [--dns-name]` is a safe write (ADR-0001): `POST` to `available-ips`, behind `--allow-writes` + confirm. `--dry-run` previews the candidate; the receipt's `object` is the created IP. |
 | `nbox tenant <slug\|name\|id>` | Tenant: group, description, relation counts, tags, custom fields. |
 | `nbox contact <name\|id>` | Contact: title, phone, email, address, link, group, tags, custom fields. |
 | `nbox provider <slug\|name\|id>` | Provider: ASNs, accounts, description, circuit count, tags, custom fields. |

--- a/docs/adr/0001-safe-write-foundation.md
+++ b/docs/adr/0001-safe-write-foundation.md
@@ -283,10 +283,20 @@ Shipped on this foundation, in order:
   surfaces the currently-next block as an advisory warning; an exhausted parent
   (`409`) is a clean error.
 
+- `ip-range reserve <start|id> [--description] [--dns-name]` — the seventh
+  write (`allocate` / `POST`), the third `allocate`: a `POST` to
+  `…/ip-ranges/{id}/available-ips/` that reserves the next free address within
+  an IP range. It proves the `allocate` pattern extends to a third endpoint
+  shape with no new machinery — same `Operation::Allocate`, same
+  `Precondition::None`, same gate/confirm/audit lifecycle, and the same
+  `object`-in-receipt pattern. The body carries optional `description` and
+  `dns_name` (the same v1 allow-list as `ip reserve`). The dry-run surfaces the
+  currently-next address as an advisory warning; an exhausted range (`409`) is
+  a clean error.
+
 Still deferred per Decision 6: choosing a specific address/block, multi-IP
-allocation, IP-range allocation (`POST` to a range's `available-ips`),
-interface/VM assignment, status/tags on reserve, generic create/delete, and
-`nbox raw` write verbs.
+allocation (`--count N`), interface/VM assignment, status/tags on reserve,
+generic create/delete, and `nbox raw` write verbs.
 
 ## References
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -335,6 +335,10 @@ pub enum Command {
         /// Max inline journal entries to fold in (implies --journal; default 5).
         #[arg(long, value_name = "N")]
         journal_limit: Option<usize>,
+
+        /// Optional write subcommand.
+        #[command(subcommand)]
+        action: Option<IpRangeAction>,
     },
 
     /// Show a tenant by slug, name, or numeric ID.
@@ -886,6 +890,51 @@ pub enum PrefixAction {
         message: Option<String>,
 
         /// Preview the plan + the candidate prefix and perform no mutation.
+        /// Needs neither `--allow-writes` nor confirmation. With `--json`,
+        /// returns the stable `MutationPlan` JSON.
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+
+        /// Apply the reviewed plan without an interactive prompt. Does NOT
+        /// enable writes on its own — `--confirm` without `--allow-writes` is a
+        /// usage error (exit 2). With `--json`, returns the stable
+        /// `MutationReceipt` JSON.
+        #[arg(long)]
+        confirm: bool,
+
+        /// The write-enable gate: required to apply ANY mutation. Kept separate
+        /// from `--confirm` so a read-only invocation can never be silently
+        /// turned into a write (ADR-0001 §4).
+        #[arg(long = "allow-writes")]
+        allow_writes: bool,
+    },
+}
+
+/// `nbox ip-range` write actions (read is the bare `nbox ip-range <value>`).
+#[derive(Debug, Subcommand)]
+pub enum IpRangeAction {
+    /// Reserve (allocate) the next available IP address within this IP range. A
+    /// write: requires the `--allow-writes` gate AND confirmation (`--confirm`,
+    /// or an interactive prompt on a TTY in plain output). `--dry-run` previews
+    /// with no mutation and needs neither. NetBox allocates the address
+    /// server-side and race-safe, so the applied address may differ from any
+    /// previewed candidate.
+    Reserve {
+        /// Set the new IP's description. Optional.
+        #[arg(long, value_name = "TEXT")]
+        description: Option<String>,
+
+        /// Set the new IP's DNS name. Optional.
+        #[arg(long = "dns-name", value_name = "NAME")]
+        dns_name: Option<String>,
+
+        /// Record this message in NetBox's object-change entry (a write-only
+        /// request field, never stored on the object). Validated to NetBox's
+        /// 200-character limit before applying. Optional.
+        #[arg(long, value_name = "MESSAGE")]
+        message: Option<String>,
+
+        /// Preview the plan + the candidate address and perform no mutation.
         /// Needs neither `--allow-writes` nor confirmation. With `--json`,
         /// returns the stable `MutationPlan` JSON.
         #[arg(long = "dry-run")]
@@ -1636,5 +1685,41 @@ mod tests {
         assert_eq!(cidr, "10.0.0.0/24");
         assert_eq!(len, 26);
         assert_eq!(desc, "dmz");
+    }
+
+    #[test]
+    fn ip_range_reserve_parses_flags() {
+        let cmd = Cli::try_parse_from([
+            "nbox",
+            "--no-tui",
+            "ip-range",
+            "10.0.0.10",
+            "reserve",
+            "--description",
+            "loopback",
+            "--dns-name",
+            "lb.example",
+            "--dry-run",
+        ])
+        .unwrap();
+        let Some(Command::IpRange {
+            value,
+            action:
+                Some(IpRangeAction::Reserve {
+                    description: Some(desc),
+                    dns_name: Some(dns),
+                    message: None,
+                    dry_run: true,
+                    confirm: false,
+                    allow_writes: false,
+                }),
+            ..
+        }) = cmd.command
+        else {
+            panic!("expected ip-range reserve");
+        };
+        assert_eq!(value, "10.0.0.10");
+        assert_eq!(desc, "loopback");
+        assert_eq!(dns, "lb.example");
     }
 }

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -45,7 +45,7 @@ use crate::netbox::models::circuits::{Circuit, CircuitTermination, Provider, Vir
 use crate::netbox::models::common::BriefObject;
 use crate::netbox::models::dcim::{Device, Interface, MacAddress, Rack, RackGroup, Site};
 use crate::netbox::models::ipam::{
-    Aggregate, Asn, IpAddress, IpRange, Prefix, RouteTarget, Vlan, VlanGroup, Vrf,
+    Aggregate, Asn, AvailableIp, IpAddress, IpRange, Prefix, RouteTarget, Vlan, VlanGroup, Vrf,
 };
 use crate::netbox::models::tenancy::{Contact, Tenant};
 use crate::netbox::models::virtualization::{Cluster, VirtualMachine, VirtualMachineType};
@@ -991,6 +991,165 @@ pub(crate) async fn apply_prefix_reserve(
 fn prefix_satisfies_length(cidr: &str, target: u8) -> bool {
     cidr.rsplit_once('/')
         .is_some_and(|(_, len_str)| len_str.parse::<u8>().is_ok_and(|len| len <= target))
+}
+
+/// Plan an `ip-range reserve <start|id>` allocation (ADR-0001 §5 steps 1–4):
+/// validate the optional changelog message, resolve the IP range by start
+/// address or ID, and build an `Allocate` plan whose body POSTs to the range's
+/// `available-ips` endpoint.
+///
+/// The endpoint is server-side race-safe (NetBox never hands out the same
+/// address twice), so the plan carries [`Precondition::None`] — there is no
+/// prior object, ETag, or `last_updated` to bind. A dry-run surfaces the
+/// *currently* next address as an advisory warning: NetBox allocates at apply
+/// time, so the applied address may differ. Only `description` / `dns_name`
+/// may be set (the v1 narrow allow-list — no status/role/tags/assignment).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn plan_ip_range_reserve(
+    client: &NetBoxClient,
+    range_ref: &str,
+    description: Option<&str>,
+    dns_name: Option<&str>,
+    changelog_message: Option<&str>,
+    profile: &str,
+    not_found: &(dyn Fn(&str, &str) -> anyhow::Error + Send + Sync),
+) -> Result<MutationPlan> {
+    // Message length is pure input validation — check first, before any network.
+    let message = match changelog_message {
+        Some(m) if !m.is_empty() => Some(m.to_string()),
+        _ => None,
+    };
+    mutation::validate_changelog_message(&message)?;
+
+    // Resolve the IP range by start address or ID (same resolver as
+    // `nbox ip-range`).
+    let range = client
+        .ip_range_by_ref(range_ref)
+        .await?
+        .ok_or_else(|| not_found("IP range", range_ref))?;
+    let endpoint = format!("/api/ipam/ip-ranges/{}/available-ips/", range.id);
+
+    let target = PlanTarget {
+        kind: "ip".to_string(),
+        r#ref: range_ref.to_string(),
+        id: range.id,
+        display: format!("{} – {}", range.start_address, range.end_address),
+        endpoint,
+        profile: profile.to_string(),
+    };
+
+    // The minimal POST body: only the fields the operator actually set. A bare
+    // reserve sends `{}` and takes NetBox's defaults.
+    let mut body = serde_json::Map::new();
+    let mut fields = Vec::new();
+    if let Some(d) = description.filter(|s| !s.is_empty()) {
+        body.insert("description".to_string(), serde_json::json!(d));
+        fields.push(FieldChange {
+            field: "description".to_string(),
+            before: Value::Null,
+            after: serde_json::json!(d),
+        });
+    }
+    if let Some(d) = dns_name.filter(|s| !s.is_empty()) {
+        body.insert("dns_name".to_string(), serde_json::json!(d));
+        fields.push(FieldChange {
+            field: "dns_name".to_string(),
+            before: Value::Null,
+            after: serde_json::json!(d),
+        });
+    }
+    let patch = Value::Object(body);
+    let precondition = Precondition::None;
+
+    // Dry-run advisory: the address NetBox would currently hand out. Read-only,
+    // and never part of the body — another client could allocate between this
+    // read and the apply POST, so the applied address may differ.
+    let mut warnings = Vec::new();
+    // NetBox's IP-range available-ips endpoint returns a bare JSON array.
+    match client
+        .get::<Vec<AvailableIp>>(
+            &format!("/api/ipam/ip-ranges/{}/available-ips/", range.id),
+            &[("limit", "1".to_string())],
+        )
+        .await
+    {
+        Ok(list) => match list.first() {
+            Some(next) => warnings.push(format!(
+                "currently next: {} — NetBox allocates at apply; the applied address may differ",
+                next.address
+            )),
+            None => warnings.push(
+                "no available addresses in this range — the reserve will fail at apply".to_string(),
+            ),
+        },
+        // A failed advisory read must not block planning; the apply POST is the
+        // authoritative attempt. Note it and carry on.
+        Err(_) => {
+            warnings.push("could not read the next available address (advisory only)".to_string());
+        }
+    }
+
+    let expires_epoch = mutation::plan_expiry_epoch(SystemTime::now());
+    let confirm_token = mutation::confirm_token(
+        &target,
+        Operation::Allocate,
+        &precondition,
+        &patch,
+        &message,
+        expires_epoch,
+    );
+
+    Ok(MutationPlan {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: Operation::Allocate,
+        target,
+        precondition,
+        fields,
+        patch,
+        no_op: false,
+        warnings,
+        errors: Vec::new(),
+        changelog_message: message,
+        confirm_token,
+        expires_at: mutation::format_iso_utc(expires_epoch),
+    })
+}
+
+/// Apply a planned IP-range reservation (ADR-0001 §5 steps 5–7): verify the
+/// plan's confirmation token + expiry, then POST the minimal body to the
+/// range's `available-ips` endpoint. NetBox allocates the next free address
+/// and returns the created IP object (`201`), which becomes the receipt's
+/// `object`.
+pub(crate) async fn apply_ip_range_reserve(
+    client: &NetBoxClient,
+    plan: &MutationPlan,
+) -> Result<MutationReceipt> {
+    plan.verify()?;
+
+    // The wire body is the minimal create patch plus the opt-in changelog_message.
+    let mut body = plan.patch.clone();
+    if let Some(msg) = &plan.changelog_message {
+        body["changelog_message"] = serde_json::json!(msg);
+    }
+
+    let (created, status): (IpAddress, u16) = client.post(&plan.target.endpoint, &body).await?;
+    let address = created.address.clone();
+    let view = IpView::build(created, None);
+    let object = serde_json::to_value(&view).ok();
+
+    Ok(MutationReceipt {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: plan.operation,
+        target: plan.target.clone(),
+        fields: plan.fields.clone(),
+        applied: true,
+        no_op: false,
+        status,
+        etag: None,
+        request_id: None,
+        object,
+        message: format!("reserved: {} in {}", address, plan.target.display),
+    })
 }
 
 // ===== Safe write follow-on: tag add/remove (ADR-0001) ===================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,7 +425,30 @@ pub async fn run(cli: Cli) -> Result<()> {
             value,
             journal,
             journal_limit,
-        }) => run_ip_range(&ctx, &value, journal, journal_limit).await,
+            action,
+        }) => match action {
+            None => run_ip_range(&ctx, &value, journal, journal_limit).await,
+            Some(crate::cli::IpRangeAction::Reserve {
+                description,
+                dns_name,
+                message,
+                dry_run,
+                confirm,
+                allow_writes,
+            }) => {
+                Box::pin(run_ip_range_reserve(
+                    &ctx,
+                    &value,
+                    description.as_deref(),
+                    dns_name.as_deref(),
+                    message.as_deref(),
+                    dry_run,
+                    confirm,
+                    allow_writes,
+                ))
+                .await
+            }
+        },
         Some(Command::Tenant { value }) => run_tenant(&ctx, &value).await,
         Some(Command::Contact { value }) => run_contact(&ctx, &value).await,
         Some(Command::Vm { value }) => run_vm(&ctx, &value).await,
@@ -1765,6 +1788,50 @@ async fn run_prefix_reserve(
     // The shared dry-run/prompt/apply/audit lifecycle — one write path.
     apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
         Box::pin(detail::apply_prefix_reserve(c, p))
+    })
+    .await
+}
+
+/// `nbox ip-range reserve <start|id>` — the third Allocate write (ADR-0001
+/// follow-on): reserve the next available IP address within an IP range via a
+/// POST to its `available-ips` endpoint, on the same gate/lifecycle/audit path
+/// as `ip reserve`. NetBox allocates the address server-side and race-safe (no
+/// client precondition), so the receipt carries the created IP object.
+/// Only `description` / `dns_name` may be set in v1 (the narrow allow-list).
+#[allow(clippy::too_many_arguments)] // the CLI flag set; collapsing loses clarity
+async fn run_ip_range_reserve(
+    ctx: &Ctx,
+    range_ref: &str,
+    description: Option<&str>,
+    dns_name: Option<&str>,
+    message: Option<&str>,
+    dry_run: bool,
+    confirm: bool,
+    allow_writes: bool,
+) -> Result<()> {
+    // Gate decision BEFORE any plan/network (shared with the PATCH pilots): a
+    // read-only invocation can never become a write (ADR-0001 §4/§5).
+    let action = gate_write(ctx, dry_run, confirm, allow_writes)?;
+
+    let (client, profile) = connect_named(ctx)?;
+    let host = audit_origin(client.base_url());
+
+    // 2–4) resolve the IP range + build the Allocate plan. (The read-only
+    // candidate GET for the dry-run advisory happens inside the planner.)
+    let plan = detail::plan_ip_range_reserve(
+        &client,
+        range_ref,
+        description,
+        dns_name,
+        message,
+        &profile,
+        &not_found,
+    )
+    .await?;
+
+    // The shared dry-run/prompt/apply/audit lifecycle — one write path.
+    apply_or_preview(ctx, &client, &plan, action, &profile, &host, |c, p| {
+        Box::pin(detail::apply_ip_range_reserve(c, p))
     })
     .await
 }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -2106,6 +2106,163 @@ async fn prefix_reserve_409_exhaustion_is_a_clean_error() {
     assert_eq!(post_count(&server).await, 1, "exactly one POST attempt");
 }
 
+// ===== ip-range reserve (ADR-0001 follow-on) ===============================
+//
+// `ip-range reserve` mirrors `ip reserve` but targets an IP range instead of
+// a prefix: same Allocate/POST pattern, same server-side race-safe
+// `Precondition::None`, same gate/confirm/audit lifecycle. The POST targets
+// `…/ip-ranges/{id}/available-ips/`.
+
+/// Mount an IP-range resolution: `GET /api/ipam/ip-ranges/?start_address=…` →
+/// one hit.
+async fn mount_ip_range_resolution(server: &MockServer, range_id: u64, start: &str, end: &str) {
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/ip-ranges/"))
+        .and(wiremock::matchers::query_param("start_address", start))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": range_id,
+                "url": format!("{}/api/ipam/ip-ranges/{}/", server.uri(), range_id),
+                "start_address": start,
+                "end_address": end
+            }]
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Mount the IP-range available-ips advisory GET: returns a bare JSON array of
+/// free addresses.
+async fn mount_ip_range_available_ips_get(server: &MockServer, range_id: u64, addr: Option<&str>) {
+    let results: Vec<Value> = match addr {
+        Some(a) => vec![json!({"address": a})],
+        None => vec![],
+    };
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/api/ipam/ip-ranges/{range_id}/available-ips/"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!(results)))
+        .mount(server)
+        .await;
+}
+
+fn run_ip_range_reserve<'a>(config: &NamedTempFile, extra: &'a [&'a str]) -> CommandOutput {
+    let mut args: Vec<&str> = vec!["--config", config.path().to_str().unwrap()];
+    args.push("--no-tui");
+    args.extend_from_slice(&["ip-range", "10.0.0.10", "reserve"]);
+    args.extend_from_slice(extra);
+    run_nbox(args)
+}
+
+#[tokio::test]
+async fn ip_range_reserve_dry_run_sends_no_post_and_shows_candidate() {
+    let server = MockServer::start().await;
+    mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
+    mount_ip_range_available_ips_get(&server, 1, Some("10.0.0.10/32")).await;
+
+    let config = write_config(&server.uri());
+    let out = run_ip_range_reserve(&config, &["--dry-run", "--json"]);
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(post_count(&server).await, 0, "dry-run must not POST");
+    let plan: Value = serde_json::from_str(&out.stdout).expect("plan JSON");
+    assert_eq!(plan["operation"], json!("allocate"));
+    assert_eq!(plan["target"]["kind"], json!("ip"));
+    assert_eq!(plan["target"]["id"], json!(1));
+    assert_eq!(plan["target"]["display"], json!("10.0.0.10 – 10.0.0.20"));
+    assert_eq!(
+        plan["target"]["endpoint"],
+        json!("/api/ipam/ip-ranges/1/available-ips/")
+    );
+    assert_eq!(plan["patch"], json!({}));
+    assert_eq!(plan["precondition"]["type"], json!("none"));
+    let warnings = plan["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or_default().contains("10.0.0.10/32")),
+        "candidate surfaced as a warning: {plan}"
+    );
+}
+
+#[tokio::test]
+async fn ip_range_reserve_with_description_and_dns_name_includes_them_in_body() {
+    let server = MockServer::start().await;
+    mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
+    mount_ip_range_available_ips_get(&server, 1, Some("10.0.0.10/32")).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
+        .and(body_partial_json(
+            json!({"description": "loopback", "dns_name": "lb.example"}),
+        ))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 42,
+            "url": "u",
+            "address": "10.0.0.10/32"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_ip_range_reserve(
+        &config,
+        &[
+            "--description",
+            "loopback",
+            "--dns-name",
+            "lb.example",
+            "--allow-writes",
+            "--confirm",
+            "--json",
+        ],
+    );
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    assert_eq!(post_count(&server).await, 1);
+    let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
+    assert_eq!(receipt["applied"], json!(true));
+    assert_eq!(receipt["status"], json!(201));
+    assert_eq!(receipt["object"]["address"], json!("10.0.0.10/32"));
+    assert!(
+        receipt["message"]
+            .as_str()
+            .unwrap()
+            .contains("reserved: 10.0.0.10/32")
+    );
+}
+
+#[tokio::test]
+async fn ip_range_reserve_confirm_without_allow_writes_is_a_usage_error() {
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_ip_range_reserve(&config, &["--confirm", "--json"]);
+    assert_error_contract(&out, 2, "writes are not enabled");
+    assert_eq!(post_count(&server).await, 0);
+}
+
+#[tokio::test]
+async fn ip_range_reserve_409_exhaustion_is_a_clean_error() {
+    let server = MockServer::start().await;
+    mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
+    mount_ip_range_available_ips_get(&server, 1, None).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
+        .respond_with(
+            ResponseTemplate::new(409)
+                .set_body_json(json!({"detail": "Insufficient space in range"})),
+        )
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_ip_range_reserve(&config, &["--allow-writes", "--confirm", "--json"]);
+
+    assert_error_contract(&out, 1, "Insufficient space");
+    assert_eq!(post_count(&server).await, 1, "exactly one POST attempt");
+}
+
 // ===== tag add (ADR-0001 follow-on) =====================================
 //
 // The fourth write command reuses the same planner/diff/confirm/concurrency/

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -2106,6 +2106,93 @@ async fn prefix_reserve_409_exhaustion_is_a_clean_error() {
     assert_eq!(post_count(&server).await, 1, "exactly one POST attempt");
 }
 
+#[tokio::test]
+async fn prefix_reserve_audit_logs_names_only_never_values_token_or_message_body() {
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "10.0.0.0/24").await;
+    mount_available_prefixes_get(&server, 1, &["10.0.0.0/25"]).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-prefixes/"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 42, "url": "u", "prefix": "10.0.0.0/25"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let log = NamedTempFile::new().expect("log file");
+    let log_path = log.path().to_path_buf();
+    drop(log);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
+        .arg("--config")
+        .arg(config.path())
+        .arg("--no-tui")
+        .arg("--log-file")
+        .arg(&log_path)
+        .arg("--log-level")
+        .arg("nbox::write_audit=info")
+        .args([
+            "prefix",
+            "10.0.0.0/24",
+            "reserve",
+            "--length",
+            "25",
+            "--description",
+            "reserve-secret-desc",
+            "--allow-writes",
+            "--confirm",
+            "--message",
+            "reserve-secret-message",
+            "--json",
+        ])
+        .env("NBOX_TOKEN", "secret-nbox-token-12345")
+        .env_remove("NBOX_LOG")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn nbox");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let log_text = std::fs::read_to_string(&log_path).expect("read log file");
+    assert!(log_text.contains("nbox::write_audit"), "log: {log_text}");
+    assert!(
+        log_text.contains("operation=\"allocate\"") || log_text.contains("operation=allocate"),
+        "operation recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("fields=\"prefix_length") || log_text.contains("fields=prefix_length"),
+        "field NAME recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("outcome=\"applied\"") || log_text.contains("outcome=applied"),
+        "outcome recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("message_present=true"),
+        "message_present flag: {log_text}"
+    );
+    assert!(
+        !log_text.contains("reserve-secret-desc"),
+        "description value leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("reserve-secret-message"),
+        "message body leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("secret-nbox-token-12345"),
+        "token leaked: {log_text}"
+    );
+}
+
 // ===== ip-range reserve (ADR-0001 follow-on) ===============================
 //
 // `ip-range reserve` mirrors `ip reserve` but targets an IP range instead of
@@ -2261,6 +2348,95 @@ async fn ip_range_reserve_409_exhaustion_is_a_clean_error() {
 
     assert_error_contract(&out, 1, "Insufficient space");
     assert_eq!(post_count(&server).await, 1, "exactly one POST attempt");
+}
+
+#[tokio::test]
+async fn ip_range_reserve_audit_logs_names_only_never_values_token_or_message_body() {
+    let server = MockServer::start().await;
+    mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
+    mount_ip_range_available_ips_get(&server, 1, Some("10.0.0.10/32")).await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 42, "url": "u", "address": "10.0.0.10/32"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let log = NamedTempFile::new().expect("log file");
+    let log_path = log.path().to_path_buf();
+    drop(log);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
+        .arg("--config")
+        .arg(config.path())
+        .arg("--no-tui")
+        .arg("--log-file")
+        .arg(&log_path)
+        .arg("--log-level")
+        .arg("nbox::write_audit=info")
+        .args([
+            "ip-range",
+            "10.0.0.10",
+            "reserve",
+            "--description",
+            "reserve-secret-desc",
+            "--allow-writes",
+            "--confirm",
+            "--message",
+            "reserve-secret-message",
+            "--json",
+        ])
+        .env("NBOX_TOKEN", "secret-nbox-token-12345")
+        .env_remove("NBOX_LOG")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn nbox");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let log_text = std::fs::read_to_string(&log_path).expect("read log file");
+    assert!(log_text.contains("nbox::write_audit"), "log: {log_text}");
+    assert!(
+        log_text.contains("operation=\"allocate\"") || log_text.contains("operation=allocate"),
+        "operation recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("http_method=\"POST\"") || log_text.contains("http_method=POST"),
+        "http_method recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("fields=\"description\"") || log_text.contains("fields=description"),
+        "field NAME recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("outcome=\"applied\"") || log_text.contains("outcome=applied"),
+        "outcome recorded: {log_text}"
+    );
+    assert!(
+        log_text.contains("message_present=true"),
+        "message_present flag: {log_text}"
+    );
+    assert!(
+        !log_text.contains("reserve-secret-desc"),
+        "description value leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("reserve-secret-message"),
+        "message body leaked: {log_text}"
+    );
+    assert!(
+        !log_text.contains("secret-nbox-token-12345"),
+        "token leaked: {log_text}"
+    );
 }
 
 // ===== tag add (ADR-0001 follow-on) =====================================


### PR DESCRIPTION
## Summary

Adds `nbox ip-range reserve <start|id>` — the seventh safe-write command and the third `allocate` write, proving the ADR-0001 allocate pattern extends to IP ranges with no new machinery.

POSTs to `…/ip-ranges/{id}/available-ips/` with optional `description` and `dns_name` (the v1 allow-list — no status/role/tags/assignment). Server-allocated and race-safe, so `Precondition::None` and the receipt carries the created IP object.

## CLI

```
nbox ip-range <start|id> reserve [--description "…"] [--dns-name "…"]
                                  [--dry-run | --allow-writes --confirm] [--message "…"]
```

- `--dry-run` previews the currently-next address as an advisory warning (NetBox allocates at apply, so the address may differ)
- `--allow-writes --confirm` to apply; bare `--confirm` is exit 2
- `--description` / `--dns-name` set those fields on the new IP
- exhausted range (409) and validation rejection (400) are clean errors (exit 1, empty stdout)

## Implementation

- `plan_ip_range_reserve` / `apply_ip_range_reserve` in `src/domain/detail.rs` — mirrors `plan_ip_reserve` / `apply_ip_reserve`: resolve IP range by start-address/id, build minimal POST body, advisory dry-run candidate, verify token + POST on apply
- `IpRangeAction::Reserve` CLI variant in `src/cli.rs`
- `run_ip_range_reserve` handler + `Command::IpRange` dispatch arm in `src/lib.rs` — reuses `gate_write` / `apply_or_preview` / `connect_named` / audit
- 5 integration tests (dry-run no-POST, description+dns-name, gate refusal, 409 exhaustion) + 1 CLI parse test

## Verification

- 1292 tests pass (6 new: 5 integration + 1 CLI parse)
- clippy clean (`-D warnings`)
- `cargo fmt` clean (pre-commit hook)

## Stacking

**Stacks on #107 (prefix reserve).** Review and merge #107 first, then rebase this onto master.

## Docs

Updated ROADMAP, CHANGELOG, AGENTS, README, FEATURES, and ADR-0001 for the new command.