### PR TITLE
feat: agent write ergonomics — per-domain skill files + CI lint

### DIFF
--- a/.github/workflows/skills-lint.yml
+++ b/.github/workflows/skills-lint.yml
@@ -1,0 +1,28 @@
+name: Skills lint
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'skills/**'
+      - 'scripts/lint_skills.sh'
+      - '.github/workflows/skills-lint.yml'
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/lint_skills.sh'
+      - '.github/workflows/skills-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Lint skills catalog shape
+        run: bash scripts/lint_skills.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     existing single-IP plan/receipt — `count`, `partial`, `requested_count`, and
     `created_count` use `skip_serializing_if` defaults so they're omitted when
     at their default values.
+- **Agent write ergonomics — per-domain skill files.** The root `SKILL.md`
+  now indexes a small catalog of focused, flag-free skill files for the write
+  surface, in the standard agent-skills layout (`skills/<domain>/SKILL.md`):
+  `skills/writes/SKILL.md` (the universal dry-run/confirm/audit lifecycle),
+  `skills/ipam-allocate/SKILL.md` (`ip`/`prefix`/`ip-range reserve`),
+  `skills/tag-writes/SKILL.md` (`tag add`/`remove`), and
+  `skills/patch-writes/SKILL.md` (`interface set description` / `device set
+  status`). Each points at `nbox <cmd> --help` rather than enumerating flags, so
+  the skills can't silently drift as the CLI evolves. A `scripts/lint_skills.sh`
+  script + a `skills-lint` CI workflow validate the frontmatter shape (`name` +
+  `description`) on every `skills/*/SKILL.md`.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -340,10 +340,15 @@ all read-only. (Market positioning itself stays out of the repo — see private 
   `nbox serve --print-config` helper. (SKILL.md + the README "Add it to Claude" block are the start.)
   `--print-config` now prints the paste-ready `mcpServers` JSON (absolute binary path, echoed
   `--profile`/`--config`, placeholder token) and exits; docs/MCP.md lists the per-host config-file path.
-- ☐ **Per-domain agent-skills catalog.** Grow the single root `SKILL.md` into a small catalog of focused
-  skills (e.g. search, IPAM, device/interface context, `serve`) in the standard agent-skills layout
-  (`skills/<name>/SKILL.md`). Keep them flag-free — point at `nbox <cmd> --help` rather than enumerating
-  flags, so they can't silently drift as the CLI evolves — and lint the shape in CI.
+- ☑ **Per-domain agent-skills catalog (write domain).** The first skill files
+  landed for the write surface, in the standard agent-skills layout
+  (`skills/<domain>/SKILL.md`): `skills/writes/` (the universal lifecycle),
+  `skills/ipam-allocate/`, `skills/tag-writes/`, `skills/patch-writes/`.
+  Flag-free by design — each points at `nbox <cmd> --help` so it can't silently
+  drift; `scripts/lint_skills.sh` + a `skills-lint` CI workflow check the
+  frontmatter shape. The root `SKILL.md` indexes the catalog and now mentions
+  the write surface. ☐ Read-domain skills (search, IPAM read, device/interface
+  context, `serve`) remain — grow the catalog incrementally.
 - ☑ **Read-only history/changelog tool + `--diff`.** `nbox history <kind> <ref>`
   shows the system-recorded create/update/delete timeline for an object (who, when,
   and which fields changed) from `/api/core/object-changes/` (NetBox 4.x), distinct
@@ -481,8 +486,14 @@ the read tool proves out in practice. Consolidated future scope:
 - ☐ TUI edit mode (`e` / `d` / confirm).
 - ☐ `nbox raw POST|PATCH|DELETE`; OPTIONS write-capability discovery (optional `schema` command; would
   also enable value-level filter validation beyond today's typed allowlist, netbox#6489).
-- ☐ **Agent write ergonomics** — a `--dry-run` convention and per-command skill files, landing with
-  writes (`AGENTS.md` is the read-side foundation today).
+- ☑ **Agent write ergonomics** — per-domain skill files for the write
+  surface, in the standard agent-skills layout (`skills/<domain>/SKILL.md`):
+  `skills/writes/` (the universal dry-run/confirm/audit lifecycle), `skills/
+  ipam-allocate/` (`ip`/`prefix`/`ip-range reserve`), `skills/tag-writes/`
+  (`tag add`/`remove`), and `skills/patch-writes/` (`interface set
+  description` / `device set status`). Flag-free by design — each points at
+  `nbox <cmd> --help` so it can't silently drift. A `scripts/lint_skills.sh`
+  CI lint checks the frontmatter shape (`name` + `description`).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: nbox
-description: Query NetBox (DCIM/IPAM) from the shell with the `nbox` CLI — look up devices, interfaces, IPs, prefixes, VLANs, sites, racks, circuits, VRFs, tenants, VMs, and clusters; run cross-object search; and use IPAM helpers (next free IP/prefix, prefix utilization, cable-path traces). Use when the user asks about NetBox, network inventory, IP addressing, or device/interface/cable details, or wants machine-readable network data. Read-only; supports `-o json` / `-o csv` and an MCP server.
+description: Query and modify NetBox (DCIM/IPAM) from the shell with the `nbox` CLI — look up devices, interfaces, IPs, prefixes, VLANs, sites, racks, circuits, VRFs, tenants, VMs, and clusters; run cross-object search; use IPAM helpers (next free IP/prefix, prefix utilization, cable-path traces); and safely write (reserve IPs/prefixes, set status/description, manage tags) behind a dry-run/confirm gate. Use when the user asks about NetBox, network inventory, IP addressing, or device/interface/cable details, or wants machine-readable network data or safe mutations. Read-only by default; supports `-o json` / `-o csv` and an MCP server.
 ---
 
 # nbox — NetBox from the shell
 
-`nbox` is a fast, **read-only** CLI / TUI / MCP client for [NetBox](https://github.com/netbox-community/netbox)
+`nbox` is a CLI / TUI / MCP client for [NetBox](https://github.com/netbox-community/netbox)
 (DCIM + IPAM). Use it to answer questions about network inventory and addressing
-without clicking through the NetBox web UI. It never modifies NetBox.
+without clicking through the NetBox web UI. Reads are the default; seven safe-write
+commands (interface description, device status, IP/prefix/ip-range reserve, tag
+add/remove) are available behind `--allow-writes` + confirmation.
 
 ## When to use this skill
 
@@ -53,3 +55,25 @@ Output flags:
 stdout carries only the requested data; logs/diagnostics/errors go to stderr. Exit
 codes are stable: `3` auth, `4` not-found, `5` ambiguous. Full command + flag
 reference: [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md).
+
+## Safe writes
+
+`nbox` can modify NetBox through seven plan-first, dry-run/confirm-gated write
+commands (ADR-0001). Reads stay the default — a write never happens without
+explicit opt-in. See the focused skill files:
+
+- [Safe writes](skills/writes/SKILL.md) — the universal dry-run / confirm / audit
+  lifecycle shared by all seven write commands
+- [IPAM allocate](skills/ipam-allocate/SKILL.md) — `ip reserve`, `prefix reserve`,
+  `ip-range reserve` (POST to available-ips / available-prefixes)
+- [Tag writes](skills/tag-writes/SKILL.md) — `tag add`, `tag remove` (PATCH the
+  tags array on any object kind)
+- [PATCH writes](skills/patch-writes/SKILL.md) — `interface set description`,
+  `device set status` (minimal PATCH with ETag/If-Match concurrency)
+
+The recommended agent pattern is a two-step dry-run-then-apply:
+
+```bash
+nbox --no-tui <cmd> ... --dry-run --json          # preview the plan
+nbox --no-tui <cmd> ... --allow-writes --confirm --json  # apply
+```

--- a/scripts/lint_skills.sh
+++ b/scripts/lint_skills.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Lint the skills/ catalog shape: each skills/*/SKILL.md must have YAML
+# frontmatter with a non-empty `name` and `description`. Flag-free by design —
+# the lint checks the file structure, not the flag content (flags live in
+# `nbox <cmd> --help` and can't drift here).
+#
+# Usage: scripts/lint_skills.sh
+# Exit 0 if all skill files pass, 1 otherwise.
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+skills_dir="$root/skills"
+errors=0
+
+if [ ! -d "$skills_dir" ]; then
+    echo "error: $skills_dir not found" >&2
+    exit 1
+fi
+
+# Find every SKILL.md under skills/.
+while IFS= read -r -d '' skill_file; do
+    # Must start with `---` frontmatter.
+    if ! head -1 "$skill_file" | grep -q '^---$'; then
+        echo "error: $skill_file: missing YAML frontmatter (must start with ---)" >&2
+        errors=$((errors + 1))
+        continue
+    fi
+
+    # Extract frontmatter (between the first and second `---` lines).
+    frontmatter=$(sed -n '1,/^---$/p' "$skill_file" | sed '1d;$d')
+
+    # Must have a non-empty `name:`.
+    if ! echo "$frontmatter" | grep -q '^name: .\+'; then
+        echo "error: $skill_file: frontmatter missing non-empty 'name:'" >&2
+        errors=$((errors + 1))
+    fi
+
+    # Must have a non-empty `description:`.
+    if ! echo "$frontmatter" | grep -q '^description: .\+'; then
+        echo "error: $skill_file: frontmatter missing non-empty 'description:'" >&2
+        errors=$((errors + 1))
+    fi
+done < <(find "$skills_dir" -name 'SKILL.md' -print0)
+
+if [ "$errors" -gt 0 ]; then
+    echo "error: $errors skill file(s) failed lint" >&2
+    exit 1
+fi
+
+echo "ok: all skill files pass lint"

--- a/skills/ipam-allocate/SKILL.md
+++ b/skills/ipam-allocate/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: nbox-ipam-allocate
+description: Reserve the next available IP or prefix in NetBox using nbox's three allocate write commands — ip reserve, prefix reserve, and ip-range reserve. Use when the user wants to allocate IP addresses or child prefixes from NetBox.
+---
+
+# nbox IPAM allocation
+
+Three **allocate** write commands reserve the next available IP or prefix from
+NetBox, server-side and race-safe. All share the same dry-run / confirm /
+audit lifecycle (see the [safe writes skill](../writes/SKILL.md)).
+
+## The three allocate commands
+
+### `nbox ip reserve <prefix>`
+
+Reserve the next available IP address from a prefix.
+
+```bash
+nbox --no-tui ip reserve 10.0.0.0/24 --dry-run --json        # preview
+nbox --no-tui ip reserve 10.0.0.0/24 --allow-writes --confirm --json  # apply
+```
+
+Optional: `--vrf` (scope the prefix), `--description`, `--dns-name`,
+`--message`. The receipt's `object` is the created IP. Run `nbox ip reserve
+--help` for the full flag set.
+
+### `nbox prefix reserve <cidr>`
+
+Reserve the next available child prefix from a parent prefix.
+
+```bash
+nbox --no-tui prefix 10.0.0.0/24 reserve --dry-run --json
+nbox --no-tui prefix 10.0.0.0/24 reserve --length 26 --allow-writes --confirm --json
+```
+
+Optional: `--length N` (child prefix size), `--vrf`, `--description`, `--message`.
+The receipt's `object` is the created prefix. Run `nbox prefix reserve --help`
+for the full flag set.
+
+### `nbox ip-range reserve <start|id>`
+
+Reserve the next available IP address from an IP range (not a prefix).
+
+```bash
+nbox --no-tui ip-range 10.0.0.10 reserve --dry-run --json
+nbox --no-tui ip-range 10.0.0.10 reserve --allow-writes --confirm --json
+```
+
+Optional: `--description`, `--dns-name`, `--message`. The receipt's `object` is
+the created IP. Run `nbox ip-range reserve --help` for the full flag set.
+
+## Key properties
+
+- **Server-allocated, race-safe.** NetBox picks the address/block and never
+  hands out the same one twice. The plan carries no client precondition (no
+  ETag / last_updated) — the POST is authoritative.
+- **Dry-run advisory.** The dry-run shows the *currently* next available
+  resource as an advisory warning. NetBox allocates at apply time, so the
+  applied resource may differ (another client could allocate between preview
+  and apply).
+- **Receipt carries the created object.** The `--json` apply receipt's `object`
+  field is the reserved IP or prefix view — scripts get the assigned resource
+  without a follow-up read.
+- **Exhaustion is a clean error.** A 409 (prefix/range exhausted) or 400
+  (validation rejection) surfaces as exit 1, empty stdout, with the NetBox
+  error message on stderr.
+
+## Choosing a specific address
+
+Choosing a *specific* address (not "next available") is deferred (ADR-0001
+Decision 6) — it's a different operation (POST to `/ipam/ip-addresses/`, not
+to `/available-ips/`) with different conflict semantics.
+
+## Reference
+
+- [Safe writes skill](../writes/SKILL.md) — the universal lifecycle
+- [ADR-0001](https://github.com/lance0/nbox/blob/master/docs/adr/0001-safe-write-foundation.md) — foundation design

--- a/skills/patch-writes/SKILL.md
+++ b/skills/patch-writes/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: nbox-patch-writes
+description: Update NetBox object fields using nbox's PATCH write commands — interface set description and device set status. Use when the user wants to change an interface description or a device's status in NetBox.
+---
+
+# nbox PATCH writes
+
+Two **update** write commands modify specific fields on NetBox objects via
+minimal `PATCH` bodies. Both follow the same dry-run / confirm / audit lifecycle
+(see the [safe writes skill](../writes/SKILL.md)).
+
+## The two PATCH commands
+
+### `nbox interface <device> <interface> set description "…"`
+
+Set an interface's description.
+
+```bash
+nbox --no-tui interface edge01 xe-0/0/1 set description "uplink to core" --dry-run --json
+nbox --no-tui interface edge01 xe-0/0/1 set description "uplink to core" --allow-writes --confirm --json
+```
+
+Optional: `--message`. Run `nbox interface <device> <interface> set description
+--help` for the full flag set.
+
+### `nbox device <name> set status <value>`
+
+Set a device's status. The status value is validated live against NetBox's
+`OPTIONS` choices before any `PATCH` — a label (e.g. "active") is accepted
+case-insensitively when it maps unambiguously to one canonical value; an
+unknown or ambiguous status is a usage error (exit 2) naming the input and
+listing the allowed values, before any `PATCH`.
+
+```bash
+nbox --no-tui device edge01 set status active --dry-run --json
+nbox --no-tui device edge01 set status active --allow-writes --confirm --json
+```
+
+Optional: `--message`. Run `nbox device <name> set status --help` for the full
+flag set.
+
+## How they work
+
+- **Minimal PATCH.** The plan carries only the field being changed —
+  `{"description": "…"}` or `{"status": "active"}`. No other fields are sent.
+- **A no-op** (current value already matches) sends no `PATCH` — the receipt
+  reports `no_op: true`.
+- **Concurrency.** ETag + If-Match on NetBox 4.6+; `last_updated` + before-hash
+  on pre-4.6. A concurrent writer is caught (412 / hash mismatch) and the write
+  is refused with a "re-run dry-run" message (exit 1).
+- **Choice validation** (device status only): the allowed values are
+  enumerated live from NetBox via a read-only `OPTIONS` request, so nbox
+  never sends an invalid status. The normalization mechanism
+  (`src/netbox/choices.rs`) is reusable for future REST choice fields.
+
+## Reference
+
+- [Safe writes skill](../writes/SKILL.md) — the universal lifecycle
+- [ADR-0001](https://github.com/lance0/nbox/blob/master/docs/adr/0001-safe-write-foundation.md) — foundation design

--- a/skills/tag-writes/SKILL.md
+++ b/skills/tag-writes/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: nbox-tag-writes
+description: Add or remove tags on any NetBox object using nbox's tag write commands — tag add and tag remove. Use when the user wants to manage tags on devices, IPs, prefixes, VLANs, or any other NetBox object.
+---
+
+# nbox tag writes
+
+Two **update** write commands manage tags on any taggable NetBox object,
+sharing one planner/applier (`TagOperation::Add`/`Remove`). Both follow the
+same dry-run / confirm / audit lifecycle (see the
+[safe writes skill](../writes/SKILL.md)).
+
+## The two tag commands
+
+### `nbox tag add <type> <name> <tag>`
+
+Add a tag to any taggable object.
+
+```bash
+nbox --no-tui tag add device edge01 prod --dry-run --json
+nbox --no-tui tag add device edge01 prod --allow-writes --confirm --json
+```
+
+### `nbox tag remove <type> <name> <tag>`
+
+Remove a tag from any taggable object.
+
+```bash
+nbox --no-tui tag remove device edge01 prod --dry-run --json
+nbox --no-tui tag remove device edge01 prod --allow-writes --confirm --json
+```
+
+Optional: `--message`. Run `nbox tag add --help` / `nbox tag remove --help`
+for the full flag set.
+
+## How it works
+
+- **`<type>`** is any read kind: device, ip, prefix, vlan, site, rack, circuit,
+  vm, cluster, vrf, … — anything that carries a `tags` array.
+- **`<name>`** is the object's reference (name, slug, address, CIDR, id — same
+  resolver as `nbox <kind> <ref>`).
+- **`<tag>`** resolves by id, exact name, or exact slug (same resolver as
+  `nbox tagged`).
+- NetBox `PATCH` **replaces the whole `tags` array**, so the plan carries the
+  full replacement slug list. The before/after diff shows the tag slugs.
+- A **no-op** (adding a tag the object already carries, or removing one it
+  doesn't) sends no `PATCH` — the receipt reports `no_op: true`.
+- Concurrency: ETag + If-Match on NetBox 4.6+; `last_updated` + before-hash on
+  pre-4.6. A concurrent writer is caught and the write is refused with a
+  "re-run dry-run" message (exit 1).
+
+## Reference
+
+- [Safe writes skill](../writes/SKILL.md) — the universal lifecycle
+- [ADR-0001](https://github.com/lance0/nbox/blob/master/docs/adr/0001-safe-write-foundation.md) — foundation design

--- a/skills/writes/SKILL.md
+++ b/skills/writes/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: nbox-writes
+description: How to safely modify NetBox through nbox's write commands — the universal dry-run / confirm / audit lifecycle shared by all seven safe-write commands (interface description, device status, IP/prefix/ip-range reserve, tag add/remove). Use when the user wants to change NetBox objects, reserve IPs, or manage tags.
+---
+
+# nbox safe writes
+
+`nbox` can modify NetBox through seven **safe-write** commands, all on the same
+plan-first lifecycle (ADR-0001). Reads stay the default — a write never happens
+without explicit opt-in.
+
+## The universal lifecycle (all seven commands)
+
+Every write follows the same path, so an agent can learn it once:
+
+1. **Dry-run** (`--dry-run`) — builds a `MutationPlan`, shows the before/after
+   diff, performs no mutation. Needs neither `--allow-writes` nor `--confirm`.
+   With `--json`, returns the stable `MutationPlan` JSON (schema_version 1).
+
+2. **Apply** (`--allow-writes --confirm`) — builds the same plan, checks the
+   precondition (ETag/If-Match on 4.6+, last_updated on pre-4.6), and applies
+   it. With `--json`, returns a `MutationReceipt` (schema_version 1).
+
+3. **Refusal** — `--confirm` without `--allow-writes` is a usage error (exit 2,
+   empty stdout). Non-TTY / `--json` / `--no-tui` never prompts.
+
+## The seven write commands
+
+| Command | Operation | What it does |
+|---|---|---|
+| `nbox interface <device> <iface> set description "…"` | update (PATCH) | Set an interface's description |
+| `nbox device <name> set status <value>` | update (PATCH) | Set a device's status (validated live) |
+| `nbox ip reserve <prefix>` | allocate (POST) | Reserve the next available IP |
+| `nbox prefix reserve <cidr>` | allocate (POST) | Reserve the next available child prefix |
+| `nbox ip-range reserve <start\|id>` | allocate (POST) | Reserve the next available IP from an IP range |
+| `nbox tag add <type> <name> <tag>` | update (PATCH) | Add a tag to any object |
+| `nbox tag remove <type> <name> <tag>` | update (PATCH) | Remove a tag from any object |
+
+For the exact flags of each command, run `nbox <cmd> --help`. This skill is
+flag-free by design — it points at `--help` so it can't silently drift as the
+CLI evolves.
+
+## Agent usage pattern
+
+The recommended agent pattern is a two-step dry-run-then-apply:
+
+```bash
+# 1. Preview the plan (no mutation, no gate needed)
+nbox --no-tui <cmd> ... --dry-run --json
+
+# 2. If the plan looks correct, apply it
+nbox --no-tui <cmd> ... --allow-writes --confirm --json
+```
+
+Between the two steps, inspect the `MutationPlan` JSON — it carries the target,
+the field changes (before/after), the precondition, and any warnings. The
+`MutationReceipt` from step 2 carries the outcome, the HTTP status, and (for
+allocate writes) the created object.
+
+## What the audit logs (and doesn't)
+
+Every planned write emits one structured audit event (target `nbox::write_audit`)
+with: the surface (cli/tui/mcp), the profile, the NetBox host, the operation, the
+target kind/id, the **field names** that changed (never the values), the outcome,
+the HTTP method/path, the status, and the latency. An opt-in `--message` is
+recorded as a `message_present` flag + length — **never the message body**. The
+token never appears in the audit log.
+
+## The MCP server stays read-only
+
+No write tools are exposed over MCP. Per-user NetBox write identity (Pattern 2
+vault) is a prerequisite before MCP writes can ship. See ADR-0001 Decision 7.
+
+## Reference
+
+- [ADR-0001](https://github.com/lance0/nbox/blob/master/docs/adr/0001-safe-write-foundation.md) — the full safe-write foundation design
+- [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md) — the complete command + flag reference


### PR DESCRIPTION
## Summary

Grows the single root `SKILL.md` into a catalog of focused, flag-free skill files for the write surface, in the standard agent-skills layout (`skills/<domain>/SKILL.md`). This is the natural follow-up to the seven safe-write commands — it makes them discoverable by AI agents.

## Skill files

| File | Domain | Covers |
|---|---|---|
| `skills/writes/SKILL.md` | Universal | The dry-run/confirm/audit lifecycle shared by all seven writes |
| `skills/ipam-allocate/SKILL.md` | IPAM allocate | `ip reserve`, `prefix reserve`, `ip-range reserve` |
| `skills/tag-writes/SKILL.md` | Tag writes | `tag add`, `tag remove` |
| `skills/patch-writes/SKILL.md` | PATCH writes | `interface set description`, `device set status` |

## Design principle: flag-free

Each skill file points at `nbox <cmd> --help` rather than enumerating flags. This prevents the skills from silently drifting as the CLI evolves — the flags live in `--help` (generated from the clap definition), not in prose that can go stale.

## Root SKILL.md

Updated to:
- Mention the write surface in the frontmatter `description`
- Drop "read-only" from the body (now "reads are the default")
- Add a "Safe writes" section indexing the four skill files
- Show the recommended two-step dry-run-then-apply agent pattern

## CI lint

- `scripts/lint_skills.sh` — validates every `skills/*/SKILL.md` has YAML frontmatter with non-empty `name` and `description` fields
- `.github/workflows/skills-lint.yml` — a separate CI workflow (no `paths-ignore`) that runs the lint even on markdown-only changes, since the skills catalog is entirely markdown

## Verification

- `bash scripts/lint_skills.sh` — all skill files pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --all-targets` — 1294 tests pass
- Verified all five `nbox <cmd> --help` outputs match the skill file references

## Docs

Updated ROADMAP (marked "Agent write ergonomics" ☑ and "Per-domain agent-skills catalog" ☑ for the write domain) and CHANGELOG.