### PR TITLE
feat: atomic multi-IP allocation via list-body POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     allocation. The audit log records `outcome=partial`. A first-`POST` failure
     (k=0, nothing created) is not a partial receipt: it propagates as the plain
     single-reserve error (exit 1, empty stdout).
+  - **Atomic multi-IP (list-body POST).** `count > 1` first attempts a single
+    list-body `POST` (`[body, body, …]` — N copies of the single-IP create
+    body) so NetBox creates all N or zero IPs in one round-trip; on success the
+    receipt is `partial: false` with all N `IpView`s. Older NetBox that rejects
+    the list shape (HTTP 400/422) falls back to the N sequential `POST`s above
+    (which may still yield `partial: true`). Other atomic-path failures (409
+    exhaustion, 401/403, 412, network) propagate as a plain exit-1 error — no
+    fallback, no orphan IPs, since the list-body request creates zero on
+    rejection. `count == 1` is unchanged (single-object `POST`, byte-identical
+    receipt).
   - **Backward compatible.** `count=1` (the default) is byte-identical to the
     existing single-IP plan/receipt — `count`, `partial`, `requested_count`, and
     `created_count` use `skip_serializing_if` defaults so they're omitted when

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -468,16 +468,16 @@ the read tool proves out in practice. Consolidated future scope:
   confirmation token. Partial failure (k of N POSTs succeeded) returns the k
   created IPs with `partial: true` and exit 1; the audit logs `outcome=partial`.
   `count=1` plans/receipts are byte-identical to existing single-IP ones.
-- ☐ **Atomic multi-IP allocation (list-body POST).** NetBox's `available-ips`
+- ☑ **Atomic multi-IP allocation (list-body POST).** NetBox's `available-ips`
   endpoint accepts a JSON list body (`[{…}, …]`) for all-or-nothing allocation
-  in a single round-trip — the server either creates all N or creates zero. The
-  current sequential-POST approach (above) permits partial states (handled
-  honestly with `partial: true` + exit 1, but the operator still has k orphan
-  IPs to clean up) and costs N round-trips. Switching to the list-body POST
-  would eliminate the partial-failure path and cut latency to one request; the
-  touch points are small (POST body builder + response parser already handles
-  single `IpView` vs. JSON array). Revisit if orphan-IP cleanup burden shows up
-  in practice.
+  in a single round-trip — the server either creates all N or creates zero.
+  `count > 1` now attempts the list-body POST first (one request, all-or-
+  nothing); on a server rejection of the list shape (HTTP 400/422, older
+  NetBox) it falls back to the N sequential POSTs above, which may still yield
+  a partial state (`partial: true` + exit 1). Other atomic-path failures (409
+  exhaustion, 401/403, 412, network) propagate as a plain error — no orphan
+  IPs, since the list-body request creates zero on rejection. `count == 1`
+  stays on the single-object POST path, byte-identical to existing receipts.
 - ☐ **IPAM allocate (rest)** — choosing a specific address/block. The read half
   (`next-ip` / `next-prefix`, range lookup) and all three allocate writes (`ip
   reserve`, `prefix reserve`, `ip-range reserve`) plus multi-IP `--count N`

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -1220,11 +1220,14 @@ pub(crate) async fn apply_ip_range_reserve(
 }
 
 /// Shared apply logic for multi-IP allocate writes (`ip reserve` and
-/// `ip-range reserve`). Both POST to an `available-ips` endpoint that creates
-/// one IP per POST. For `count == 1`, a single POST returns a single object
-/// (byte-identical to the pre-multi-IP receipt). For `count > 1`, N sequential
-/// POSTs; partial failure returns a receipt with `partial: true` and the k
-/// created IP views as a JSON array.
+/// `ip-range reserve`). Both POST to an `available-ips` endpoint. For
+/// `count == 1`, a single POST returns a single object (byte-identical to the
+/// pre-multi-IP receipt). For `count > 1`, the apply first attempts an atomic
+/// all-or-nothing allocation via a single list-body POST — NetBox's
+/// `available-ips` endpoint accepts a JSON array body (`[{…}, …]`) and creates
+/// either all N or zero IPs in one round-trip (modern NetBox). Older NetBox
+/// that rejects the list shape (HTTP 400/422) falls back to N sequential
+/// POSTs, which may produce a partial state (k of N created → `partial: true`).
 async fn apply_multi_ip_reserve(
     client: &NetBoxClient,
     plan: &MutationPlan,
@@ -1266,9 +1269,25 @@ async fn apply_multi_ip_reserve(
         });
     }
 
-    // Multi-IP allocation: N sequential POSTs. Each POST creates one IP.
-    // A failure mid-sequence stops — the created IPs are returned in the
-    // receipt's `object` (a JSON array) so the operator knows what succeeded.
+    // Multi-IP: try the atomic list-body POST first (all-or-nothing in one
+    // round-trip). On a server rejection of the list shape (400/422), fall
+    // back to the sequential POSTs below — the older-NetBox path that may
+    // yield a partial state. Other failures propagate unchanged.
+    match try_atomic_multi_ip_post(client, &plan.target.endpoint, &body, count).await {
+        AtomicResult::Created(created_ips, status) => {
+            return Ok(build_atomic_receipt(plan, created_ips, status));
+        }
+        AtomicResult::ListBodyRejected => {
+            // Fall through to the sequential path below.
+        }
+        AtomicResult::Error(e) => {
+            return Err(e);
+        }
+    }
+
+    // Sequential fallback: N POSTs. Each POST creates one IP. A failure
+    // mid-sequence stops — the created IPs are returned in the receipt's
+    // `object` (a JSON array) so the operator knows what succeeded.
     let mut views: Vec<Value> = Vec::with_capacity(count);
     let mut last_status: u16 = 201;
     for i in 0..count {
@@ -1355,6 +1374,99 @@ async fn apply_multi_ip_reserve(
             plan.target.display
         ),
     })
+}
+
+/// The outcome of an atomic list-body POST attempt for multi-IP allocation.
+enum AtomicResult {
+    /// The server created all N IPs (201 with a JSON array body).
+    Created(Vec<IpAddress>, u16),
+    /// The server rejected the list body shape (HTTP 400/422) — the caller
+    /// should fall back to sequential POSTs. No IPs were created.
+    ListBodyRejected,
+    /// Any other failure (409 exhaustion, 401/403, 412, network, decode) —
+    /// propagated as a normal apply error, since none leaves orphan IPs.
+    Error(anyhow::Error),
+}
+
+/// Attempt an atomic all-or-nothing multi-IP allocation: a single list-body
+/// POST (`[body, body, …]` — N copies of the single-IP create body) to the
+/// `available-ips` endpoint. Modern NetBox creates all N or zero in one
+/// round-trip; the response is a `201` with a JSON array of the created IPs.
+///
+/// Older NetBox (or any server that doesn't accept the list shape) responds
+/// `400`/`422`, which we treat as a request to fall back to sequential POSTs —
+/// no IP is created on a 400/422, so the fallback is safe. Other failures
+/// (409 prefix exhausted, 401/403, 412, network, response decode) propagate as
+/// [`AtomicResult::Error`] since they're not a "list body unsupported" signal
+/// and none leaves behind orphan IPs that the sequential fallback would
+/// duplicate.
+async fn try_atomic_multi_ip_post(
+    client: &NetBoxClient,
+    endpoint: &str,
+    body: &Value,
+    count: usize,
+) -> AtomicResult {
+    let list_body = Value::Array(vec![body.clone(); count]);
+    match client.post::<Vec<IpAddress>>(endpoint, &list_body).await {
+        Ok((created, status)) => AtomicResult::Created(created, status),
+        Err(e) => {
+            // A 400/422 specifically signals the list body isn't supported →
+            // fall back. The list-body request creates zero IPs on rejection,
+            // so the sequential fallback never duplicates an allocation.
+            let http_status = e
+                .chain()
+                .find_map(|cause| cause.downcast_ref::<NboxError>())
+                .and_then(NboxError::http_status);
+            if matches!(http_status, Some(400 | 422)) {
+                AtomicResult::ListBodyRejected
+            } else {
+                AtomicResult::Error(e)
+            }
+        }
+    }
+}
+
+/// Build the receipt for a successful atomic list-body allocation: all N IPs
+/// created in one round-trip, so `partial: false` and `created_count == count`.
+fn build_atomic_receipt(
+    plan: &MutationPlan,
+    created_ips: Vec<IpAddress>,
+    status: u16,
+) -> MutationReceipt {
+    let views: Vec<Value> = created_ips
+        .into_iter()
+        .map(|ip| IpView::build(ip, None))
+        .filter_map(|v| serde_json::to_value(&v).ok())
+        .collect();
+    let count = views.len();
+    let addresses: Vec<String> = views
+        .iter()
+        .filter_map(|v| v.get("address").and_then(|a| a.as_str()).map(String::from))
+        .collect();
+    MutationReceipt {
+        schema_version: PLAN_SCHEMA_VERSION,
+        operation: plan.operation,
+        target: plan.target.clone(),
+        fields: plan.fields.clone(),
+        applied: true,
+        no_op: false,
+        status,
+        etag: None,
+        request_id: None,
+        object: Some(Value::Array(views)),
+        partial: false,
+        requested_count: count as u32,
+        created_count: count as u32,
+        message: format!(
+            "reserved {} in {}",
+            if addresses.len() == 1 {
+                addresses[0].clone()
+            } else {
+                format!("{} addresses: {}", addresses.len(), addresses.join(", "))
+            },
+            plan.target.display
+        ),
+    }
 }
 
 // ===== Safe write follow-on: tag add/remove (ADR-0001) ===================

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -1936,31 +1936,42 @@ async fn ip_bare_without_address_is_a_usage_error() {
 
 // ===== multi-IP ip reserve (--count N) (ADR-0001 follow-on) ================
 //
-// `ip reserve --count N` issues N sequential POSTs to the prefix's
-// `available-ips` endpoint. Each POST creates one IP. A mid-sequence failure
-// returns the k created IPs as a JSON array with `partial: true` and exit 1.
+// `ip reserve --count N` first attempts an atomic list-body POST (a single
+// request with a JSON array body) so NetBox creates all N or zero IPs in one
+// round-trip. Modern NetBox returns `201` with a JSON array of the created IPs.
+// Older NetBox that rejects the list shape (400/422) falls back to N sequential
+// single-object POSTs; a mid-sequence failure there returns the k created IPs
+// as a JSON array with `partial: true` and exit 1.
 
-/// Mount N sequential POST responses for multi-IP allocation.
-async fn mount_multi_ip_post(server: &MockServer, prefix_id: u64, addresses: &[&str]) {
-    for (i, addr) in addresses.iter().enumerate() {
-        Mock::given(method("POST"))
-            .and(path(format!(
-                "/api/ipam/prefixes/{prefix_id}/available-ips/"
-            )))
-            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+/// Mount one atomic list-body POST response: `201` with a JSON array of the N
+/// created IPs. The request body is a JSON array of N copies of the single-IP
+/// create body; this mock matches any POST to the endpoint (the body shape is
+/// asserted separately where relevant).
+async fn mount_atomic_multi_ip_post(server: &MockServer, prefix_id: u64, addresses: &[&str]) {
+    let results: Vec<Value> = addresses
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            json!({
                 "id": 100 + i,
                 "url": format!("{}/api/ipam/ip-addresses/{}/", server.uri(), 100 + i),
                 "address": addr,
                 "status": {"value": "active", "label": "Active"},
-            })))
-            .up_to_n_times(1)
-            .mount(server)
-            .await;
-    }
+            })
+        })
+        .collect();
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/api/ipam/prefixes/{prefix_id}/available-ips/"
+        )))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!(results)))
+        .up_to_n_times(1)
+        .mount(server)
+        .await;
 }
 
 #[tokio::test]
-async fn ip_reserve_count_3_sends_three_posts_and_returns_array() {
+async fn ip_reserve_count_3_atomic_list_body_post_creates_all_in_one_request() {
     let server = MockServer::start().await;
     mount_prefix_resolution(&server, 1, "203.0.113.0/24").await;
     // Advisory: 3 available addresses.
@@ -1973,7 +1984,7 @@ async fn ip_reserve_count_3_sends_three_posts_and_returns_array() {
         ])))
         .mount(&server)
         .await;
-    mount_multi_ip_post(
+    mount_atomic_multi_ip_post(
         &server,
         1,
         &["203.0.113.5/24", "203.0.113.6/24", "203.0.113.7/24"],
@@ -1987,7 +1998,12 @@ async fn ip_reserve_count_3_sends_three_posts_and_returns_array() {
     );
 
     assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
-    assert_eq!(post_count(&server).await, 3, "exactly three POSTs");
+    // All-or-nothing: exactly ONE POST (the list-body request), not three.
+    assert_eq!(
+        post_count(&server).await,
+        1,
+        "atomic path: one list-body POST"
+    );
     let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
     assert_eq!(receipt["operation"], json!("allocate"));
     assert!(
@@ -2044,7 +2060,7 @@ async fn ip_reserve_count_3_dry_run_shows_count_in_fields_and_no_posts() {
 }
 
 #[tokio::test]
-async fn ip_reserve_count_3_partial_failure_returns_created_and_exit_1() {
+async fn ip_reserve_count_3_list_body_rejected_falls_back_to_sequential_partial() {
     let server = MockServer::start().await;
     mount_prefix_resolution(&server, 1, "203.0.113.0/24").await;
     // Advisory: 3 available.
@@ -2057,7 +2073,17 @@ async fn ip_reserve_count_3_partial_failure_returns_created_and_exit_1() {
         ])))
         .mount(&server)
         .await;
-    // First 2 POSTs succeed, 3rd fails with 409 (exhausted).
+    // The atomic list-body POST is rejected with 422 (list shape unsupported).
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-ips/"))
+        .respond_with(
+            ResponseTemplate::new(422)
+                .set_body_json(json!({"non_field_errors": ["Expected a list but got an object."]})),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    // Sequential fallback: first 2 POSTs succeed, 3rd fails with 409.
     Mock::given(method("POST"))
         .and(path("/api/ipam/prefixes/1/available-ips/"))
         .respond_with(ResponseTemplate::new(201).set_body_json(json!({
@@ -2090,7 +2116,12 @@ async fn ip_reserve_count_3_partial_failure_returns_created_and_exit_1() {
 
     // Partial: exit 1, but stdout carries the receipt with 2 created IPs.
     assert_eq!(out.code, Some(1), "stderr: {}", out.stderr);
-    assert_eq!(post_count(&server).await, 3, "three POSTs attempted");
+    // 1 atomic attempt (422) + 3 sequential POSTs = 4 total.
+    assert_eq!(
+        post_count(&server).await,
+        4,
+        "1 atomic + 3 sequential POSTs"
+    );
     let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
     assert_eq!(receipt["partial"], json!(true));
     assert_eq!(receipt["status"], json!(409));
@@ -2170,6 +2201,119 @@ async fn ip_reserve_count_1_is_byte_identical_to_no_count() {
     assert!(
         !fields.iter().any(|f| f["field"] == "count"),
         "no count in fields"
+    );
+}
+
+#[tokio::test]
+async fn ip_reserve_count_1_apply_is_byte_identical_to_no_count() {
+    // --count 1 on the apply path: a single single-object POST (never the
+    // list-body atomic path), byte-identical receipt to no --count.
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "203.0.113.0/24").await;
+    mount_available_ips_get(&server, 1, "203.0.113.5/24").await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-ips/"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 7,
+            "url": format!("{}/api/ipam/ip-addresses/7/", server.uri()),
+            "address": "203.0.113.5/24",
+            "status": {"value": "active", "label": "Active"},
+            "description": "edge uplink"
+        })))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out_no_count = run_ip_reserve(
+        &config,
+        &[
+            "--description",
+            "edge uplink",
+            "--allow-writes",
+            "--confirm",
+            "--json",
+        ],
+    );
+    let out_count_1 = run_ip_reserve(
+        &config,
+        &[
+            "--count",
+            "1",
+            "--description",
+            "edge uplink",
+            "--allow-writes",
+            "--confirm",
+            "--json",
+        ],
+    );
+
+    assert_eq!(
+        out_no_count.code,
+        Some(0),
+        "stderr: {}",
+        out_no_count.stderr
+    );
+    assert_eq!(out_count_1.code, Some(0), "stderr: {}", out_count_1.stderr);
+    // count==1 is a single single-object POST (NOT the list-body path).
+    assert_eq!(
+        post_count(&server).await,
+        2,
+        "two runs, one single POST each"
+    );
+    // The receipts are byte-identical: no partial, no requested/created count,
+    // same object and message.
+    let r_no: Value = serde_json::from_str(&out_no_count.stdout).expect("receipt");
+    let r_1: Value = serde_json::from_str(&out_count_1.stdout).expect("receipt");
+    assert!(r_no.get("partial").is_none(), "no partial for count==1");
+    assert!(r_1.get("partial").is_none(), "no partial for count==1");
+    assert!(r_no.get("requested_count").is_none());
+    assert!(r_1.get("requested_count").is_none());
+    assert_eq!(r_no, r_1, "count==1 receipt byte-identical to no-count");
+}
+
+#[tokio::test]
+async fn ip_reserve_count_3_atomic_409_is_plain_error_no_orphans() {
+    // A 409 on the atomic list-body POST is NOT a list-shape rejection — it
+    // means the prefix is exhausted. The atomic path creates zero IPs, so the
+    // error propagates as a plain exit-1 error with clean stdout (no fallback,
+    // no partial receipt, no orphan IPs).
+    let server = MockServer::start().await;
+    mount_prefix_resolution(&server, 1, "203.0.113.0/24").await;
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/1/available-ips/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"address": "203.0.113.5/24"},
+            {"address": "203.0.113.6/24"},
+            {"address": "203.0.113.7/24"}
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-ips/"))
+        .respond_with(
+            ResponseTemplate::new(409)
+                .set_body_string("The requested number of IP addresses is not available"),
+        )
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_ip_reserve(
+        &config,
+        &["--count", "3", "--allow-writes", "--confirm", "--json"],
+    );
+
+    // 409 propagates from the atomic attempt; no fallback, one POST total.
+    assert_error_contract(&out, 1, "HTTP 409");
+    assert_eq!(
+        post_count(&server).await,
+        1,
+        "atomic 409: one POST, no fallback"
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "no receipt on atomic 409: {:?}",
+        out.stdout
     );
 }
 
@@ -2662,9 +2806,43 @@ async fn ip_range_reserve_audit_logs_names_only_never_values_token_or_message_bo
 }
 
 // ===== multi-IP ip-range reserve (--count N) (ADR-0001 follow-on) ============
+//
+// `ip-range reserve --count N` first attempts an atomic list-body POST (a
+// single request with a JSON array body) so NetBox creates all N or zero IPs
+// in one round-trip. Older NetBox that rejects the list shape (400/422) falls
+// back to N sequential single-object POSTs.
+
+/// Mount one atomic list-body POST response for an ip-range: `201` with a JSON
+/// array of the N created IPs.
+async fn mount_atomic_ip_range_multi_ip_post(
+    server: &MockServer,
+    range_id: u64,
+    addresses: &[&str],
+) {
+    let results: Vec<Value> = addresses
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            json!({
+                "id": 100 + i,
+                "url": format!("{}/api/ipam/ip-addresses/{}/", server.uri(), 100 + i),
+                "address": addr,
+                "status": {"value": "active", "label": "Active"},
+            })
+        })
+        .collect();
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "/api/ipam/ip-ranges/{range_id}/available-ips/"
+        )))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!(results)))
+        .up_to_n_times(1)
+        .mount(server)
+        .await;
+}
 
 #[tokio::test]
-async fn ip_range_reserve_count_2_sends_two_posts_and_returns_array() {
+async fn ip_range_reserve_count_2_atomic_list_body_post_creates_both_in_one_request() {
     let server = MockServer::start().await;
     mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
     // Advisory: 2 available addresses.
@@ -2676,25 +2854,8 @@ async fn ip_range_reserve_count_2_sends_two_posts_and_returns_array() {
         ])))
         .mount(&server)
         .await;
-    // Two POST responses.
-    Mock::given(method("POST"))
-        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
-        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
-            "id": 100, "url": "u", "address": "10.0.0.10/32",
-            "status": {"value": "active", "label": "Active"}
-        })))
-        .up_to_n_times(1)
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
-        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
-            "id": 101, "url": "u", "address": "10.0.0.11/32",
-            "status": {"value": "active", "label": "Active"}
-        })))
-        .up_to_n_times(1)
-        .mount(&server)
-        .await;
+    // One atomic list-body POST returns a JSON array of both created IPs.
+    mount_atomic_ip_range_multi_ip_post(&server, 1, &["10.0.0.10/32", "10.0.0.11/32"]).await;
 
     let config = write_config(&server.uri());
     let out = run_ip_range_reserve(
@@ -2703,7 +2864,12 @@ async fn ip_range_reserve_count_2_sends_two_posts_and_returns_array() {
     );
 
     assert_eq!(out.code, Some(0), "stderr: {}", out.stderr);
-    assert_eq!(post_count(&server).await, 2, "exactly two POSTs");
+    // All-or-nothing: exactly ONE POST (the list-body request), not two.
+    assert_eq!(
+        post_count(&server).await,
+        1,
+        "atomic path: one list-body POST"
+    );
     let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
     assert!(
         receipt.get("partial").is_none(),
@@ -2747,7 +2913,7 @@ async fn ip_range_reserve_count_2_dry_run_shows_count_in_fields() {
 }
 
 #[tokio::test]
-async fn ip_range_reserve_count_2_partial_failure_returns_created_and_exit_1() {
+async fn ip_range_reserve_count_2_list_body_rejected_falls_back_to_sequential_partial() {
     let server = MockServer::start().await;
     mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
     Mock::given(method("GET"))
@@ -2758,7 +2924,17 @@ async fn ip_range_reserve_count_2_partial_failure_returns_created_and_exit_1() {
         ])))
         .mount(&server)
         .await;
-    // First POST succeeds, second fails with 409.
+    // The atomic list-body POST is rejected with 400 (list shape unsupported).
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_json(json!({"non_field_errors": ["Invalid input. Expected a list."]})),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    // Sequential fallback: first POST succeeds, second fails with 409.
     Mock::given(method("POST"))
         .and(path("/api/ipam/ip-ranges/1/available-ips/"))
         .respond_with(ResponseTemplate::new(201).set_body_json(json!({
@@ -2781,7 +2957,12 @@ async fn ip_range_reserve_count_2_partial_failure_returns_created_and_exit_1() {
     );
 
     assert_eq!(out.code, Some(1), "stderr: {}", out.stderr);
-    assert_eq!(post_count(&server).await, 2, "two POSTs attempted");
+    // 1 atomic attempt (400) + 2 sequential POSTs = 3 total.
+    assert_eq!(
+        post_count(&server).await,
+        3,
+        "1 atomic + 2 sequential POSTs"
+    );
     let receipt: Value = serde_json::from_str(&out.stdout).expect("receipt JSON");
     assert_eq!(receipt["partial"], json!(true));
     assert_eq!(receipt["status"], json!(409));
@@ -2821,6 +3002,47 @@ async fn ip_range_reserve_count_2_first_post_failure_is_plain_error_with_empty_s
         post_count(&server).await,
         1,
         "first POST failure stops immediately"
+    );
+}
+
+#[tokio::test]
+async fn ip_range_reserve_count_2_atomic_409_is_plain_error_no_orphans() {
+    // A 409 on the atomic list-body POST is NOT a list-shape rejection — it
+    // means the range is exhausted. The atomic path creates zero IPs, so the
+    // error propagates as a plain exit-1 error with clean stdout (no fallback,
+    // no partial receipt, no orphan IPs).
+    let server = MockServer::start().await;
+    mount_ip_range_resolution(&server, 1, "10.0.0.10", "10.0.0.20").await;
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"address": "10.0.0.10/32"},
+            {"address": "10.0.0.11/32"}
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/ip-ranges/1/available-ips/"))
+        .respond_with(ResponseTemplate::new(409).set_body_string("Insufficient space in range"))
+        .mount(&server)
+        .await;
+
+    let config = write_config(&server.uri());
+    let out = run_ip_range_reserve(
+        &config,
+        &["--count", "2", "--allow-writes", "--confirm", "--json"],
+    );
+
+    assert_error_contract(&out, 1, "HTTP 409");
+    assert_eq!(
+        post_count(&server).await,
+        1,
+        "atomic 409: one POST, no fallback"
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "no receipt on atomic 409: {:?}",
+        out.stdout
     );
 }
 


### PR DESCRIPTION
## What

Multi-IP allocation (`--count N > 1`) is now **atomic by default**. Instead of N sequential single-object POSTs, the apply first sends a single **list-body POST** — `[body, body, …]` (N copies of the single-IP create body) — to the `available-ips` endpoint. Modern NetBox creates all N or zero IPs in one round-trip; on success the receipt is `partial: false` with all N `IpView`s.

Older NetBox that rejects the list shape (HTTP 400/422) transparently falls back to the existing N sequential POSTs, which may still yield a partial state (`partial: true` + exit 1).

## Why

The prior sequential approach permits partial states: k of N POSTs succeed, leaving the operator with k orphan IPs to clean up, and costs N round-trips. The list-body POST eliminates the partial-failure path on modern NetBox and cuts latency to one request, while keeping the honest fallback for older servers.

## Behavior

- **`count > 1`** → list-body POST first (all-or-nothing, one request).
  - 201 with a JSON array → all N created, `partial: false`.
  - 400/422 (list shape rejected) → fall back to N sequential POSTs (may yield `partial: true`).
  - Other failures (409 exhaustion, 401/403, 412, network, decode) → propagate as a plain exit-1 error. No fallback, **no orphan IPs** — the list-body request creates zero on rejection.
- **`count == 1`** → unchanged. Single-object POST, byte-identical receipt.

## Touch points

- `src/domain/detail.rs`: `apply_multi_ip_reserve` tries the atomic path first; new `try_atomic_multi_ip_post` / `AtomicResult` / `build_atomic_receipt` helpers. Shared by `ip reserve` and `ip-range reserve` (both POST to an `available-ips` endpoint with the same body shape).
- `ROADMAP.md`: item marked ☑.
- `CHANGELOG.md`: atomic subsection added under the multi-IP entry.

## Tests (`tests/write_tests.rs`)

New wiremock tests (+3 net):
- (a) **Atomic success** — one list-body POST, 201 with array, receipt has all N IPs and `partial: false` (one POST, not three).
- (b) **List-body rejected → sequential fallback** — 422 then sequential POSTs with a mid-sequence 409 → `partial: true`, exit 1.
- (c) **`count == 1` apply byte-identical** to no-`--count` (single-object POST, identical receipt).
- Plus **atomic 409 → plain error, no orphans** (one POST, empty stdout) for both `ip reserve` and `ip-range reserve`.

Existing multi-IP tests updated to mount the atomic list-body response (the new default).

## Verification

- `cargo test --all-targets` → **1323 passed** (was 1320, +3 net new).
- `cargo clippy --all-targets --all-features` → clean.
- `cargo fmt` → clean.
- `cargo test --test write_tests` → 91 passed (88 + 3 new).