### PR TITLE
perf: output streaming — write JSON/CSV directly to stdout, skip Value/String materialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1280,8 +1280,7 @@ async fn run_search(
                     .filter(|s| !s.is_empty())
                     .collect()
             });
-            let value = serde_json::to_value(&results)?;
-            print!("{}", output::csv::to_csv(&value, columns.as_deref())?);
+            output::csv::print_streaming(&results, columns.as_deref())?;
         }
         Format::Plain => {
             if results.is_empty() {

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -8,6 +8,8 @@
 //! Scalars/complex cell values are stringified (nested objects/arrays as
 //! compact JSON).
 
+use std::io::Write;
+
 use anyhow::Result;
 use serde::Serialize;
 use serde_json::Value;
@@ -21,6 +23,36 @@ const CSV_NOT_TABULAR: &str = "CSV output is only supported for tabular results 
 pub fn print<T: Serialize>(value: &T) -> Result<()> {
     let value = serde_json::to_value(value)?;
     print!("{}", to_csv(&value, None)?);
+    Ok(())
+}
+
+/// Write CSV directly to a locked stdout, row by row, instead of building one
+/// full String. Byte-identical to `print` (and `to_csv`) — `escape` and `cell`
+/// are reused unchanged; only the writer target differs (`write!` vs
+/// `String::push_str`).
+pub fn print_streaming<T: Serialize>(value: &T, cols: Option<&[String]>) -> Result<()> {
+    let v = serde_json::to_value(value)?; // still need Value to inspect shape
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    match &v {
+        Value::Array(items) => {
+            // Two-pass: infer columns first (needed before writing header), then stream rows.
+            let columns = match cols {
+                Some(c) if !c.is_empty() => c.to_vec(),
+                _ => infer_columns(items),
+            };
+            write_header(&mut lock, &columns)?;
+            for item in items {
+                write_row(&mut lock, item, &columns)?;
+            }
+        }
+        Value::Object(_) => {
+            return Err(NboxError::Usage(CSV_NOT_TABULAR.to_string()).into());
+        }
+        other => {
+            writeln!(lock, "{}", escape(&cell(other)))?;
+        }
+    }
     Ok(())
 }
 
@@ -78,6 +110,27 @@ fn row<'a>(fields: impl Iterator<Item = &'a str>) -> String {
 fn row_owned(fields: impl Iterator<Item = String>) -> String {
     let escaped: Vec<String> = fields.map(|f| escape(&f)).collect();
     format!("{}\n", escaped.join(","))
+}
+
+/// Write the CSV header line (escaped column names joined by commas, trailing
+/// newline) to `w`. Streaming-path sibling of the `row` helper — builds the line
+/// as a String then writes it, so the byte output matches `array_csv` exactly.
+fn write_header<W: Write>(w: &mut W, columns: &[String]) -> Result<()> {
+    let line = row(columns.iter().map(String::as_str));
+    w.write_all(line.as_bytes())?;
+    Ok(())
+}
+
+/// Write one CSV record for `item` (an object) to `w`, selecting `columns` in
+/// order; missing keys render as empty cells. Streaming-path sibling of
+/// `row_owned` — byte-identical to the `array_csv` row output.
+fn write_row<W: Write>(w: &mut W, item: &Value, columns: &[String]) -> Result<()> {
+    let values = columns
+        .iter()
+        .map(|c| item.get(c).map(cell).unwrap_or_default());
+    let line = row_owned(values);
+    w.write_all(line.as_bytes())?;
+    Ok(())
 }
 
 /// Stringify a single JSON value for a CSV cell.

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,5 +1,7 @@
 //! JSON output for scriptable / agent consumers.
 
+use std::io::Write;
+
 use anyhow::Result;
 use serde::Serialize;
 use serde_json::Value;
@@ -50,6 +52,24 @@ pub fn render_with<T: Serialize>(value: &T, opts: &JsonOptions) -> Result<String
 /// Print `value` as JSON, applying field selection, envelope, and raw options.
 pub fn print_with<T: Serialize>(value: &T, opts: &JsonOptions) -> Result<()> {
     println!("{}", render_with(value, opts)?);
+    Ok(())
+}
+
+/// Write a value directly to a locked stdout via `serde_json::to_writer_pretty`,
+/// skipping the intermediate `Value` + `String` materialization. Byte-identical
+/// to `render_with(value, &JsonOptions::default())` followed by `println!` —
+/// `to_writer_pretty` and `to_string_pretty` share the same formatter. Only
+/// called when no shaping is needed (`opts.fields.is_none() && !opts.envelope`);
+/// `opts.raw` selects the compact writer.
+pub fn print_streaming<T: Serialize>(value: &T, opts: &JsonOptions) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    if opts.raw {
+        serde_json::to_writer(&mut lock, value)?;
+    } else {
+        serde_json::to_writer_pretty(&mut lock, value)?;
+    }
+    writeln!(lock)?;
     Ok(())
 }
 

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -21,8 +21,18 @@ pub fn emit<T: Serialize>(
     plain: impl FnOnce(),
 ) -> Result<()> {
     match format {
-        Format::Json => json::print_with(value, opts)?,
-        Format::Csv => csv::print(value)?,
+        Format::Json => {
+            // Fast path: when no shaping is needed, stream straight to a locked
+            // stdout via serde_json::to_writer_pretty — skipping both the
+            // intermediate Value and the full String materialization. Byte-identical
+            // to print_with (to_writer_pretty and to_string_pretty share a formatter).
+            if opts.fields.is_none() && !opts.envelope {
+                json::print_streaming(value, opts)?;
+            } else {
+                json::print_with(value, opts)?;
+            }
+        }
+        Format::Csv => csv::print_streaming(value, None)?,
         Format::Plain => plain(),
     }
     Ok(())


### PR DESCRIPTION
## Summary

The JSON/CSV output paths previously materialized a full `serde_json::Value` then a full `String` before writing. This adds a streaming fast path that writes directly to a locked `StdoutLock` when no shaping is needed, skipping both allocations.

## Changes

### JSON (`src/output/json.rs`)
- New `print_streaming<T: Serialize>(value, opts)` writes via `serde_json::to_writer_pretty` (or `to_writer` for `--raw`) directly to a locked stdout, then `writeln!`. Byte-identical to `render_with(value, &JsonOptions::default())` followed by `println!` — `to_writer_pretty` and `to_string_pretty` share the same formatter.

### CSV (`src/output/csv.rs`)
- New `print_streaming<T: Serialize>(value, cols)` infers columns, then streams the header + rows one at a time to a locked stdout via `write_header`/`write_row` helpers. The helpers build each line as a `String` (reusing the existing `row`/`row_owned`/`escape`/`cell` unchanged) then `write_all` it, so the byte output is identical to the materializing `to_csv` path.

### Wiring (`src/output/mod.rs`, `src/lib.rs`)
- `emit` uses `json::print_streaming` when `opts.fields.is_none() && !opts.envelope`, falling back to `json::print_with` for shaped output.
- `emit` uses `csv::print_streaming` for the CSV arm.
- `run_search`'s CSV arm (which bypasses `emit` to pass `--cols`) now calls `csv::print_streaming` directly instead of `to_value` + `to_csv` + `print!`.

## Old functions kept
`render_with`, `print_with`, `to_csv`, and `print` are unchanged — the test helpers (`render_json`, `shaped_json` in `tests/support/json_contract.rs`) call `render_with` directly, and `tests/csv_contracts_tests.rs` calls `to_csv` directly. The streaming path is additional, not a replacement.

## Verification
- `cargo test --test output_flags_tests` — 8 passed
- `cargo test --test csv_contracts_tests` — 10 passed
- `cargo test --test golden_output_tests` — 10 passed
- `cargo test --test perf_baseline_tests` — 5 passed (JSON single-write test still passes)