### PR TITLE
ci: feature matrix — intermediate feature combos + musl lean check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,55 @@ jobs:
       - name: Run security audit
         run: cargo audit
 
+  feature-matrix:
+    name: feature-matrix (${{ matrix.features }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - features: "http"
+            test: true
+          - features: "clipboard"
+            test: false
+          - features: "updates"
+            test: false
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build (--no-default-features --features ${{ matrix.features }})
+        run: cargo build --no-default-features --features ${{ matrix.features }} --locked --verbose
+
+      - name: Test (--no-default-features --features ${{ matrix.features }})
+        if: matrix.test
+        run: cargo test --no-default-features --features ${{ matrix.features }} --locked --verbose
+
+  musl-lean-check:
+    name: musl-lean-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Check lean musl build
+        run: cargo check --no-default-features --locked --target x86_64-unknown-linux-musl
+
   # Decide the cross-compile matrix by event. On a PR, build ONLY linux-musl (the
   # release-critical static target, and the leg that runs on a fast, never-queued
   # ubuntu runner) so the PR gate isn't gated on the slow macOS/Windows runners —

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -45,6 +45,17 @@ step "Build smoke — all features + no default features"
 cargo build --all-features --locked
 cargo build --no-default-features --locked
 
+step "Feature matrix — intermediate combinations"
+# Intermediate feature combinations between all-on and all-off. Mirror the
+# feature-matrix CI job so the pre-tag gate catches the same combos locally.
+for feat in http clipboard updates; do
+    echo "--- smoke: --no-default-features --features $feat ---"
+    cargo build --no-default-features --features "$feat" --locked || exit 1
+done
+# http has feature-gated integration tests (tests/mcp_serve_http_tests.rs).
+echo "--- smoke: test --no-default-features --features http ---"
+cargo test --no-default-features --features http --locked || exit 1
+
 step "Man pages + shell completions generate"
 smoke_dir="$(mktemp -d)"
 trap 'rm -rf "$smoke_dir"' EXIT


### PR DESCRIPTION
## What

Adds CI coverage for the intermediate feature combinations that sit between the two existing extremes (all-features, no-default-features), which were previously untested.

## Changes

### `.github/workflows/ci.yml`

- **`feature-matrix` job** — matrix build/test of each individual feature in isolation (`--no-default-features --features <feat>`):
  - `http` → build **and** test (it gates `tests/mcp_serve_http_tests.rs` behind `#![cfg(feature = "http")]`)
  - `clipboard` → build only (no feature-gated test file)
  - `updates` → build only (no feature-gated test file)
  - `fail-fast: false` so one leg failing doesn't mask the others.
- **`musl-lean-check` job** — `cargo check --no-default-features --target x86_64-unknown-linux-musl`. Catches static-link issues on the minimal dependency surface early on every PR, without the cost of a full musl build/test.

Both jobs follow existing conventions: `actions/checkout@v7`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, `--locked`, `--verbose` where appropriate. The top-level `paths-ignore: **.md` and `env: RUSTFLAGS: "-D warnings"` apply to them as to every other job.

### `scripts/smoke.sh`

Mirrors the feature-matrix combos in the local pre-tag gate so a tag never moves on a tree that would fail the new CI job. Added after the existing `--all-features` / `--no-default-features` build smoke:

- build loop over `http clipboard updates`
- test run for `http` (the only feature-gated integration test)

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml"))'` -> valid
- `bash -n scripts/smoke.sh` -> syntax OK
- Confirmed `http`, `clipboard`, `updates` all exist in `Cargo.toml` `[features]`
- Confirmed `tests/mcp_serve_http_tests.rs` is gated by `#![cfg(feature = "http")]` (justifies `test: true` only on the `http` leg)

No runtime tests -- this is CI/smoke configuration.
