### PR TITLE
feat: observability contracts — pin nbox status, MCP status, audit fields

### DIFF
--- a/src/netbox/status.rs
+++ b/src/netbox/status.rs
@@ -421,4 +421,34 @@ mod tests {
             "unverified (endpoint absent (NetBox < 4.5))"
         );
     }
+
+    #[test]
+    fn auth_check_serde_shape_tags_each_variant() {
+        // The `token` field of `nbox status` / MCP `nbox_status` is a tagged
+        // enum (`#[serde(tag = "status", rename_all = "snake_case")]`). An agent
+        // reads `token.status` to decide validity, so the tag value and the
+        // per-variant fields are a stable contract — pin all three shapes.
+        let valid = serde_json::to_value(AuthCheck::Valid {
+            username: "admin".into(),
+            display: Some("Admin".into()),
+        })
+        .expect("serialize Valid");
+        assert_eq!(valid["status"], "valid");
+        assert_eq!(valid["username"], "admin");
+        assert_eq!(valid["display"], "Admin");
+
+        let invalid = serde_json::to_value(AuthCheck::Invalid {
+            reason: "bad token".into(),
+        })
+        .expect("serialize Invalid");
+        assert_eq!(invalid["status"], "invalid");
+        assert_eq!(invalid["reason"], "bad token");
+
+        let unverified = serde_json::to_value(AuthCheck::Unverified {
+            reason: "not checked".into(),
+        })
+        .expect("serialize Unverified");
+        assert_eq!(unverified["status"], "unverified");
+        assert_eq!(unverified["reason"], "not checked");
+    }
 }

--- a/src/netbox/write_audit.rs
+++ b/src/netbox/write_audit.rs
@@ -196,6 +196,7 @@ mod tests {
         assert_eq!(Outcome::DryRun.as_str(), "dry_run");
         assert_eq!(Outcome::NoOp.as_str(), "no_op");
         assert_eq!(Outcome::Applied.as_str(), "applied");
+        assert_eq!(Outcome::Partial.as_str(), "partial");
         assert_eq!(Outcome::NotApplied.as_str(), "not_applied");
         assert_eq!(Outcome::Stale.as_str(), "stale");
         assert_eq!(Outcome::Validation.as_str(), "validation");
@@ -250,5 +251,98 @@ mod tests {
         let s = Started::now();
         // Just exercises the path; a freshly started stopwatch reads ~0ms.
         assert!(s.elapsed_ms() < 5_000);
+    }
+
+    /// The tracing event `emit()` produces carries exactly the documented
+    /// field allow-list — and no `token`/`authorization`/secret — regardless
+    /// of what an operator filters. Pins the field names an agent/log scraper
+    /// can rely on; a removed, renamed, or added field fails here.
+    #[test]
+    fn write_audit_field_allowlist_is_stable() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        use tracing::field::{Field, Visit};
+        use tracing::subscriber::with_default;
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::{Layer, Registry};
+
+        // A tracing layer that records the field NAMES of every event under
+        // the write-audit target. We use it to prove the emitted record carries
+        // exactly the documented allow-list — and, crucially, no
+        // `token`/`authorization` field.
+        #[derive(Default)]
+        struct Capture {
+            names: Arc<StdMutex<Vec<String>>>,
+        }
+        struct NameVisitor<'a> {
+            names: &'a mut Vec<String>,
+        }
+        impl Visit for NameVisitor<'_> {
+            fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
+                self.names.push(field.name().to_string());
+            }
+            fn record_str(&mut self, field: &Field, _value: &str) {
+                self.names.push(field.name().to_string());
+            }
+        }
+        impl<S: tracing::Subscriber> Layer<S> for Capture {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                if event.metadata().target() != AUDIT_TARGET {
+                    return;
+                }
+                let mut names = self.names.lock().unwrap();
+                let mut v = NameVisitor { names: &mut names };
+                event.record(&mut v);
+            }
+        }
+
+        let names = Arc::new(StdMutex::new(Vec::new()));
+        let layer = Capture {
+            names: names.clone(),
+        };
+        let subscriber = Registry::default().with(layer);
+
+        with_default(subscriber, || {
+            ev(&["description", "status"], None).emit();
+        });
+
+        let names = names.lock().unwrap();
+
+        // The exact documented allow-list (plus the `message` event message).
+        let allowed = [
+            "message",
+            "surface",
+            "profile",
+            "host",
+            "operation",
+            "target_kind",
+            "target_id",
+            "target_display",
+            "fields",
+            "outcome",
+            "http_method",
+            "http_path",
+            "status",
+            "latency_ms",
+            "request_id",
+            "message_present",
+            "message_len",
+        ];
+        for name in names.iter() {
+            assert!(
+                allowed.contains(&name.as_str()),
+                "write-audit event emitted an unexpected field: {name}"
+            );
+        }
+        // The forbidden fields must never be present, under any name.
+        for forbidden in ["token", "authorization", "secret", "bearer"] {
+            assert!(
+                !names.iter().any(|n| n == forbidden),
+                "write-audit event must never emit a `{forbidden}` field"
+            );
+        }
+        // Sanity: a representative allow-list field did make it through.
+        assert!(names.iter().any(|n| n == "outcome"));
+        assert!(names.iter().any(|n| n == "surface"));
     }
 }

--- a/tests/observability_contracts_tests.rs
+++ b/tests/observability_contracts_tests.rs
@@ -1,0 +1,169 @@
+//! Observability contracts for `nbox status` at the process boundary.
+//!
+//! These drive the real compiled `nbox` binary against a `wiremock` NetBox so
+//! the public `nbox status --json` shape and exit-code contract are pinned where
+//! an agent (or script) actually consumes them: stable top-level key set, nested
+//! `api`/`capabilities`/`token` shapes, and exit 3 on authentication failure with
+//! clean stdout. The mirror contract for the MCP `nbox_status` tool lives in
+//! `src/mcp/tests.rs::contracts::status_report_shape_is_pinned`.
+
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+use serde_json::json;
+use support::binary::CommandOutput;
+use tempfile::NamedTempFile;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod support;
+
+/// Assert a JSON object has exactly these top-level keys (order-independent).
+/// Pins the contract's key set: a removed or renamed field, or a new one not
+/// listed here, fails the test. Mirrors the `assert_keys` helper in the MCP
+/// contracts module so the CLI and MCP contracts read identically.
+fn assert_keys(value: &Value, expected: &[&str]) {
+    let obj = value.as_object().expect("a JSON object");
+    let mut got: Vec<&str> = obj.keys().map(String::as_str).collect();
+    got.sort_unstable();
+    let mut want: Vec<&str> = expected.to_vec();
+    want.sort_unstable();
+    assert_eq!(got, want, "key set drifted; full value: {value}");
+}
+
+/// Assert the binary error contract: stable exit code, clean stdout, and an
+/// actionable substring on stderr. Mirrors `assert_error_contract` in
+/// `error_contract_tests.rs`.
+fn assert_error_contract(output: &CommandOutput, code: i32, expected_stderr: impl AsRef<str>) {
+    assert_eq!(output.code, Some(code), "stderr: {}", output.stderr);
+    assert!(
+        output.stdout.is_empty(),
+        "error paths must keep stdout clean, got: {:?}",
+        output.stdout
+    );
+    assert!(
+        output.stderr.contains(expected_stderr.as_ref()),
+        "stderr should contain {:?}, got: {:?}",
+        expected_stderr.as_ref(),
+        output.stderr
+    );
+}
+
+/// A temp config whose `token_env` is deliberately never exported, so token
+/// resolution falls through to `NBOX_TOKEN` (set per Command). Mirrors the
+/// shared `support::binary::temp_config` plus an explicit token env name.
+fn temp_config(url: &str) -> NamedTempFile {
+    support::binary::temp_config(url)
+}
+
+/// Run `nbox --config <config> --no-tui --json status` with `NBOX_TOKEN` set.
+/// Token precedence is `token_env` → `NBOX_TOKEN` → config token; the profile's
+/// `token_env` (`NBOX_TEST_TOKEN_UNUSED`) is never exported, so resolution lands
+/// on the `NBOX_TOKEN` we set here (matching the pattern in `it_netbox.rs`).
+fn run_status(config: &NamedTempFile, token: &str) -> CommandOutput {
+    let out = Command::new(env!("CARGO_BIN_EXE_nbox"))
+        .arg("--config")
+        .arg(config.path())
+        .arg("--no-tui")
+        .arg("--json")
+        .arg("status")
+        .env("NBOX_TOKEN", token)
+        .env_remove("NBOX_LOG")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn nbox");
+    CommandOutput {
+        code: out.status.code(),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+/// `nbox status --json` key-set contract — mirrors the MCP
+/// `status_report_shape_is_pinned` test at the process boundary, so an agent
+/// reading stdout sees the same shape a host reading the MCP tool gets.
+#[tokio::test]
+async fn cli_status_key_set_is_pinned() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/status/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "netbox-version": "4.5.5",
+            "django-version": "5.1",
+            "python-version": "3.12"
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/authentication-check/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "username": "admin"
+        })))
+        .mount(&server)
+        .await;
+    // A REST-only profile never probes GraphQL, but mount a 404 defensively so a
+    // future preference change can't make this test flap on an unmocked path.
+    Mock::given(method("POST"))
+        .and(path("/graphql/"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let config = temp_config(&server.uri());
+    let out = run_status(&config, "test-token");
+
+    assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
+    let value: Value = serde_json::from_str(&out.stdout).expect("parse status JSON");
+
+    // Top-level contract: every key always present (no skip_serializing).
+    assert_keys(
+        &value,
+        &[
+            "api",
+            "capabilities",
+            "django_version",
+            "netbox_url",
+            "netbox_version",
+            "python_version",
+            "token",
+        ],
+    );
+
+    // Per-surface routing: each surface reports configured + effective; the
+    // optional `reason` is omitted when there is no fallback (REST profile).
+    assert_keys(&value["api"], &["search", "vrf", "route_target"]);
+    assert_keys(&value["api"]["search"], &["configured", "effective"]);
+    assert_keys(&value["api"]["vrf"], &["configured", "effective"]);
+    assert_keys(&value["api"]["route_target"], &["configured", "effective"]);
+
+    // Capability summary: the three blocks.
+    assert_keys(&value["capabilities"], &["graphql", "rest", "version"]);
+
+    // Credential preflight: the `token` verdict carries the discriminator and,
+    // on `valid`, the resolved username. `display` is omitted when NetBox
+    // reports none distinct from the username (the mock body has no `display`).
+    assert_eq!(value["token"]["status"], "valid");
+    assert_keys(&value["token"], &["status", "username"]);
+    assert_eq!(value["token"]["username"], "admin");
+}
+
+/// `nbox status` exits 3 with clean stdout and an "authentication failed"
+/// message when `/api/status/` rejects the token (401). Pins the exit-code
+/// contract a script relies on to distinguish auth failure from a generic error.
+#[tokio::test]
+async fn cli_status_exits_3_on_auth_failure() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/status/"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let config = temp_config(&server.uri());
+    let out = run_status(&config, "test-token");
+
+    assert_error_contract(&out, 3, "authentication failed");
+}


### PR DESCRIPTION
## What

Pins the observability surface an agent (or script) reads to detect backend, version, capability, and failure mode — as stable contracts, not prose.

## Changes

### `tests/observability_contracts_tests.rs` (new)
Binary-level contracts driving the real `nbox` binary against a `wiremock` NetBox, mirroring the MCP `nbox_status` contract test at `src/mcp/tests.rs:2128`:

1. **`cli_status_key_set_is_pinned`** — mocks `/api/status/` (200, NetBox 4.5.5) + `/api/authentication-check/` (200, admin) + a defensive `/graphql/` 404, runs `nbox --config <config> --no-tui --json status`, parses stdout JSON, and asserts:
   - The exact top-level key set is `[api, capabilities, django_version, netbox_url, netbox_version, python_version, token]`.
   - `api` has `[search, vrf, route_target]`, each with `[configured, effective]` (no `reason` on a clean REST profile).
   - `capabilities` has `[graphql, rest, version]`.
   - `token.status == "valid"` with `[status, username]`.
2. **`cli_status_exits_3_on_auth_failure`** — mocks `/api/status/` 401, asserts exit 3, empty stdout, stderr contains "authentication failed".

### `src/netbox/status.rs`
3. **`auth_check_serde_shape_tags_each_variant`** — unit test serializing all three `AuthCheck` variants (`Valid{username, display:Some}`, `Invalid{reason}`, `Unverified{reason}`) to JSON `Value` and asserting the `status` tag key carries the correct snake_case value plus the variant fields.

### `src/netbox/write_audit.rs`
4. **`outcome_strings_are_stable`** — extended to include `Outcome::Partial => "partial"` in the assertion list.
5. **`write_audit_field_allowlist_is_stable`** — new unit test using a tracing capture layer to assert `WriteAuditEvent::emit()` emits exactly the documented field allow-list (surface, profile, host, operation, target_kind, target_id, target_display, fields, outcome, http_method, http_path, status, latency_ms, request_id, message_present, message_len) plus the `message` event message — and never `token`/`authorization`/`secret`/`bearer`.

### `src/mcp/audit.rs` (no changes)
The `AuthMode` string table (`loopback`, `static-bearer`, `oidc`) and MCP `Outcome` string table (`ok`, `auth-failed`, `rate-limited`, `error`) are already pinned by the existing `auth_mode_as_str_is_stable` and `outcome_as_str_is_stable` tests — verified, no changes needed.

## Verification

- `cargo test --test observability_contracts_tests` — 2 passed
- `cargo test --lib -- netbox::status::tests netbox::write_audit::tests` — 19 passed (includes the 2 new unit tests)
- `cargo test --lib -- mcp::audit::tests::auth_mode_as_str_is_stable mcp::audit::tests::outcome_as_str_is_stable` — 2 passed (pre-existing, unchanged)