### PR TITLE
refactor: CLI contract harness — unify assert_error_contract and migrate duplicates

### DIFF
--- a/tests/error_contract_tests.rs
+++ b/tests/error_contract_tests.rs
@@ -5,27 +5,14 @@
 //! stderr. Lower-level tests still cover typed error propagation in detail.
 
 use serde_json::json;
-use support::binary::{CommandOutput, run_nbox, temp_config};
+use support::binary::{
+    CommandOutput, assert_error_contract, assert_json_stdout, assert_success, run_nbox, temp_config,
+};
 use support::netbox::page;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod support;
-
-fn assert_error_contract(output: &CommandOutput, code: i32, expected_stderr: impl AsRef<str>) {
-    assert_eq!(output.code, Some(code), "stderr: {}", output.stderr);
-    assert!(
-        output.stdout.is_empty(),
-        "error paths must keep stdout clean, got: {:?}",
-        output.stdout
-    );
-    assert!(
-        output.stderr.contains(expected_stderr.as_ref()),
-        "stderr should contain {:?}, got: {:?}",
-        expected_stderr.as_ref(),
-        output.stderr
-    );
-}
 
 fn run_device(config: &tempfile::NamedTempFile, value: &str) -> CommandOutput {
     run_nbox([
@@ -199,4 +186,68 @@ async fn mac_ambiguous_exits_5_and_lists_the_interfaces() {
         "stderr should name the carrying interfaces: {:?}",
         output.stderr
     );
+}
+
+/// Contract test for the `tests/support/binary` harness itself: prove the
+/// three canonical helpers accept the shapes they promise (`impl AsRef<str>`
+/// for the error substring, a success `CommandOutput` for `assert_success`, and
+/// valid JSON stdout for `assert_json_stdout`) and panic on the wrong shape.
+/// These build `CommandOutput` directly (no binary spawn, no network) so the
+/// harness is pinned independently of any CLI behavior change.
+#[test]
+fn harness_helpers_accept_the_documented_shapes() {
+    // `assert_error_contract`: a `&str` (the common call-site shape) satisfies
+    // `impl AsRef<str>`, and a `String` does too.
+    let err = CommandOutput {
+        code: Some(2),
+        stdout: String::new(),
+        stderr: "no command given: pass --help".into(),
+    };
+    assert_error_contract(&err, 2, "no command given");
+    assert_error_contract(&err, 2, String::from("no command given"));
+
+    // `assert_success`: exit 0 with a non-empty stderr (warnings allowed on a
+    // success path) is accepted — only the code is constrained.
+    let ok = CommandOutput {
+        code: Some(0),
+        stdout: String::new(),
+        stderr: "warning: stale cache".into(),
+    };
+    assert_success(&ok);
+
+    // `assert_json_stdout`: exit 0 with valid JSON parses and returns the Value.
+    let json_out = CommandOutput {
+        code: Some(0),
+        stdout: r#"{"schema_version":1,"applied":true}"#.into(),
+        stderr: String::new(),
+    };
+    let value = assert_json_stdout(&json_out);
+    assert_eq!(value["schema_version"], json!(1));
+    assert_eq!(value["applied"], json!(true));
+}
+
+/// The error-contract helper rejects a polluted stdout on the error path (the
+/// whole point of the contract — errors never touch the data stream).
+#[test]
+#[should_panic(expected = "error paths must keep stdout clean")]
+fn harness_error_contract_rejects_polluted_stdout() {
+    let err = CommandOutput {
+        code: Some(2),
+        stdout: "leaked data".into(),
+        stderr: "no command given".into(),
+    };
+    assert_error_contract(&err, 2, "no command given");
+}
+
+/// `assert_json_stdout` panics (not a silent `unwrap`) when stdout is not valid
+/// JSON, so a malformed-data regression is loud.
+#[test]
+#[should_panic(expected = "stdout is not valid JSON")]
+fn harness_json_stdout_panics_on_non_json() {
+    let bad = CommandOutput {
+        code: Some(0),
+        stdout: "not json at all".into(),
+        stderr: String::new(),
+    };
+    let _ = assert_json_stdout(&bad);
 }

--- a/tests/no_tui_tests.rs
+++ b/tests/no_tui_tests.rs
@@ -10,51 +10,46 @@
 //! no TTY at all), and the refusal happens before any TUI/terminal init, so a
 //! blocking `wait()` cannot hang. Every command here is network-free.
 
-use std::process::{Command, Stdio};
+mod support;
 
-/// Run `nbox <args>` with no TTY (stdin from null, piped stdout/stderr) and
-/// return `(exit_code, stdout, stderr)`. `wait_with_output` reads to EOF and
-/// reaps the child, so it cannot hang once the process exits.
-fn run(args: &[&str]) -> (Option<i32>, String, String) {
-    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("spawn nbox");
-    (
-        out.status.code(),
-        String::from_utf8_lossy(&out.stdout).into_owned(),
-        String::from_utf8_lossy(&out.stderr).into_owned(),
-    )
-}
+use support::binary::run_nbox;
 
 #[test]
 fn no_tui_with_no_subcommand_refuses_with_exit_2() {
-    let (code, stdout, stderr) = run(&["--no-tui"]);
+    let out = run_nbox(["--no-tui"]);
 
-    assert_eq!(code, Some(2), "expected usage exit code 2");
-    assert!(stdout.is_empty(), "stdout must stay clean, got: {stdout:?}");
+    assert_eq!(out.code, Some(2), "expected usage exit code 2");
     assert!(
-        stderr.contains("--no-tui"),
-        "stderr should explain --no-tui, got: {stderr:?}"
+        out.stdout.is_empty(),
+        "stdout must stay clean, got: {:?}",
+        out.stdout
     );
     assert!(
-        stderr.contains("no command given"),
-        "stderr should name the empty invocation, got: {stderr:?}"
+        out.stderr.contains("--no-tui"),
+        "stderr should explain --no-tui, got: {:?}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("no command given"),
+        "stderr should name the empty invocation, got: {:?}",
+        out.stderr
     );
 }
 
 #[test]
 fn no_tui_with_explicit_tui_subcommand_refuses_with_exit_2() {
-    let (code, stdout, stderr) = run(&["--no-tui", "tui"]);
+    let out = run_nbox(["--no-tui", "tui"]);
 
-    assert_eq!(code, Some(2), "expected usage exit code 2");
-    assert!(stdout.is_empty(), "stdout must stay clean, got: {stdout:?}");
+    assert_eq!(out.code, Some(2), "expected usage exit code 2");
     assert!(
-        stderr.contains("conflicts with the `tui` command"),
-        "stderr should name the conflict with `tui`, got: {stderr:?}"
+        out.stdout.is_empty(),
+        "stdout must stay clean, got: {:?}",
+        out.stdout
+    );
+    assert!(
+        out.stderr.contains("conflicts with the `tui` command"),
+        "stderr should name the conflict with `tui`, got: {:?}",
+        out.stderr
     );
 }
 
@@ -64,7 +59,7 @@ fn no_tui_is_a_no_op_on_a_normal_subcommand() {
     // unaffected. With no config/profile, `nbox --no-tui status` fails to connect
     // (it does NOT get the --no-tui usage refusal), proving the flag is inert
     // here. We assert it did NOT exit 2 with the --no-tui message.
-    let (code, stdout, stderr) = run(&[
+    let out = run_nbox([
         "--no-tui",
         "--config",
         "/nonexistent/nbox/config/does-not-exist.toml",
@@ -73,11 +68,16 @@ fn no_tui_is_a_no_op_on_a_normal_subcommand() {
 
     // It fails (no usable config), but never launches a TUI and never prints the
     // --no-tui refusal — the flag is a silent no-op on a real subcommand.
-    assert_ne!(code, Some(0), "status with no config should fail");
+    assert_ne!(out.code, Some(0), "status with no config should fail");
     assert!(
-        !stderr.contains("no command given") && !stderr.contains("--no-tui suppresses"),
-        "the --no-tui refusal must not fire on a real subcommand, got: {stderr:?}"
+        !out.stderr.contains("no command given") && !out.stderr.contains("--no-tui suppresses"),
+        "the --no-tui refusal must not fire on a real subcommand, got: {:?}",
+        out.stderr
     );
     // stdout stays clean on the error path regardless.
-    assert!(stdout.is_empty(), "stdout must stay clean, got: {stdout:?}");
+    assert!(
+        out.stdout.is_empty(),
+        "stdout must stay clean, got: {:?}",
+        out.stdout
+    );
 }

--- a/tests/support/binary.rs
+++ b/tests/support/binary.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+use serde_json::Value;
 use tempfile::NamedTempFile;
 
 pub struct CommandOutput {
@@ -45,4 +46,39 @@ pub fn temp_config(url: &str) -> NamedTempFile {
     .expect("write temp config");
     config.flush().expect("flush temp config");
     config
+}
+
+/// Assert the process-level error contract: a stable exit code, EMPTY stdout
+/// (errors never pollute the data stream), and an actionable stderr substring.
+/// `stderr_contains` accepts `impl AsRef<str>` so call sites can pass `&str`
+/// or `String` interchangeably.
+pub fn assert_error_contract(output: &CommandOutput, code: i32, stderr_contains: impl AsRef<str>) {
+    assert_eq!(output.code, Some(code), "stderr: {}", output.stderr);
+    assert!(
+        output.stdout.is_empty(),
+        "error paths must keep stdout clean, got: {:?}",
+        output.stdout
+    );
+    assert!(
+        output.stderr.contains(stderr_contains.as_ref()),
+        "stderr should contain {:?}, got: {:?}",
+        stderr_contains.as_ref(),
+        output.stderr
+    );
+}
+
+/// Assert the success-path contract: exit code 0 (stderr is reported on failure
+/// for context but otherwise unconstrained — warnings on a success path are
+/// allowed).
+pub fn assert_success(output: &CommandOutput) {
+    assert_eq!(output.code, Some(0), "stderr: {}", output.stderr);
+}
+
+/// Assert the process exited 0 and parse stdout as JSON. Panics with both the
+/// parse error and the raw stdout if the output is not valid JSON, so a
+/// malformed-data regression is obvious from the failure message.
+pub fn assert_json_stdout(output: &CommandOutput) -> Value {
+    assert_success(output);
+    serde_json::from_str(&output.stdout)
+        .unwrap_or_else(|e| panic!("stdout is not valid JSON: {e}\n{}", output.stdout))
 }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -22,7 +22,7 @@ mod support;
 use std::process::{Command, Stdio};
 
 use serde_json::{Value, json};
-use support::binary::{CommandOutput, run_nbox, temp_config};
+use support::binary::{CommandOutput, assert_error_contract, run_nbox, temp_config};
 use tempfile::NamedTempFile;
 use wiremock::matchers::{body_partial_json, header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -32,23 +32,6 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// token-redaction assertion). Identical shape to `support::binary::temp_config`.
 fn write_config(server_uri: &str) -> NamedTempFile {
     temp_config(server_uri)
-}
-
-/// Assert the process-level error contract: a stable exit code, EMPTY stdout
-/// (errors never pollute the data stream), and an actionable stderr substring.
-fn assert_error_contract(output: &CommandOutput, code: i32, stderr_contains: &str) {
-    assert_eq!(output.code, Some(code), "stderr: {}", output.stderr);
-    assert!(
-        output.stdout.is_empty(),
-        "error paths must keep stdout clean, got: {:?}",
-        output.stdout
-    );
-    assert!(
-        output.stderr.contains(stderr_contains),
-        "stderr should contain {:?}, got: {:?}",
-        stderr_contains,
-        output.stderr
-    );
 }
 
 /// The device + interface-name resolution mocks `plan_interface_description_update`


### PR DESCRIPTION
## Summary

Promotes the ad-hoc `(exit_code, clean stdout, stderr substring)` assertion patterns duplicated across test files into one canonical harness in `tests/support/binary.rs`, then migrates every duplicate to use it. The harness extends the existing patterns — it does not replace them or invent new conventions.

## Changes

### 1. Canonical harness in `tests/support/binary.rs`
Adds three reusable helpers alongside the existing `CommandOutput` / `run_nbox` / `temp_config`:

- `assert_error_contract(&output, code, stderr_contains: impl AsRef<str>)` — exit code, **empty stdout** (errors never pollute the data stream), and an actionable stderr substring. `impl AsRef<str>` accepts both `&str` and `String`.
- `assert_success(&output)` — exit code 0 (stderr otherwise unconstrained; warnings on a success path are allowed).
- `assert_json_stdout(&output) -> serde_json::Value` — exit 0 plus parseable JSON stdout; panics with the parse error *and* the raw stdout on failure so a malformed-data regression is loud.

### 2. Migrate the duplicated copies
- `tests/write_tests.rs` — removed the local `assert_error_contract` (took `&str`); added `assert_error_contract` to the `support::binary` import. All 38 call sites pass `&str`, which satisfies `impl AsRef<str>`. No call-site changes.
- `tests/error_contract_tests.rs` — removed the local `assert_error_contract` (took `impl AsRef<str>`); added it to the import.
- `tests/no_tui_tests.rs` — replaced the local `fn run(args) -> (Option<i32>, String, String)` with `run_nbox` + `CommandOutput`. Tuple destructuring at call sites became field access (`.code` / `.stdout` / `.stderr`). `run_nbox` additionally strips `NBOX_LOG`/`RUST_LOG`, which the local `run` did not.

### 3. Contract test for the harness itself
Added three tests in `tests/error_contract_tests.rs` that build `CommandOutput` directly (no binary spawn, no network) so the harness is pinned independently of any CLI behavior change:

- `harness_helpers_accept_the_documented_shapes` — `&str` and `String` both satisfy `assert_error_contract`; a success `CommandOutput` with a warning stderr passes `assert_success`; valid JSON stdout parses via `assert_json_stdout`.
- `harness_error_contract_rejects_polluted_stdout` — `#[should_panic]` proving the empty-stdout invariant is enforced.
- `harness_json_stdout_panics_on_non_json` — `#[should_panic]` proving non-JSON stdout fails loudly.

## Verification

Ran only the three specified suites (no full-suite run):

```
cargo test --test write_tests          → 86 passed
cargo test --test error_contract_tests → 11 passed  (includes 3 new harness tests)
cargo test --test no_tui_tests          →  3 passed
```