### PR TITLE
feat: structured export — Prometheus service-discovery JSON

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -40,6 +40,19 @@ array on any object). The MCP server stays read-only.
 | `nbox open <kind>/<ref>` | Open an object in the browser. Kinds: device, ip, prefix, vlan, site, rack, rack-group, circuit, virtual-circuit, aggregate, asn, ip-range, tenant, contact, provider, vm, vm-type, cluster, vrf, route-target, mac, and `interface/<device>/<name>` (the interface name may contain slashes, e.g. `xe-0/0/1`). |
 | `nbox raw GET <path>` | Raw read-only API request (escape hatch). |
 
+## Structured exports
+
+| Command | What |
+| ------- | ---- |
+| `nbox export prometheus-sd --prefix <cidr> [--vrf] [--port N]` | Emit Prometheus file-based service-discovery JSON (`[{"targets": ["ip:port"], "labels": {...}}]`) for IPs assigned within a prefix. Reuses the read engine: resolves the prefix (with `--vrf` disambiguation), lists its member IPs, enriches each with its assigned device's site/role/status via one `id__in` fetch, and groups targets by device. Pipe straight to a file Prometheus scrapes. |
+| `nbox export prometheus-sd --tag <slug> [--port N]` | Same SD JSON, sourced from IPs carrying a tag (IP-addresses `?tag=` filter). |
+
+Targets are `ip:port` (default port `9100`, the conventional `node_exporter`
+port). Labels per group: `device`, `site`, `role`, `status`, `tags` (comma-
+joined, de-duplicated, sorted). IPs without an assigned device group by site
+(or a single `device=""` group). `--prefix` and `--tag` are mutually
+exclusive. Output is a compact JSON array on stdout — pipe-safe, no envelope.
+
 Every detail lookup surfaces the object's `tags` (joined slugs in plain output, a
 `tags` array in `--json`), dropped when the object has none, plus its non-empty
 custom fields as `cf.<name>`. `owner` (NetBox 4.5+) — a native owner (user or

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -618,6 +618,51 @@ pub enum Command {
         #[arg(long)]
         print_config: bool,
     },
+
+    /// Structured read-only exports (e.g. Prometheus service-discovery JSON).
+    /// Query NetBox via the read engine and emit a fixed structured shape to
+    /// stdout — distinct from the presentation-oriented JSON/CSV view layer.
+    Export {
+        #[command(subcommand)]
+        action: ExportAction,
+    },
+}
+
+/// `nbox export` — structured read-only exports (file-SD JSON for Prometheus,
+/// etc.). Each subcommand queries NetBox via the read engine and emits a fixed
+/// structured shape to stdout, distinct from the presentation-oriented
+/// JSON/CSV view layer.
+///
+/// The subcommand names are the consumer format (`prometheus-sd`), not a
+/// generic verb, so a future `--format`/`<consumer>` split stays obvious.
+#[derive(Debug, Subcommand)]
+pub enum ExportAction {
+    /// Emit Prometheus file-based service-discovery JSON
+    /// (`[{"targets": ["ip:port"], "labels": {...}}]`) for IPs in a prefix
+    /// or carrying a tag. Targets are grouped by device; labels carry
+    /// device/site/role/status/tags. Pipe the output straight to a file
+    /// Prometheus scrapes (`prometheus-sd.json` in its `file_sd_configs`).
+    PrometheusSd {
+        /// Source prefix in CIDR notation. IPs assigned within the prefix
+        /// become targets. Mutually exclusive with `--tag`.
+        #[arg(long, value_name = "CIDR")]
+        prefix: Option<String>,
+
+        /// Source tag slug (or name): IPs carrying this tag become targets.
+        /// Mutually exclusive with `--prefix`.
+        #[arg(long, value_name = "SLUG")]
+        tag: Option<String>,
+
+        /// Disambiguate the prefix by VRF (name, slug, or RD) when the CIDR
+        /// exists in more than one VRF. Ignored with `--tag`.
+        #[arg(long, value_name = "VRF")]
+        vrf: Option<String>,
+
+        /// Scrape target port. Defaults to 9100 (the conventional
+        /// `node_exporter` port).
+        #[arg(long, value_name = "PORT", default_value_t = crate::export::DEFAULT_PORT)]
+        port: u16,
+    },
 }
 
 /// `nbox tag` write actions (ADR-0001 safe-write foundation). Add and remove

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -1,0 +1,305 @@
+//! Structured read-only exports.
+//!
+//! The export surface turns NetBox read-engine results into a fixed structured
+//! shape an external system consumes — distinct from the human/JSON/CSV view
+//! layer, which is presentation-oriented. The first (and currently only) export
+//! is Prometheus service-discovery JSON: `[{"targets": ["ip:port"], "labels":
+//! {"key": "value"}}]`, the file-based SD format Prometheus scrapes.
+//!
+//! [`prometheus_sd`] is pure: it takes already-enriched [`ExportIp`] records
+//! (gathered by the CLI, which reuses the query layer in `netbox::query`) and a
+//! port, and produces [`Vec<TargetGroup>`]. Grouping, label derivation, and the
+//! `ip:port` target string live here so they're unit-testable without a mock
+//! NetBox.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// One enriched IP for export: the address (without prefix length) plus the
+/// device/site/role/status/tag metadata that becomes Prometheus labels.
+///
+/// The CLI gathers these from the read engine — IPs in a prefix
+/// ([`crate::netbox::query`] `prefix_ips`) or carrying a tag (IP addresses
+/// endpoint `?tag=<slug>`), enriched with the assigned device's site/role via
+/// a single `id__in` device fetch — and hands them to [`prometheus_sd`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportIp {
+    /// The IP address without its prefix length, e.g. `10.0.0.5`.
+    pub address: String,
+    /// The assigned device's name, when the IP is on a device interface.
+    pub device: Option<String>,
+    /// The device's site name (NetBox `site.display`), when known.
+    pub site: Option<String>,
+    /// The device's role (NetBox `role.display`), when known.
+    pub role: Option<String>,
+    /// The IP or device status value (e.g. `active`), when known.
+    pub status: Option<String>,
+    /// Tag slugs carried by the IP, in NetBox order.
+    pub tags: Vec<String>,
+}
+
+/// A Prometheus service-discovery target group: a list of `host:port` targets
+/// sharing one label map. Serialized as `{"targets": [...], "labels": {...}}`,
+/// the shape Prometheus's file-SD config scrapes.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TargetGroup {
+    pub targets: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+}
+
+/// Default scrape port when `--port` is omitted. `9100` is the conventional
+/// `node_exporter` port — the common ops default for a Prometheus host target.
+pub const DEFAULT_PORT: u16 = 9100;
+
+/// Strip a `/prefixlen` suffix from a NetBox address (`10.0.0.5/24` →
+/// `10.0.0.5`). Passes through unchanged when there is no slash (an address
+/// already given without a mask, or an IPv6 with no trailing length).
+#[must_use]
+pub fn strip_prefix_len(address: &str) -> String {
+    address.split('/').next().unwrap_or(address).to_string()
+}
+
+/// Build Prometheus service-discovery target groups from enriched IPs.
+///
+/// Targets are grouped by device: every IP sharing a device lands in one group
+/// whose `targets` is the device's `ip:port` list and whose `labels` carry the
+/// shared device/site/role/status. Per-IP tags are unioned (de-duplicated,
+/// sorted) into a single comma-joined `tags` label so a group with mixed tags
+/// still surfaces all of them. IPs without an assigned device form per-site
+/// groups (or a single `device=""` group when site is unknown), so unassigned
+/// addresses aren't silently dropped.
+///
+/// Groups are returned in a stable order: assigned-device groups sorted by
+/// device name, then unassigned groups sorted by site (with the empty-site
+/// group last). Within a group, targets are sorted by address so re-runs are
+/// deterministic.
+#[must_use]
+pub fn prometheus_sd(ips: &[ExportIp], port: u16) -> Vec<TargetGroup> {
+    use std::collections::{BTreeSet, HashMap};
+
+    // Group key: (device, site) for assigned IPs; (None, site) for unassigned.
+    // A device's site is constant across its IPs in practice, but we keep the
+    // site on the key so two IPs of the same device in (theoretically)
+    // different sites don't collapse.
+    let mut groups: HashMap<(Option<String>, Option<String>), Vec<&ExportIp>> = HashMap::new();
+    for ip in ips {
+        let key = (ip.device.clone(), ip.site.clone());
+        groups.entry(key).or_default().push(ip);
+    }
+
+    let mut out: Vec<TargetGroup> = Vec::with_capacity(groups.len());
+    for ((device, site), mut members) in groups {
+        // Deterministic target order within a group: by address.
+        members.sort_by(|a, b| a.address.cmp(&b.address));
+
+        let targets: Vec<String> = members
+            .iter()
+            .map(|ip| format!("{}:{}", ip.address, port))
+            .collect();
+
+        // Shared labels: device/site/role/status come from the (constant across
+        // the group) device. Role/status are taken from the first member — they
+        // are device-level, so they agree across a device's IPs.
+        let role = members.first().and_then(|m| m.role.clone());
+        let status = members.first().and_then(|m| m.status.clone());
+
+        // Union the tags across the group, sorted + de-duplicated.
+        let mut tagset: BTreeSet<&str> = BTreeSet::new();
+        for m in &members {
+            for t in &m.tags {
+                tagset.insert(t.as_str());
+            }
+        }
+
+        let mut labels: BTreeMap<String, String> = BTreeMap::new();
+        if let Some(dev) = &device {
+            labels.insert("device".to_string(), dev.clone());
+        } else {
+            // An empty string keeps the label present so Prometheus's `relabel`
+            // can match unassigned targets uniformly.
+            labels.insert("device".to_string(), String::new());
+        }
+        if let Some(s) = &site {
+            labels.insert("site".to_string(), s.clone());
+        }
+        if let Some(r) = &role {
+            labels.insert("role".to_string(), r.clone());
+        }
+        if let Some(st) = &status {
+            labels.insert("status".to_string(), st.clone());
+        }
+        if !tagset.is_empty() {
+            labels.insert(
+                "tags".to_string(),
+                tagset.into_iter().collect::<Vec<_>>().join(","),
+            );
+        }
+
+        out.push(TargetGroup { targets, labels });
+    }
+
+    // Stable group order: assigned-device groups first (by device name), then
+    // unassigned (by site, empty-site last).
+    out.sort_by(|a, b| {
+        let a_dev = a.labels.get("device").map_or("", String::as_str);
+        let b_dev = b.labels.get("device").map_or("", String::as_str);
+        let a_unassigned = a_dev.is_empty();
+        let b_unassigned = b_dev.is_empty();
+        (
+            a_unassigned,
+            a_dev,
+            a.labels.get("site").map_or("", String::as_str),
+        )
+            .cmp(&(
+                b_unassigned,
+                b_dev,
+                b.labels.get("site").map_or("", String::as_str),
+            ))
+    });
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ip(address: &str, device: Option<&str>, site: Option<&str>) -> ExportIp {
+        ExportIp {
+            address: address.to_string(),
+            device: device.map(str::to_string),
+            site: site.map(str::to_string),
+            role: None,
+            status: Some("active".to_string()),
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn strip_prefix_len_handles_v4_and_bare() {
+        assert_eq!(strip_prefix_len("10.0.0.5/24"), "10.0.0.5");
+        assert_eq!(strip_prefix_len("10.0.0.5"), "10.0.0.5");
+        assert_eq!(strip_prefix_len("2001:db8::1/64"), "2001:db8::1");
+        assert_eq!(strip_prefix_len(""), "");
+    }
+
+    #[test]
+    fn groups_by_device_and_appends_port() {
+        let ips = vec![
+            ip("10.0.0.5", Some("edge01"), Some("iad1")),
+            ip("10.0.0.6", Some("edge01"), Some("iad1")),
+            ip("10.0.0.7", Some("edge02"), Some("iad1")),
+        ];
+        let groups = prometheus_sd(&ips, 9100);
+        assert_eq!(groups.len(), 2, "{groups:?}");
+
+        let edge01 = groups
+            .iter()
+            .find(|g| g.labels.get("device").map(String::as_str) == Some("edge01"))
+            .expect("edge01 group");
+        assert_eq!(edge01.targets, vec!["10.0.0.5:9100", "10.0.0.6:9100"]);
+        assert_eq!(edge01.labels.get("site").map(String::as_str), Some("iad1"));
+        assert_eq!(
+            edge01.labels.get("status").map(String::as_str),
+            Some("active")
+        );
+
+        let edge02 = groups
+            .iter()
+            .find(|g| g.labels.get("device").map(String::as_str) == Some("edge02"))
+            .expect("edge02 group");
+        assert_eq!(edge02.targets, vec!["10.0.0.7:9100"]);
+    }
+
+    #[test]
+    fn unions_tags_sorted_and_deduped() {
+        let ips = vec![
+            ExportIp {
+                address: "10.0.0.5".to_string(),
+                device: Some("edge01".to_string()),
+                site: Some("iad1".to_string()),
+                role: None,
+                status: Some("active".to_string()),
+                tags: vec!["prod".to_string(), "us-east".to_string()],
+            },
+            ExportIp {
+                address: "10.0.0.6".to_string(),
+                device: Some("edge01".to_string()),
+                site: Some("iad1".to_string()),
+                role: None,
+                status: Some("active".to_string()),
+                tags: vec!["us-east".to_string(), "monitoring".to_string()],
+            },
+        ];
+        let groups = prometheus_sd(&ips, 9100);
+        assert_eq!(groups.len(), 1);
+        let tags = groups[0].labels.get("tags").expect("tags label");
+        assert_eq!(tags, "monitoring,prod,us-east");
+    }
+
+    #[test]
+    fn unassigned_ips_group_by_site() {
+        let ips = vec![
+            ip("10.0.0.9", None, Some("iad1")),
+            ip("10.0.0.10", None, Some("iad1")),
+            ip("10.0.0.11", None, None),
+        ];
+        let groups = prometheus_sd(&ips, 9100);
+        // Two unassigned groups: one with site iad1, one with no site.
+        assert_eq!(groups.len(), 2);
+        let unassigned_site = groups
+            .iter()
+            .find(|g| g.labels.get("site").map(String::as_str) == Some("iad1"))
+            .expect("iad1 unassigned group");
+        assert_eq!(
+            unassigned_site.labels.get("device").map(String::as_str),
+            Some("")
+        );
+        assert_eq!(unassigned_site.targets.len(), 2);
+
+        let no_site = groups
+            .iter()
+            .find(|g| !g.labels.contains_key("site"))
+            .expect("no-site group");
+        assert_eq!(no_site.targets, vec!["10.0.0.11:9100"]);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_array() {
+        let groups = prometheus_sd(&[], 9100);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn serializes_to_prometheus_sd_shape() {
+        let ips = vec![ip("10.0.0.5", Some("edge01"), Some("iad1"))];
+        let groups = prometheus_sd(&ips, 9100);
+        let json = serde_json::to_value(&groups).unwrap();
+        let arr = json.as_array().expect("array");
+        assert_eq!(arr.len(), 1);
+        let group = &arr[0];
+        assert!(group.get("targets").is_some());
+        assert!(group.get("labels").is_some());
+        let targets = group["targets"].as_array().expect("targets array");
+        assert_eq!(targets[0], "10.0.0.5:9100");
+        assert_eq!(group["labels"]["device"], "edge01");
+        assert_eq!(group["labels"]["site"], "iad1");
+    }
+
+    #[test]
+    fn role_and_status_become_labels() {
+        let mut ip1 = ip("10.0.0.5", Some("edge01"), Some("iad1"));
+        ip1.role = Some("router".to_string());
+        let groups = prometheus_sd(&[ip1], 9100);
+        assert_eq!(
+            groups[0].labels.get("role").map(String::as_str),
+            Some("router")
+        );
+        assert_eq!(
+            groups[0].labels.get("status").map(String::as_str),
+            Some("active")
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod cli;
 pub mod config;
 pub mod domain;
 pub mod error;
+pub mod export;
 pub mod mac;
 pub mod mcp;
 pub mod netbox;
@@ -564,6 +565,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             limit,
             diff,
         }) => run_history(&ctx, &kind, &value, limit, diff).await,
+        Some(Command::Export { action }) => run_export(&ctx, action).await,
         Some(Command::Raw { method, path }) => run_raw(&ctx, &method, &path).await,
         Some(Command::Status) => run_status(&ctx).await,
         Some(Command::Config { command }) => config::run_config(
@@ -2546,6 +2548,178 @@ async fn run_tagged(ctx: &Ctx, tag: &str, limit: usize) -> Result<()> {
             println!("{:<7} {}", r.kind, r.display);
         }
     })
+}
+
+/// `nbox export <action>` — structured read-only exports.
+///
+/// `prometheus-sd` queries NetBox for IPs in a prefix (or carrying a tag),
+/// enriches each with its assigned device's site/role, and emits Prometheus
+/// file-SD JSON to stdout. The SD JSON is the only sensible output shape for
+/// this subcommand, so it is written directly (not via the plain/JSON/CSV
+/// view layer) — `--json`/`--output` are accepted (global flags) but have no
+/// effect: the export's format is fixed by its consumer.
+async fn run_export(ctx: &Ctx, action: crate::cli::ExportAction) -> Result<()> {
+    use crate::cli::ExportAction::PrometheusSd;
+    use crate::export::{ExportIp, prometheus_sd, strip_prefix_len};
+    use crate::netbox::models::ipam::IpAddress;
+
+    let PrometheusSd {
+        prefix,
+        tag,
+        vrf,
+        port,
+    } = action;
+
+    // Exactly one source — `--prefix` xor `--tag`.
+    match (prefix.as_deref(), tag.as_deref()) {
+        (Some(_), Some(_)) => {
+            return Err(error::NboxError::Usage(
+                "--prefix and --tag are mutually exclusive — pass one".to_string(),
+            )
+            .into());
+        }
+        (None, None) => {
+            return Err(error::NboxError::Usage(
+                "pass --prefix <cidr> or --tag <slug>".to_string(),
+            )
+            .into());
+        }
+        _ => {}
+    }
+
+    let client = connect(ctx)?;
+
+    // Gather the source IPs. The prefix path resolves the prefix (so --vrf
+    // disambiguation + 404 reuse the read engine) then lists its member IPs,
+    // scoped to the resolved prefix's VRF. The tag path resolves the tag (id)
+    // then lists IPs carrying it via the IP-addresses `?tag=` filter.
+    let ips: Vec<IpAddress> = if let Some(cidr) = prefix.as_deref() {
+        let p = detail::resolve_prefix(&client, cidr, vrf.as_deref(), &not_found).await?;
+        let vrf_id = p.vrf.as_ref().map(|v| v.id);
+        client.prefix_ips(cidr, vrf_id, EXPORT_IP_CAP).await?
+    } else {
+        let tag_slug = tag.as_deref().unwrap();
+        let tag_info = client
+            .tag_by_ref(tag_slug)
+            .await?
+            .ok_or_else(|| not_found("tag", tag_slug))?;
+        client
+            .list_all(
+                crate::netbox::endpoints::Endpoint::IpAddresses,
+                vec![("tag", tag_info.slug.clone())],
+                EXPORT_IP_CAP,
+            )
+            .await?
+    };
+
+    // Enrich: resolve the distinct assigned devices in one `id__in` fetch so
+    // site/role/status come from the device (the IP's `assigned_object`
+    // interface brief carries a nested device id but not site/role). IPs
+    // without an assigned device keep `device=None` and fall back to per-site
+    // grouping in [`prometheus_sd`].
+    let device_map = resolve_assigned_devices(&client, &ips).await?;
+
+    let export_ips: Vec<ExportIp> = ips
+        .into_iter()
+        .map(|ip| {
+            let (device_id, device_name) = assigned_device(&ip);
+            let (site, role, status, dev_tags) = device_id
+                .and_then(|id| device_map.get(&id))
+                .map(|d| {
+                    let site = d
+                        .site
+                        .as_ref()
+                        .map(crate::netbox::models::common::BriefObject::label);
+                    let role = d
+                        .role
+                        .as_ref()
+                        .map(crate::netbox::models::common::BriefObject::label);
+                    (
+                        site,
+                        role,
+                        d.status.as_ref().map(|c| c.value.clone()),
+                        d.tags.clone(),
+                    )
+                })
+                .unwrap_or((
+                    None,
+                    None,
+                    ip.status.as_ref().map(|c| c.value.clone()),
+                    Vec::new(),
+                ));
+            // Prefer the device's tags when a device resolved; else the IP's own tags.
+            let tags = if dev_tags.is_empty() {
+                ip.tags.into_iter().map(|t| t.slug).collect::<Vec<_>>()
+            } else {
+                dev_tags.into_iter().map(|t| t.slug).collect()
+            };
+            ExportIp {
+                address: strip_prefix_len(&ip.address),
+                device: device_name,
+                site,
+                role,
+                status,
+                tags,
+            }
+        })
+        .collect();
+
+    let groups = prometheus_sd(&export_ips, port);
+    // SD JSON is a compact array on stdout — pipe-safe, no envelope.
+    let json = serde_json::to_string(&groups).context("serializing Prometheus SD JSON")?;
+    println!("{json}");
+    Ok(())
+}
+
+/// Cap on the number of source IPs an export gathers. Generous — a /24 is
+/// 254 addresses — but bounded so a misconfigured `--tag` over a huge table
+/// can't stream unbounded work into one export.
+const EXPORT_IP_CAP: usize = 5_000;
+
+/// Resolve the distinct devices an IP set is assigned to, in one
+/// `?id__in=…` fetch. Returns an empty map when no IP has an assigned device
+/// (or NetBox omits the nested device brief). Stale/missing device ids are
+/// tolerated — they simply don't appear, so the IP groups as unassigned.
+async fn resolve_assigned_devices(
+    client: &NetBoxClient,
+    ips: &[crate::netbox::models::ipam::IpAddress],
+) -> Result<std::collections::HashMap<u64, crate::netbox::models::dcim::Device>> {
+    use std::collections::HashSet;
+    let mut ids: HashSet<u64> = HashSet::new();
+    for ip in ips {
+        if let Some(id) = assigned_device(ip).0 {
+            ids.insert(id);
+        }
+    }
+    if ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let id_list = ids.iter().map(u64::to_string).collect::<Vec<_>>().join(",");
+    let devices: Vec<crate::netbox::models::dcim::Device> = client
+        .list_all(
+            crate::netbox::endpoints::Endpoint::Devices,
+            vec![("id__in", id_list)],
+            ids.len(),
+        )
+        .await?;
+    Ok(devices.into_iter().map(|d| (d.id, d)).collect())
+}
+
+/// Extract the assigned device's `(id, name)` from an IP's polymorphic
+/// `assigned_object`. The brief is a `dcim.interface` carrying a nested
+/// `device: {id, display, name}`; both keys are optional and permissively
+/// read so an unassigned IP (or a non-interface assignment) yields `None`.
+fn assigned_device(ip: &crate::netbox::models::ipam::IpAddress) -> (Option<u64>, Option<String>) {
+    let dev = ip.assigned_object.as_ref().and_then(|o| o.get("device"));
+    let id = dev
+        .and_then(|d| d.get("id"))
+        .and_then(serde_json::Value::as_u64);
+    let name = dev.and_then(|d| {
+        d.get("name")
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| d.get("display").and_then(serde_json::Value::as_str))
+    });
+    (id, name.map(str::to_string))
 }
 
 /// `nbox journal <kind> <ref>` — recent journal entries for an object.

--- a/tests/export_tests.rs
+++ b/tests/export_tests.rs
@@ -1,0 +1,260 @@
+//! Integration tests for the `nbox export prometheus-sd` structured export.
+//!
+//! These mock a NetBox prefix's IPs (and the assigned-device enrichment fetch)
+//! and assert the emitted JSON matches the Prometheus file-SD shape, including
+//! the label mapping (device name, site, role, status, tags → labels).
+
+mod support;
+
+use nbox::config::ProfileConfig;
+use nbox::netbox::client::NetBoxClient;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use support::binary::{assert_json_stdout, run_nbox, temp_config};
+
+fn client(server: &MockServer) -> NetBoxClient {
+    let profile = ProfileConfig {
+        url: server.uri(),
+        ..Default::default()
+    };
+    NetBoxClient::new(&profile, None).unwrap()
+}
+
+/// Mount the prefix-resolution GET (`?prefix=<cidr>`) returning one prefix.
+async fn mount_prefix(server: &MockServer, prefix_id: u64, cidr: &str) {
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/"))
+        .and(query_param("prefix", cidr))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{
+                "id": prefix_id,
+                "url": format!("{}/api/ipam/prefixes/{}/", server.uri(), prefix_id),
+                "prefix": cidr,
+                "status": {"value": "active", "label": "Active"}
+            }]
+        })))
+        .mount(server)
+        .await;
+}
+
+/// One NetBox IP-address wire row, assigned to a device interface.
+fn ip_row(id: u64, address: &str, device_id: u64, device_name: &str, tags: &[&str]) -> Value {
+    let tags_arr: Vec<Value> = tags
+        .iter()
+        .map(|t| json!({"id": 1, "name": t, "slug": t}))
+        .collect();
+    json!({
+        "id": id,
+        "url": format!("http://nb/api/ipam/ip-addresses/{}/", id),
+        "address": address,
+        "status": {"value": "active", "label": "Active"},
+        "assigned_object_type": "dcim.interface",
+        "assigned_object_id": 100 + id,
+        "assigned_object": {
+            "id": 100 + id,
+            "name": "eth0",
+            "display": "eth0",
+            "device": {"id": device_id, "name": device_name, "display": device_name}
+        },
+        "tags": tags_arr
+    })
+}
+
+#[tokio::test]
+async fn prometheus_sd_groups_ips_by_device_and_labels() {
+    let server = MockServer::start().await;
+    let cidr = "10.0.0.0/24";
+    mount_prefix(&server, 5, cidr).await;
+
+    // Member IPs of the prefix (global table, vrf_id=null).
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/ip-addresses/"))
+        .and(query_param("parent", cidr))
+        .and(query_param("vrf_id", "null"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 3, "next": null, "previous": null,
+            "results": [
+                ip_row(1, "10.0.0.5/24", 1, "edge01", &["prod"]),
+                ip_row(2, "10.0.0.6/24", 1, "edge01", &["prod"]),
+                ip_row(3, "10.0.0.7/24", 2, "edge02", &["monitoring"]),
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // Device enrichment: one fetch for the distinct device ids.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 2, "next": null, "previous": null,
+            "results": [
+                {"id": 1, "url": "http://nb/api/dcim/devices/1/", "name": "edge01",
+                 "status": {"value": "active", "label": "Active"},
+                 "role": {"id": 9, "display": "router"},
+                 "site": {"id": 1, "display": "iad1"},
+                 "tags": [{"id": 1, "name": "prod", "slug": "prod"}]},
+                {"id": 2, "url": "http://nb/api/dcim/devices/2/", "name": "edge02",
+                 "status": {"value": "active", "label": "Active"},
+                 "role": {"id": 9, "display": "router"},
+                 "site": {"id": 1, "display": "iad1"},
+                 "tags": [{"id": 2, "name": "monitoring", "slug": "monitoring"}]},
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client(&server);
+    let p = nbox::domain::detail::resolve_prefix(&client, cidr, None, &|n, v| {
+        anyhow::anyhow!("no {n} matched {v}")
+    })
+    .await
+    .unwrap();
+    let vrf_id = p.vrf.as_ref().map(|v| v.id);
+    let ips = client.prefix_ips(cidr, vrf_id, 5000).await.unwrap();
+    assert_eq!(ips.len(), 3);
+
+    // Run the CLI end-to-end via the binary.
+    let config = temp_config(&server.uri());
+    let out = run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "export".as_ref(),
+        "prometheus-sd".as_ref(),
+        "--prefix".as_ref(),
+        cidr.as_ref(),
+        "--port".as_ref(),
+        "9100".as_ref(),
+    ]);
+    let arr = assert_json_stdout(&out);
+    let groups = arr.as_array().expect("SD JSON is an array");
+    assert_eq!(groups.len(), 2, "two device groups, got: {groups:?}");
+
+    let edge01 = groups
+        .iter()
+        .find(|g| g["labels"]["device"] == "edge01")
+        .expect("edge01 group");
+    let targets = edge01["targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 2);
+    assert!(targets.iter().any(|t| t == "10.0.0.5:9100"));
+    assert!(targets.iter().any(|t| t == "10.0.0.6:9100"));
+    assert_eq!(edge01["labels"]["site"], "iad1");
+    assert_eq!(edge01["labels"]["role"], "router");
+    assert_eq!(edge01["labels"]["status"], "active");
+    assert_eq!(edge01["labels"]["tags"], "prod");
+
+    let edge02 = groups
+        .iter()
+        .find(|g| g["labels"]["device"] == "edge02")
+        .expect("edge02 group");
+    assert_eq!(edge02["targets"][0], "10.0.0.7:9100");
+    assert_eq!(edge02["labels"]["tags"], "monitoring");
+}
+
+#[tokio::test]
+async fn prometheus_sd_tag_path_queries_ip_addresses_by_tag() {
+    let server = MockServer::start().await;
+
+    // Tag resolution: by name.
+    Mock::given(method("GET"))
+        .and(path("/api/extras/tags/"))
+        .and(query_param("name", "prod"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{"id": 7, "name": "prod", "slug": "prod"}]
+        })))
+        .mount(&server)
+        .await;
+
+    // IPs carrying the tag (slug form).
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/ip-addresses/"))
+        .and(query_param("tag", "prod"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [ip_row(1, "10.9.0.5/24", 1, "edge01", &["prod"])]
+        })))
+        .mount(&server)
+        .await;
+
+    // Device enrichment.
+    Mock::given(method("GET"))
+        .and(path("/api/dcim/devices/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [
+                {"id": 1, "url": "u", "name": "edge01",
+                 "status": {"value": "active", "label": "Active"},
+                 "site": {"id": 1, "display": "iad1"},
+                 "tags": [{"id": 1, "name": "prod", "slug": "prod"}]},
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let config = temp_config(&server.uri());
+    let out = run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "export".as_ref(),
+        "prometheus-sd".as_ref(),
+        "--tag".as_ref(),
+        "prod".as_ref(),
+    ]);
+    let arr = assert_json_stdout(&out);
+    let groups = arr.as_array().unwrap();
+    assert_eq!(groups.len(), 1);
+    // Default port 9100.
+    assert_eq!(groups[0]["targets"][0], "10.9.0.5:9100");
+    assert_eq!(groups[0]["labels"]["device"], "edge01");
+    assert_eq!(groups[0]["labels"]["site"], "iad1");
+}
+
+#[tokio::test]
+async fn prometheus_sd_requires_prefix_or_tag() {
+    let server = MockServer::start().await;
+    let config = temp_config(&server.uri());
+    let out = run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "export".as_ref(),
+        "prometheus-sd".as_ref(),
+    ]);
+    // Usage error → exit 2, clean stdout.
+    assert_eq!(out.code, Some(2), "stderr: {}", out.stderr);
+    assert!(out.stdout.is_empty(), "stdout must be clean on usage error");
+    assert!(
+        out.stderr.contains("--prefix") && out.stderr.contains("--tag"),
+        "stderr should name the required flags: {}",
+        out.stderr
+    );
+}
+
+#[tokio::test]
+async fn prometheus_sd_rejects_both_prefix_and_tag() {
+    let server = MockServer::start().await;
+    let config = temp_config(&server.uri());
+    let out = run_nbox([
+        "--config".as_ref(),
+        config.path().as_os_str(),
+        "--no-tui".as_ref(),
+        "export".as_ref(),
+        "prometheus-sd".as_ref(),
+        "--prefix".as_ref(),
+        "10.0.0.0/24".as_ref(),
+        "--tag".as_ref(),
+        "prod".as_ref(),
+    ]);
+    assert_eq!(out.code, Some(2));
+    assert!(out.stdout.is_empty());
+    assert!(
+        out.stderr.contains("mutually exclusive"),
+        "stderr: {}",
+        out.stderr
+    );
+}


### PR DESCRIPTION
## Summary

Adds a structured read-only export surface: `nbox export prometheus-sd` emits
Prometheus file-based service-discovery JSON
(`[{"targets": ["ip:port"], "labels": {"key": "value"}}]`) for IPs in a prefix
or carrying a tag. A concrete, differentiated ops use case that showcases the
read engine.

## What

- **`src/export/mod.rs`** (new): a pure `prometheus_sd(ips, port) -> Vec<TargetGroup>` that groups enriched IPs by device, derives labels (`device`/`site`/`role`/`status`/`tags`), and emits the SD shape. `ExportIp` enriched-input type, `strip_prefix_len`, `DEFAULT_PORT = 9100`. Deterministic target + group ordering; tags unioned/de-duped/sorted; unassigned IPs fall back to per-site (or `device=""`) groups.
- **CLI** (`src/cli.rs`): `nbox export prometheus-sd --prefix <cidr> | --tag <slug>` with `--vrf` and `--port` (default 9100). `--prefix`/`--tag` mutually exclusive; omitting both is a usage error (exit 2).
- **Dispatch** (`src/lib.rs::run_export`): reuses the read engine — `detail::resolve_prefix` + `prefix_ips` for the prefix path; `tag_by_ref` + the IP-addresses `?tag=` filter for the tag path. Enriches each IP with its assigned device's site/role/status via one `?id__in` device fetch, then calls `prometheus_sd`. Output is a compact JSON array on stdout (pipe-safe; format flags are no-ops — the SD shape is fixed by its consumer).
- **Docs**: new \"Structured exports\" section in `docs/FEATURES.md`.

## Tests

- 7 unit tests in `src/export/mod.rs`: grouping by device, port suffix, tag union/sort/dedup, label mapping, SD JSON serialization shape, unassigned fallback, empty input.
- 4 wiremock integration tests in `tests/export_tests.rs`: prefix path groups IPs + labels (`device`/`site`/`role`/`status`/`tags`), tag path queries IPs by tag, missing source → exit 2, mutually-exclusive → exit 2.

## Verification

- `cargo test --all-targets`: **1331 passed** (1320 baseline + 11 new)
- `cargo clippy --all-targets --all-features`: clean
- `cargo fmt`: clean
- `nbox export prometheus-sd --prefix 10.0.0.0/24 --port 9100 --json` emits valid Prometheus SD JSON to stdout (covered by the wiremock integration test)