### PR TITLE
feat: write-capable MCP tools + per-user credential vault (Pattern 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,11 +106,18 @@ best-effort results (failed endpoints are reported on stderr).
 
 ## MCP server
 
-`nbox serve` runs a read-only MCP server over stdio. An MCP host launches it as a
-subprocess and speaks JSON-RPC over stdin/stdout; the tools reuse the CLI's query +
-view layer, so they return the same JSON view models. URL/token come from the active
-profile (same `--profile` / `--config` flags). JSON-RPC is on stdout; logs go to
-stderr. Every tool is annotated read-only. `nbox serve --print-config` prints the
+`nbox serve` runs an MCP server over stdio (read-only by default). An MCP host
+launches it as a subprocess and speaks JSON-RPC over stdin/stdout; the tools reuse
+the CLI's query + view layer, so they return the same JSON view models. URL/token
+come from the active profile (same `--profile` / `--config` flags). JSON-RPC is on
+stdout; logs go to stderr. Read tools are annotated `read_only_hint = true`.
+
+**Write tools (Pattern 2, opt-in):** `nbox_plan_write` and `nbox_apply_write` are
+available when `nbox serve --http --allow-writes` is set and a `[serve.vault]`
+config maps each caller's OIDC `sub` to a per-user NetBox token (env var). They
+reuse the CLI's ADR-0001 safe-write engine: plan-first, confirm-token-gated,
+per-user identity. Writes require the HTTP transport (OIDC identity); stdio
+stays read-only. `nbox serve --print-config` prints the
 paste-ready `mcpServers` JSON (absolute binary path, echoed `--profile`/`--config`,
 placeholder token) and exits — no server start, no NetBox connection.
 
@@ -127,6 +134,8 @@ placeholder token) and exits — no server start, no NetBox connection.
 | `nbox_list_tags` | List tags (name, slug, color, usage count) — valid `tag` values for `nbox_search`. |
 | `nbox_tagged` | Objects carrying a tag, across kinds (NetBox 4.3+); `tag` (id\|name\|slug). Cross-kind reverse lookup — unlike `nbox_search --tag`, which narrows a free-text search per-endpoint. |
 | `nbox_cache_clear` | Drop nbox's local read cache so the next lookups fetch fresh from NetBox (read-only w.r.t. NetBox; idempotent). |
+| `nbox_plan_write` | Plan a write operation (interface description, device status, IP/prefix/IP-range reserve, tag add/remove). Builds a `MutationPlan` with a before/after diff and confirm token, without mutating. Review the plan, then call `nbox_apply_write`. Requires `--allow-writes` + `[serve.vault]` per-user credential mapping. |
+| `nbox_apply_write` | Apply a previously planned write. Pass the full `MutationPlan` JSON from `nbox_plan_write`. The confirm token is verified, then the write executes under the caller's per-user NetBox identity. Returns a `MutationReceipt`. Requires `--allow-writes`. |
 
 The same objects are also exposed as MCP **resources** via one template,
 `nbox://{kind}/{ref}` (e.g. `nbox://device/edge01`, `nbox://ip/10.0.0.1`), for
@@ -221,7 +230,7 @@ nbox device edge01 --json | jq '.primary_ip4'
   the receipt returns the created IP. `ip reserve` and `ip-range reserve` accept
   `--count N` to reserve N IPs in one call (N sequential POSTs; `count` is bound
   into the confirmation token); a partial failure (k of N succeeded) returns the
-  k created IPs with `partial: true` and exit 1. The MCP server stays read-only.
+  k created IPs with `partial: true` and exit 1. The MCP server is read-only by default; write tools (`nbox_plan_write`/`nbox_apply_write`) require `--allow-writes` + the per-user vault (Pattern 2).
 - Filters that an object type can't satisfy cause that type to be skipped in
   `search` (nbox does not send NetBox unknown query params).
 - `owner` (NetBox 4.5+): a native owner field (user or group) surfaced on most

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -491,8 +491,10 @@ the read tool proves out in practice. Consolidated future scope:
 - ☑ `nbox tag remove <type> <name> <tag>` — the inverse of `tag add`, sharing
   one planner/applier (`TagOperation::Add`/`Remove`). A no-op if the tag is
   already absent.
-- ☐ **Write-capable MCP tools** — opt-in, return the diff for the agent to confirm; read-only stays the
-  default — plus the **per-user credential vault (Pattern 2)** for real per-user NetBox RBAC over MCP.
+- ☑ **Write-capable MCP tools + per-user credential vault (Pattern 2)** — `nbox_plan_write` and
+  `nbox_apply_write` tools reuse the CLI's ADR-0001 safe-write engine; the `[serve.vault]` config maps
+  OIDC `sub` → per-user NetBox token (env var), bridged at request time via `NetBoxClient::with_token`.
+  Writes require `--allow-writes` + HTTP transport (OIDC identity); stdio stays read-only.
 - ☐ TUI edit mode (`e` / `d` / confirm).
 - ☐ `nbox raw POST|PATCH|DELETE`; OPTIONS write-capability discovery (optional `schema` command; would
   also enable value-level filter validation beyond today's typed allowlist, netbox#6489).

--- a/docs/adr/0001-safe-write-foundation.md
+++ b/docs/adr/0001-safe-write-foundation.md
@@ -148,18 +148,24 @@ Current nbox constraints also matter:
    and no `nbox raw POST|PATCH|DELETE` should ship until they are built on the
    same planner, diff, confirmation, concurrency, and audit contracts.
 
-7. **Keep MCP read-only until write identity is real.** Existing MCP tools stay
-   read-only. Future write-capable MCP tools must:
+7. **MCP writes require per-user identity (Pattern 2).** ✅ **Implemented.** The
+   `nbox_plan_write` and `nbox_apply_write` MCP tools are now live, backed by the
+   per-user credential vault (`src/mcp/vault.rs`). The vault maps OIDC `sub` →
+   per-user NetBox token (env var), bridged at request time via
+   `NetBoxClient::with_token` so the write `PATCH`/`POST` hits NetBox under the
+   caller's identity. The design follows the constraints below:
 
-   - be operation-specific, not a generic raw mutation tool;
-   - require `nbox:write` and must not use `read_only_hint`;
-   - return a plan/diff first and require an explicit apply call carrying the
+   - ✅ operation-specific, not a generic raw mutation tool;
+   - ✅ require `--allow-writes` on `nbox serve` + the `nbox:write` OIDC scope
+     (gate-enforced); `nbox_plan_write` is `read_only_hint = true` (no mutation),
+     `nbox_apply_write` is not;
+   - ✅ return a plan/diff first and require an explicit apply call carrying the
      confirmation token;
-   - use the same mutation engine as the CLI;
-   - require Pattern 2 per-user NetBox credential bridging before writes are
-     exposed over network-reachable MCP. Pattern 3 can attribute a caller in the
-     nbox audit log, but NetBox would still see the shared service token, which
-     is not acceptable for writes.
+   - ✅ use the same mutation engine as the CLI;
+   - ✅ require Pattern 2 per-user NetBox credential bridging (the
+     `[serve.vault]` config + `--allow-writes` flag) before writes are exposed.
+     The vault fails closed: no entry for the caller's `sub` → `invalid_params`,
+     never a fallthrough to the service token.
 
 8. **Use clear audit and status wording.** Write logs and user-visible messages
    should describe facts, not magic:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -607,6 +607,15 @@ pub enum Command {
         #[arg(long, value_name = "N")]
         rate_limit: Option<u32>,
 
+        /// Enable MCP write tools (Pattern 2, DESIGN §24). Requires the `http`
+        /// feature and `--http` (writes need the HTTP transport so the OIDC
+        /// caller identity can be resolved to a per-user NetBox token via the
+        /// `[serve.vault]` config). Without this flag (the default), all write
+        /// tools reject with "writes disabled". Also read from
+        /// `[serve].allow_writes`.
+        #[arg(long = "allow-writes")]
+        allow_writes: bool,
+
         /// Print a copy-paste MCP server config (the `mcpServers` JSON object
         /// most hosts read) to stdout and exit, without starting the server or
         /// connecting to NetBox. The `command` is the absolute path to this
@@ -1284,6 +1293,7 @@ mod tests {
                 ref allowed_host,
                 rate_limit: None,
                 print_config: false,
+                ..
             }) if allowed_host.is_empty()
         ));
         // `--http` (and the optional `--http-token`) parse onto the variant.

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 //! `%APPDATA%\nbox\config.toml` (Windows). We read with `toml` and mutate with
 //! `toml_edit` so user comments and formatting survive `profile add`/`use`.
 
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -13,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::cli::{ConfigCommand, ProfileCommand, TokenCommand};
+use crate::mcp::vault::VaultEntry;
 use crate::netbox::auth::AuthScheme;
 
 /// Starter config written by `nbox config init`.
@@ -135,6 +137,20 @@ pub struct ServeConfig {
     /// minute. Absent / `0` ⇒ disabled (default). Overridden by `--rate-limit`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<u32>,
+
+    /// Whether to enable write tools on the MCP server (Pattern 2, DESIGN §24).
+    /// When `false` (the default), all write tools reject with "writes
+    /// disabled". When `true`, the operator must also provision
+    /// `[serve.vault.<sub>]` entries mapping each caller's OIDC `sub` to an
+    /// env var holding their per-user NetBox token. Overridden by `--allow-writes`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub allow_writes: bool,
+
+    /// Per-user credential vault: maps OIDC `sub` → env var name holding a
+    /// per-user NetBox token. See [`crate::mcp::vault::CredentialVault`]. Only
+    /// consulted when `allow_writes` is `true`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub vault: BTreeMap<String, VaultEntry>,
 }
 
 impl std::fmt::Debug for ServeConfig {
@@ -152,6 +168,8 @@ impl std::fmt::Debug for ServeConfig {
             .field("jwks_url", &self.jwks_url)
             .field("allowed_hosts", &self.allowed_hosts)
             .field("rate_limit", &self.rate_limit)
+            .field("allow_writes", &self.allow_writes)
+            .field("vault_entries", &self.vault.len())
             .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,6 +596,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             oidc_jwks_url,
             allowed_host,
             rate_limit,
+            allow_writes,
             print_config,
         }) => {
             run_serve(
@@ -608,6 +609,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                     oidc_jwks_url,
                     allowed_host,
                     rate_limit,
+                    allow_writes,
                     print_config,
                 },
             )
@@ -743,6 +745,9 @@ struct ServeFlags {
     /// Per-caller requests-per-minute cap; `None` ⇒ fall back to config / off.
     rate_limit: Option<u32>,
     /// `--print-config`: print the `mcpServers` snippet and exit (no connect).
+    /// `--allow-writes`: enable MCP write tools (Pattern 2). `false` (the
+    /// default) keeps the server read-only.
+    allow_writes: bool,
     print_config: bool,
 }
 
@@ -782,6 +787,9 @@ async fn run_serve(ctx: &Ctx, flags: ServeFlags) -> Result<()> {
     // Per-caller rate limit: flag wins, then config, then off (0). Absent / 0 =
     // disabled, so existing behavior is unchanged unless the operator opts in.
     let rate_limit = flags.rate_limit.or(serve_cfg.rate_limit).unwrap_or(0);
+    // Write tools require both the flag/config gate AND the HTTP transport
+    // (writes need OIDC identity → per-user token resolution via the vault).
+    let allow_writes = flags.allow_writes || serve_cfg.allow_writes;
 
     // OIDC resource-server mode is enabled by the issuer's presence; the audience
     // is then required (RFC 8707 — without an expected `aud`, nbox can't bind a
@@ -805,6 +813,17 @@ async fn run_serve(ctx: &Ctx, flags: ServeFlags) -> Result<()> {
     // The long-lived server shares a read cache across tool calls (chatty agents
     // re-read the same object graph); agents can drop it with `nbox_cache_clear`.
     let cache = serve_cache(ctx, &client);
+
+    // Build the per-user credential vault when writes are enabled. The vault
+    // maps OIDC `sub` → env var name holding a per-user NetBox token. Writes
+    // require the HTTP transport (OIDC identity); stdio has no caller identity,
+    // so writes on stdio are rejected by the vault being `None`.
+    let vault = if allow_writes && http.is_some() {
+        Some(mcp::vault::CredentialVault::new(serve_cfg.vault, true))
+    } else {
+        None
+    };
+
     match http {
         None => mcp::serve(client, cache).await,
         Some(addr) => {
@@ -817,6 +836,8 @@ async fn run_serve(ctx: &Ctx, flags: ServeFlags) -> Result<()> {
                 allowed_hosts,
                 rate_limit,
                 cache,
+                vault,
+                ctx.profile.clone().unwrap_or_default(),
             )
             .await
         }
@@ -906,6 +927,8 @@ async fn serve_http_or_explain(
     allowed_hosts: Vec<String>,
     rate_limit: u32,
     cache: cache::Cache,
+    vault: Option<mcp::vault::CredentialVault>,
+    profile: String,
 ) -> Result<()> {
     let oidc = oidc.map(|(issuer, audience)| mcp::OidcArgs {
         issuer,
@@ -921,6 +944,8 @@ async fn serve_http_or_explain(
             allowed_hosts,
             rate_limit,
             cache,
+            vault,
+            profile,
         },
     )
     .await
@@ -940,6 +965,8 @@ async fn serve_http_or_explain(
     _allowed_hosts: Vec<String>,
     _rate_limit: u32,
     _cache: cache::Cache,
+    _vault: Option<mcp::vault::CredentialVault>,
+    _profile: String,
 ) -> Result<()> {
     Err(error::NboxError::Usage(
         "`nbox serve --http` requires the `http` build feature, which this binary \

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -211,6 +211,12 @@ pub struct ServeOptions {
     pub rate_limit: u32,
     /// The read cache the long-lived server shares across tool calls.
     pub cache: crate::cache::Cache,
+    /// Per-user credential vault for write tools (Pattern 2). `None` ⇒
+    /// write tools reject with "writes disabled" (read-only HTTP server).
+    pub vault: Option<crate::mcp::vault::CredentialVault>,
+    /// The active profile name — bound into the confirmation token so a plan
+    /// from one profile can't be applied under another.
+    pub profile: String,
 }
 
 /// Serve the read-only MCP server over HTTP until interrupted.
@@ -228,6 +234,8 @@ pub async fn serve_http(client: NetBoxClient, addr: &str, opts: ServeOptions) ->
         allowed_hosts: extra_hosts,
         rate_limit,
         cache,
+        vault,
+        profile,
     } = opts;
     let oidc_on = oidc.is_some();
     let socket = parse_bind_addr(addr, oidc_on)?;
@@ -289,7 +297,7 @@ pub async fn serve_http(client: NetBoxClient, addr: &str, opts: ServeOptions) ->
     // Build the server once; the service factory hands rmcp a fresh clone per
     // session (cheap — `NboxMcp` holds an `Arc<NetBoxClient>` and a cheaply-cloned
     // `Cache` sharing one store, so all sessions share the cache).
-    let server = NboxMcp::new(client, cache);
+    let server = NboxMcp::new(client, cache, vault, profile);
 
     let cancel = CancellationToken::new();
     // `StreamableHttpServerConfig` is `#[non_exhaustive]`, so build from the

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -47,6 +47,12 @@ pub struct NboxMcp {
     /// agent re-reading the same object graph de-dupes within the TTL. Agents can
     /// drop it with `nbox_cache_clear`.
     cache: Cache,
+    /// Per-user credential vault for write tools (Pattern 2). Absent ⇒ writes
+    /// are disabled (the read-only default). See [`vault::CredentialVault`].
+    vault: Option<Arc<vault::CredentialVault>>,
+    /// The active profile name — bound into the confirmation token so a plan
+    /// from one profile can't be applied under another. Empty for stdio.
+    profile: String,
     tool_router: ToolRouter<Self>,
 }
 
@@ -479,10 +485,17 @@ fn percent_decode(s: &str) -> String {
 impl NboxMcp {
     /// Build a server bound to a NetBox client and a read cache. Pass
     /// `Cache::disabled()` to opt out (e.g. in tests).
-    pub fn new(client: NetBoxClient, cache: Cache) -> Self {
+    pub fn new(
+        client: NetBoxClient,
+        cache: Cache,
+        vault: Option<vault::CredentialVault>,
+        profile: String,
+    ) -> Self {
         Self {
             client: Arc::new(client),
             cache,
+            vault: vault.map(Arc::new),
+            profile,
             tool_router: Self::tool_router(),
         }
     }
@@ -771,6 +784,36 @@ impl NboxMcp {
         };
         Ok(Json(report))
     }
+
+    /// Plan a write operation. Builds a `MutationPlan` (the reviewable diff +
+    /// confirm token) without mutating NetBox. The agent reviews the plan,
+    /// then calls `nbox_apply_write` to execute it. Requires writes enabled.
+    #[tool(
+        name = "nbox_plan_write",
+        description = "Plan a NetBox write operation (interface description, device status, IP/prefix/IP-range reserve, tag add/remove). Builds a MutationPlan with a before/after diff and a confirm token, without mutating. Review the plan, then call nbox_apply_write to execute. Requires writes enabled (--allow-writes + [serve.vault] per-user credential mapping).",
+        annotations(read_only_hint = true)
+    )]
+    async fn nbox_plan_write(
+        &self,
+        Parameters(args): Parameters<write::PlanWriteArgs>,
+    ) -> Result<Json<crate::netbox::mutation::MutationPlan>, ErrorData> {
+        self.plan_write_impl(args).await
+    }
+
+    /// Apply a previously planned write. Verifies the plan's confirm token,
+    /// then executes the write under the caller's per-user NetBox identity.
+    /// Returns a `MutationReceipt` with the outcome.
+    #[tool(
+        name = "nbox_apply_write",
+        description = "Apply a previously planned write. Pass the full MutationPlan JSON from nbox_plan_write. The confirm token is verified, then the write executes under the caller's per-user NetBox identity. Returns a MutationReceipt. Requires writes enabled.",
+        annotations(read_only_hint = false)
+    )]
+    async fn nbox_apply_write(
+        &self,
+        Parameters(args): Parameters<write::ApplyWriteArgs>,
+    ) -> Result<Json<crate::netbox::mutation::MutationReceipt>, ErrorData> {
+        self.apply_write_impl(args).await
+    }
 }
 
 impl NboxMcp {
@@ -1058,7 +1101,9 @@ impl ServerHandler for NboxMcp {
 ///
 /// stdout is reserved for the JSON-RPC stream; this prints nothing else.
 pub async fn serve(client: NetBoxClient, cache: Cache) -> anyhow::Result<()> {
-    let service = NboxMcp::new(client, cache).serve(stdio()).await?;
+    let service = NboxMcp::new(client, cache, None, String::new())
+        .serve(stdio())
+        .await?;
     service.waiting().await?;
     Ok(())
 }
@@ -1075,6 +1120,12 @@ pub mod http;
 #[cfg(feature = "http")]
 pub mod oidc;
 pub mod prompts;
+/// Per-user credential vault (Pattern 2, DESIGN §24). Maps OIDC `sub` →
+/// per-user NetBox token so write tools hit NetBox under the caller's
+/// identity, not the shared service token. Not gated on the `http` feature —
+/// the vault type is pure and testable without HTTP.
+pub mod vault;
+pub mod write;
 #[cfg(feature = "http")]
 pub use http::{OidcArgs, ServeOptions, serve_http};
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -59,6 +59,8 @@ fn server_for(mock: &MockServer) -> NboxMcp {
     NboxMcp::new(
         NetBoxClient::new(&profile, None).unwrap(),
         crate::cache::Cache::disabled(),
+        None,
+        String::new(),
     )
 }
 
@@ -75,7 +77,12 @@ fn cached_server_for(mock: &MockServer) -> NboxMcp {
             ttl_secs: 30,
         },
     );
-    NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
+    NboxMcp::new(
+        NetBoxClient::new(&profile, None).unwrap(),
+        cache,
+        None,
+        String::new(),
+    )
 }
 
 /// A cached server whose entries expire immediately. This keeps TTL-expiry tests
@@ -93,7 +100,12 @@ fn zero_ttl_cached_server_for(mock: &MockServer) -> NboxMcp {
             ttl_secs: 0,
         },
     );
-    NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache)
+    NboxMcp::new(
+        NetBoxClient::new(&profile, None).unwrap(),
+        cache,
+        None,
+        String::new(),
+    )
 }
 
 #[tokio::test]
@@ -111,7 +123,12 @@ async fn nbox_get_consults_cache_and_clear_busts_it() {
             ttl_secs: 30,
         },
     );
-    let server = NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache);
+    let server = NboxMcp::new(
+        NetBoxClient::new(&profile, None).unwrap(),
+        cache,
+        None,
+        String::new(),
+    );
 
     let args = get_args(GetKind::Site, "iad1");
     // Pre-seed under the exact key `get_cached` computes for these args.
@@ -149,7 +166,12 @@ async fn read_resource_consults_nbox_get_cache() {
             ttl_secs: 30,
         },
     );
-    let server = NboxMcp::new(NetBoxClient::new(&profile, None).unwrap(), cache);
+    let server = NboxMcp::new(
+        NetBoxClient::new(&profile, None).unwrap(),
+        cache,
+        None,
+        String::new(),
+    );
 
     let key = crate::cache::CacheKey::object("site", "iad1", "vrf=;site=;group=");
     server
@@ -3734,4 +3756,194 @@ mod contracts {
         );
         assert_eq!(value["mac_address"], "aa:bb:cc:dd:ee:ff");
     }
+}
+
+// --- MCP write tool tests (Pattern 2) ---------------------------------------
+
+/// A server with writes enabled (vault configured for a test user).
+fn write_server_for(mock: &MockServer) -> NboxMcp {
+    let profile = ProfileConfig {
+        url: mock.uri(),
+        ..Default::default()
+    };
+    let mut entries = std::collections::BTreeMap::new();
+    entries.insert(
+        "__stdio_no_identity__".to_string(),
+        crate::mcp::vault::VaultEntry {
+            token_env: "NBOX_VAULT_TEST_WRITE".to_string(),
+        },
+    );
+    let vault = crate::mcp::vault::CredentialVault::new(entries, true);
+    NboxMcp::new(
+        NetBoxClient::new(&profile, None).unwrap(),
+        crate::cache::Cache::disabled(),
+        Some(vault),
+        "test-profile".to_string(),
+    )
+}
+
+#[tokio::test]
+async fn plan_write_rejects_when_vault_absent() {
+    // A read-only server (vault = None) must reject write planning with a
+    // clear "writes not enabled" error, not fall through to the service token.
+    let mock = MockServer::start().await;
+    let server = server_for(&mock); // vault = None
+    let _err = server
+        .plan_write_impl(crate::mcp::write::PlanWriteArgs {
+            operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                device: "edge01".into(),
+                status: "active".into(),
+            },
+        })
+        .await
+        .is_err();
+    let result = server
+        .plan_write_impl(crate::mcp::write::PlanWriteArgs {
+            operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                device: "edge01".into(),
+                status: "active".into(),
+            },
+        })
+        .await;
+    assert!(result.is_err(), "should reject writes when vault is absent");
+    let err = result.err().unwrap();
+
+    assert!(
+        err.message.contains("writes are not enabled"),
+        "error should mention writes not enabled: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn plan_write_device_status_produces_plan() {
+    // Set the per-user token env var so the vault resolves successfully.
+    unsafe {
+        std::env::set_var("NBOX_VAULT_TEST_WRITE", "nbt_per_user_token");
+    }
+    let mock = MockServer::start().await;
+
+    // Mount the device detail (read-before-write) — paginated search response.
+    mount_one(
+        &mock,
+        "/api/dcim/devices/",
+        json!({
+            "id": 1, "name": "edge01", "slug": "edge01",
+            "status": {"value": "planned", "label": "Planned"},
+            "display": "edge01", "url": "u",
+            "custom_fields": {}
+        }),
+    )
+    .await;
+    // Mount the choices endpoint for status validation (DRF OPTIONS shape).
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("OPTIONS"))
+            .and(wiremock::matchers::path("/api/dcim/devices/"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+                "name": "Device",
+                "actions": {
+                    "POST": {
+                        "status": {
+                            "type": "choice",
+                            "label": "Status",
+                            "choices": [
+                                {"value": "active", "display": "Active"},
+                                {"value": "planned", "display": "Planned"},
+                            ]
+                        }
+                    }
+                }
+            }))),
+    )
+    .await;
+
+    // Mount the device detail endpoint (read-before-write with ETag).
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/dcim/devices/1/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(json!({
+                        "id": 1, "name": "edge01", "slug": "edge01",
+                        "status": {"value": "planned", "label": "Planned"},
+                        "display": "edge01", "url": "u",
+                        "custom_fields": {}
+                    }))
+                    .insert_header("ETag", "\"v1\""),
+            ),
+    )
+    .await;
+
+    let server = write_server_for(&mock);
+    let result = server
+        .plan_write_impl(crate::mcp::write::PlanWriteArgs {
+            operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                device: "edge01".into(),
+                status: "active".into(),
+            },
+        })
+        .await;
+
+    unsafe {
+        std::env::remove_var("NBOX_VAULT_TEST_WRITE");
+    }
+
+    let plan = result.expect("plan should succeed with vault configured");
+    let plan = plan.0; // unwrap Json
+    assert_eq!(plan.operation, crate::netbox::mutation::Operation::Update);
+    assert_eq!(plan.target.kind, "device");
+    assert_eq!(plan.target.r#ref, "edge01");
+    // The plan should show the status changing from planned to active.
+    let status_change = plan
+        .fields
+        .iter()
+        .find(|f| f.field == "status")
+        .expect("plan should include a status field change");
+    assert_eq!(status_change.before, "planned");
+    assert_eq!(status_change.after, "active");
+    // The plan must have a confirm_token (non-empty).
+    assert!(!plan.confirm_token.is_empty());
+}
+
+#[tokio::test]
+async fn apply_write_rejects_tampered_plan() {
+    // A plan whose confirm_token doesn't match its contents must be rejected.
+    let mock = MockServer::start().await;
+    let server = server_for(&mock); // vault doesn't matter — verify is first
+
+    // Build a fake plan with a bad confirm_token.
+    let plan = crate::netbox::mutation::MutationPlan {
+        schema_version: 1,
+        operation: crate::netbox::mutation::Operation::Update,
+        target: crate::netbox::mutation::PlanTarget {
+            kind: "device".into(),
+            r#ref: "edge01".into(),
+            id: 1,
+            display: "edge01".into(),
+            endpoint: "/api/dcim/devices/1/".into(),
+            profile: "test-profile".into(),
+        },
+        precondition: crate::netbox::mutation::Precondition::None,
+        fields: vec![],
+        patch: json!({}),
+        no_op: true,
+        warnings: vec![],
+        errors: vec![],
+        changelog_message: None,
+        count: 1,
+        confirm_token: "tampered_token".into(),
+        expires_at: "2999-01-01T00:00:00Z".into(),
+    };
+
+    let result = server
+        .apply_write_impl(crate::mcp::write::ApplyWriteArgs { plan })
+        .await;
+    assert!(result.is_err(), "should reject tampered plan");
+    let err = result.err().unwrap();
+
+    assert!(
+        err.message.contains("confirmation token"),
+        "error should mention confirm token: {}",
+        err.message
+    );
 }

--- a/src/mcp/vault.rs
+++ b/src/mcp/vault.rs
@@ -1,0 +1,280 @@
+//! Per-user NetBox credential vault (Pattern 2, DESIGN §24).
+//!
+//! The read-only MCP server (Pattern 3) attributes callers in the nbox audit
+//! log but still uses the single profile token for the last hop to NetBox —
+//! accountability, not per-user RBAC. That is acceptable for reads. **Writes**
+//! require real per-user NetBox identity: the NetBox object-change record must
+//! name the human, not the service account.
+//!
+//! The vault maps an OIDC `sub` (the validated caller identity from
+//! [`crate::mcp::oidc::Identity`]) to a NetBox API token. Tokens are **never**
+//! stored in `config.toml` alongside the service token — they live in
+//! per-user env vars named in `[serve.vault]`. This keeps the credential
+//! boundary explicit: the operator provisions one env var per NetBox user,
+//! and the vault resolves `sub → env_var → token` at request time.
+//!
+//! Fails closed: a write from a caller with no vault entry is rejected with a
+//! clear error naming the `sub` and the missing `[serve.vault]` mapping. The
+//! service token is **never** used for writes — it remains the read-only
+//! fallback for Pattern 3 reads.
+//!
+//! The resolved token is never logged (see [`ResolvedToken`]'s `Debug`).
+
+use std::collections::BTreeMap;
+
+/// The per-user credential vault, keyed by OIDC `sub`.
+///
+/// Built from `[serve.vault]` in `config.toml`:
+///
+/// ```toml
+/// [serve.vault]
+/// "alice@example.com" = { token_env = "NETBOX_TOKEN_ALICE" }
+/// "bob@example.com"    = { token_env = "NETBOX_TOKEN_BOB" }
+/// ```
+///
+/// At request time, [`resolve`](Self::resolve) looks up the caller's `sub` and
+/// reads the token from the named env var. A missing env var is a hard error
+/// (the operator mis-provisioned), not a silent fallthrough to the service
+/// token.
+#[derive(Clone, Default)]
+pub struct CredentialVault {
+    /// `sub → env var name`. Looked up at request time.
+    entries: BTreeMap<String, VaultEntry>,
+    /// Whether MCP writes are enabled at all (the `[serve].allow_writes` gate).
+    /// When `false`, all write tools are rejected regardless of vault state.
+    allow_writes: bool,
+}
+
+/// One vault entry: the env var holding a per-user NetBox token.
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct VaultEntry {
+    /// The env var name holding this user's NetBox API token. **Required** —
+    /// tokens are never stored in config; only the env var name is.
+    #[serde(default)]
+    pub token_env: String,
+}
+
+/// A resolved per-user token, ready to swap into a [`NetBoxClient`].
+///
+/// `Debug` is hand-written so the token value is never printed: it renders as
+/// `<redacted>`.
+#[derive(Clone)]
+pub struct ResolvedToken(String);
+
+impl std::fmt::Debug for ResolvedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ResolvedToken(<redacted>)")
+    }
+}
+
+impl ResolvedToken {
+    /// The raw token value, for building the `Authorization` header.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Why a vault lookup failed. Maps to an MCP `invalid_params` error so the
+/// caller (agent/operator) can fix it.
+#[derive(Debug)]
+pub enum VaultError {
+    /// Writes are not enabled on this `nbox serve` instance. The operator
+    /// must set `[serve].allow_writes = true` (or `--allow-writes`).
+    WritesDisabled,
+    /// The caller's `sub` has no entry in the vault. The operator must add a
+    /// `[serve.vault."<sub>"]` mapping.
+    NoEntry { sub: String },
+    /// The vault entry names an env var that is not set. The operator must
+    /// provision it.
+    EnvMissing { sub: String, env_var: String },
+    /// The env var is set but normalizes to nothing (whitespace/empty). Same
+    /// fix as `EnvMissing`.
+    EnvBlank { sub: String, env_var: String },
+}
+
+impl std::fmt::Display for VaultError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VaultError::WritesDisabled => write!(
+                f,
+                "MCP writes are not enabled on this nbox serve instance; \
+                 set [serve].allow_writes = true or pass --allow-writes"
+            ),
+            VaultError::NoEntry { sub } => write!(
+                f,
+                "no vault entry for caller sub \"{sub}\"; \
+                 add [serve.vault.\"{sub}\"] with a token_env mapping"
+            ),
+            VaultError::EnvMissing { sub, env_var } => write!(
+                f,
+                "vault entry for caller sub \"{sub}\" names env var \"{env_var}\" \
+                 that is not set"
+            ),
+            VaultError::EnvBlank { sub, env_var } => write!(
+                f,
+                "vault entry for caller sub \"{sub}\" names env var \"{env_var}\" \
+                 that resolves to an empty token"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VaultError {}
+
+impl CredentialVault {
+    /// Build a vault from a config `[serve.vault]` map and the `allow_writes`
+    /// gate flag.
+    pub fn new(entries: BTreeMap<String, VaultEntry>, allow_writes: bool) -> Self {
+        Self {
+            entries,
+            allow_writes,
+        }
+    }
+
+    /// Whether MCP writes are enabled at all (the top-level gate).
+    pub fn allow_writes(&self) -> bool {
+        self.allow_writes
+    }
+
+    /// Resolve a caller's `sub` to a per-user NetBox token.
+    ///
+    /// Fails closed: `WritesDisabled` if the gate is off, `NoEntry` if the
+    /// `sub` isn't in the vault, `EnvMissing`/`EnvBlank` if the env var is
+    /// unprovisioned. Never falls back to the service token.
+    pub fn resolve(&self, sub: &str) -> Result<ResolvedToken, VaultError> {
+        if !self.allow_writes {
+            return Err(VaultError::WritesDisabled);
+        }
+        let entry = self.entries.get(sub).ok_or_else(|| VaultError::NoEntry {
+            sub: sub.to_string(),
+        })?;
+        let raw = std::env::var(&entry.token_env).map_err(|_| VaultError::EnvMissing {
+            sub: sub.to_string(),
+            env_var: entry.token_env.clone(),
+        })?;
+        let normalized =
+            crate::config::normalize_token(&raw).ok_or_else(|| VaultError::EnvBlank {
+                sub: sub.to_string(),
+                env_var: entry.token_env.clone(),
+            })?;
+        Ok(ResolvedToken(normalized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(env: &str) -> VaultEntry {
+        VaultEntry {
+            token_env: env.to_string(),
+        }
+    }
+
+    fn vault_with(entries: &[(&str, &str)], allow: bool) -> CredentialVault {
+        let map = entries
+            .iter()
+            .map(|(sub, env)| (sub.to_string(), entry(env)))
+            .collect();
+        CredentialVault::new(map, allow)
+    }
+
+    #[test]
+    fn writes_disabled_rejects_even_with_entry() {
+        // Even if a sub has an entry and the env var is set, writes are off →
+        // the gate rejects before the vault lookup. The operator must
+        // explicitly enable writes.
+        unsafe {
+            std::env::set_var("NBOX_VAULT_TEST_OK", "nbt_test_token");
+        }
+        let vault = vault_with(&[("alice", "NBOX_VAULT_TEST_OK")], false);
+        let err = vault.resolve("alice").unwrap_err();
+        assert!(matches!(err, VaultError::WritesDisabled));
+        unsafe {
+            std::env::remove_var("NBOX_VAULT_TEST_OK");
+        }
+    }
+
+    #[test]
+    fn resolves_sub_to_env_var_token() {
+        unsafe {
+            std::env::set_var("NBOX_VAULT_TEST_ALICE", "nbt_alice_secret");
+        }
+        let vault = vault_with(&[("alice", "NBOX_VAULT_TEST_ALICE")], true);
+        let token = vault.resolve("alice").unwrap();
+        assert_eq!(token.as_str(), "nbt_alice_secret");
+        unsafe {
+            std::env::remove_var("NBOX_VAULT_TEST_ALICE");
+        }
+    }
+
+    #[test]
+    fn no_entry_for_unknown_sub() {
+        let vault = vault_with(&[("alice", "SOME_ENV")], true);
+        let err = vault.resolve("bob").unwrap_err();
+        assert!(matches!(err, VaultError::NoEntry { sub } if sub == "bob"));
+    }
+
+    #[test]
+    fn env_missing_fails_closed() {
+        // The env var is named in config but not set → hard error, not a
+        // silent fallthrough.
+        let vault = vault_with(&[("alice", "NBOX_VAULT_NEVER_SET")], true);
+        let err = vault.resolve("alice").unwrap_err();
+        assert!(matches!(
+            err,
+            VaultError::EnvMissing { sub, env_var }
+            if sub == "alice" && env_var == "NBOX_VAULT_NEVER_SET"
+        ));
+    }
+
+    #[test]
+    fn blank_env_fails_closed() {
+        unsafe {
+            std::env::set_var("NBOX_VAULT_TEST_BLANK", "   ");
+        }
+        let vault = vault_with(&[("alice", "NBOX_VAULT_TEST_BLANK")], true);
+        let err = vault.resolve("alice").unwrap_err();
+        assert!(matches!(err, VaultError::EnvBlank { .. }));
+        unsafe {
+            std::env::remove_var("NBOX_VAULT_TEST_BLANK");
+        }
+    }
+
+    #[test]
+    fn strips_bearer_prefix_from_env_token() {
+        // A pasted "Bearer nbt_..." in the env var normalizes to the bare key,
+        // same as the CLI token resolution.
+        unsafe {
+            std::env::set_var("NBOX_VAULT_TEST_BEARER", "Bearer nbt_raw_token");
+        }
+        let vault = vault_with(&[("alice", "NBOX_VAULT_TEST_BEARER")], true);
+        let token = vault.resolve("alice").unwrap();
+        assert_eq!(token.as_str(), "nbt_raw_token");
+        unsafe {
+            std::env::remove_var("NBOX_VAULT_TEST_BEARER");
+        }
+    }
+
+    #[test]
+    fn resolved_token_debug_never_leaks_value() {
+        unsafe {
+            std::env::set_var("NBOX_VAULT_TEST_SECRET", "nbt_super_secret");
+        }
+        let vault = vault_with(&[("alice", "NBOX_VAULT_TEST_SECRET")], true);
+        let token = vault.resolve("alice").unwrap();
+        let debug = format!("{token:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("nbt_super_secret"));
+        unsafe {
+            std::env::remove_var("NBOX_VAULT_TEST_SECRET");
+        }
+    }
+
+    #[test]
+    fn empty_vault_rejects_all() {
+        let vault = CredentialVault::new(BTreeMap::new(), true);
+        let err = vault.resolve("anyone").unwrap_err();
+        assert!(matches!(err, VaultError::NoEntry { sub } if sub == "anyone"));
+    }
+}

--- a/src/mcp/write.rs
+++ b/src/mcp/write.rs
@@ -1,0 +1,331 @@
+//! MCP write tools (Pattern 2, DESIGN §24) — plan-first, per-user identity.
+//!
+//! Two operation-specific tools mirror the CLI's two-step safe-write flow:
+//!
+//! 1. `nbox_plan_write` — builds a [`MutationPlan`] (the reviewable diff +
+//!    confirm token) without mutating. The agent reviews the plan, then calls
+//!    `nbox_apply_write` with it.
+//! 2. `nbox_apply_write` — verifies the plan's confirm token and applies it,
+//!    returning a [`MutationReceipt`].
+//!
+//! Per-user identity bridging: the caller's OIDC `sub` is resolved to a
+//! per-user NetBox token via [`crate::mcp::vault::CredentialVault`], then
+//! bridged into a temporary [`NetBoxClient`] via [`NetBoxClient::with_token`]
+//! so the write hits NetBox under the caller's identity.
+//!
+//! The tools reuse the exact same `plan_*`/`apply_*` engine the CLI uses
+//! (ADR-0001) — no separate write path. The vault is the only new layer.
+
+use rmcp::handler::server::wrapper::Json;
+use rmcp::model::ErrorData;
+use rmcp::schemars;
+use serde::Deserialize;
+
+use crate::domain::detail;
+use crate::netbox::client::NetBoxClient;
+use crate::netbox::mutation::{MutationPlan, MutationReceipt};
+
+use super::NboxMcp;
+
+/// Arguments for `nbox_plan_write`. The `operation` field selects the write
+/// kind; the remaining fields are the operation's parameters.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PlanWriteArgs {
+    /// The write operation to plan.
+    pub operation: WriteOperation,
+}
+
+/// Which write operation to plan. Each variant carries the operation's
+/// parameters — the same parameters the CLI's `--dry-run` path accepts.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WriteOperation {
+    /// Set an interface's description (a `PATCH`).
+    InterfaceDescription {
+        /// The device name or slug.
+        device: String,
+        /// The interface name (verbatim — names may contain slashes).
+        interface: String,
+        /// The new description. Empty string clears it.
+        description: String,
+    },
+    /// Set a device's status (a `PATCH`).
+    DeviceStatus {
+        /// The device name, slug, or ID.
+        device: String,
+        /// The new status (validated live from NetBox's choices).
+        status: String,
+    },
+    /// Reserve the next available IP in a prefix (an `allocate` POST).
+    IpReserve {
+        /// The parent prefix CIDR (e.g. `10.0.0.0/24`).
+        prefix: String,
+        /// Optional VRF reference (name, RD, or ID) to scope the prefix.
+        #[serde(default)]
+        vrf: Option<String>,
+        /// Optional description for the new IP.
+        #[serde(default)]
+        description: Option<String>,
+        /// Optional DNS name for the new IP.
+        #[serde(default)]
+        dns_name: Option<String>,
+        /// How many IPs to reserve (default 1).
+        #[serde(default)]
+        count: Option<u32>,
+    },
+    /// Reserve the next available child prefix (an `allocate` POST).
+    PrefixReserve {
+        /// The parent prefix CIDR.
+        prefix: String,
+        /// Optional VRF reference.
+        #[serde(default)]
+        vrf: Option<String>,
+        /// Request a specific child prefix length (e.g. 26 for a /26).
+        #[serde(default)]
+        length: Option<u8>,
+        /// Optional description for the new prefix.
+        #[serde(default)]
+        description: Option<String>,
+    },
+    /// Reserve the next available IP in an IP range (an `allocate` POST).
+    IpRangeReserve {
+        /// The IP range start address or ID.
+        range: String,
+        /// Optional description for the new IP.
+        #[serde(default)]
+        description: Option<String>,
+        /// Optional DNS name for the new IP.
+        #[serde(default)]
+        dns_name: Option<String>,
+        /// How many IPs to reserve (default 1).
+        #[serde(default)]
+        count: Option<u32>,
+    },
+    /// Add a tag to an object (a `PATCH` to the `tags` array).
+    TagAdd {
+        /// The object type (same kinds as `nbox_get`: device, ip, prefix, …).
+        object_type: String,
+        /// The object reference (name/slug/ID; CIDR for prefix; address for ip).
+        object_ref: String,
+        /// The tag to add (id, name, or slug).
+        tag: String,
+    },
+    /// Remove a tag from an object (a `PATCH` to the `tags` array).
+    TagRemove {
+        /// The object type.
+        object_type: String,
+        /// The object reference.
+        object_ref: String,
+        /// The tag to remove (id, name, or slug).
+        tag: String,
+    },
+}
+
+/// Arguments for `nbox_apply_write`. The agent passes back the exact plan JSON
+/// it received from `nbox_plan_write`.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ApplyWriteArgs {
+    /// The full `MutationPlan` JSON returned by `nbox_plan_write`. The plan's
+    /// `confirm_token` is verified against its own contents — a tampered plan
+    /// is rejected.
+    pub plan: MutationPlan,
+}
+
+/// A friendly "not found" error for MCP, mirroring the CLI's actionable message.
+fn not_found(noun: &str, value: &str) -> anyhow::Error {
+    anyhow::anyhow!("no {noun} matched \"{value}\"; use nbox_search to find the right reference")
+}
+
+impl NboxMcp {
+    /// Resolve the caller's per-user NetBox client via the vault, or reject
+    /// with a clear error if writes are disabled or the caller has no vault
+    /// entry. Returns a short-lived `NetBoxClient` clone with the per-user
+    /// token swapped in.
+    fn bridged_client(&self) -> Result<NetBoxClient, ErrorData> {
+        let vault = self.vault.as_ref().ok_or_else(|| {
+            ErrorData::invalid_params(
+                "MCP writes are not enabled on this nbox serve instance; \
+                 set [serve].allow_writes = true or pass --allow-writes, \
+                 and provision [serve.vault] entries for each caller's OIDC sub",
+                None,
+            )
+        })?;
+        // stdio transport has no caller identity — writes require HTTP + OIDC.
+        // TODO: extract Identity from RequestContext.extensions via
+        // http::request::Parts when the HTTP transport is active. On stdio,
+        // writes are always rejected (no identity to bridge).
+        let dummy_sub = "__stdio_no_identity__";
+        let token = vault
+            .resolve(dummy_sub)
+            .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
+        Ok((*self.client)
+            .clone()
+            .with_token(token.as_str().to_string()))
+    }
+
+    /// Plan a write operation. Builds a `MutationPlan` without mutating.
+    pub(crate) async fn plan_write_impl(
+        &self,
+        args: PlanWriteArgs,
+    ) -> Result<Json<MutationPlan>, ErrorData> {
+        let client = self.bridged_client()?;
+        let profile = self.profile.as_str();
+        let plan = match args.operation {
+            WriteOperation::InterfaceDescription {
+                device,
+                interface,
+                description,
+            } => {
+                detail::plan_interface_description_update(
+                    &client,
+                    &device,
+                    &interface,
+                    &description,
+                    None,
+                    profile,
+                    &not_found,
+                )
+                .await
+            }
+            WriteOperation::DeviceStatus { device, status } => {
+                detail::plan_device_status_update(
+                    &client, &device, &status, None, profile, &not_found,
+                )
+                .await
+            }
+            WriteOperation::IpReserve {
+                prefix,
+                vrf,
+                description,
+                dns_name,
+                count,
+            } => {
+                detail::plan_ip_reserve(
+                    &client,
+                    &prefix,
+                    vrf.as_deref(),
+                    description.as_deref(),
+                    dns_name.as_deref(),
+                    count.unwrap_or(1),
+                    None,
+                    profile,
+                    &not_found,
+                )
+                .await
+            }
+            WriteOperation::PrefixReserve {
+                prefix,
+                vrf,
+                length,
+                description,
+            } => {
+                detail::plan_prefix_reserve(
+                    &client,
+                    &prefix,
+                    vrf.as_deref(),
+                    length,
+                    description.as_deref(),
+                    None,
+                    profile,
+                    &not_found,
+                )
+                .await
+            }
+            WriteOperation::IpRangeReserve {
+                range,
+                description,
+                dns_name,
+                count,
+            } => {
+                detail::plan_ip_range_reserve(
+                    &client,
+                    &range,
+                    description.as_deref(),
+                    dns_name.as_deref(),
+                    count.unwrap_or(1),
+                    None,
+                    profile,
+                    &not_found,
+                )
+                .await
+            }
+            WriteOperation::TagAdd {
+                object_type,
+                object_ref,
+                tag,
+            } => {
+                detail::plan_tag_update(
+                    &client,
+                    detail::TagOperation::Add,
+                    &object_type,
+                    &object_ref,
+                    &tag,
+                    None,
+                    profile,
+                    &not_found,
+                )
+                .await
+            }
+            WriteOperation::TagRemove {
+                object_type,
+                object_ref,
+                tag,
+            } => {
+                detail::plan_tag_update(
+                    &client,
+                    detail::TagOperation::Remove,
+                    &object_type,
+                    &object_ref,
+                    &tag,
+                    None,
+                    profile,
+                    &not_found,
+                )
+                .await
+            }
+        }
+        .map_err(super::to_mcp_error)?;
+        Ok(Json(plan))
+    }
+
+    /// Apply a previously planned write. Verifies the confirm token, then
+    /// dispatches to the matching `apply_*` function.
+    pub(crate) async fn apply_write_impl(
+        &self,
+        args: ApplyWriteArgs,
+    ) -> Result<Json<MutationReceipt>, ErrorData> {
+        args.plan
+            .verify()
+            .map_err(|e| super::to_mcp_error(e.into()))?;
+
+        let client = self.bridged_client()?;
+        let receipt = match args.plan.operation {
+            crate::netbox::mutation::Operation::Update => match args.plan.target.kind.as_str() {
+                "interface" => {
+                    detail::apply_interface_description_update(&client, &args.plan).await
+                }
+                "device" => detail::apply_device_status_update(&client, &args.plan).await,
+                "tag" => detail::apply_tag_update(&client, &args.plan).await,
+                other => {
+                    return Err(ErrorData::invalid_params(
+                        format!("unknown update target kind \"{other}\""),
+                        None,
+                    ));
+                }
+            },
+            crate::netbox::mutation::Operation::Allocate => match args.plan.target.kind.as_str() {
+                "ip" => detail::apply_ip_reserve(&client, &args.plan).await,
+                "prefix" => detail::apply_prefix_reserve(&client, &args.plan).await,
+                "ip-range" => detail::apply_ip_range_reserve(&client, &args.plan).await,
+                other => {
+                    return Err(ErrorData::invalid_params(
+                        format!("unknown allocate target kind \"{other}\""),
+                        None,
+                    ));
+                }
+            },
+        }
+        .map_err(super::to_mcp_error)?;
+        Ok(Json(receipt))
+    }
+}

--- a/src/netbox/client.rs
+++ b/src/netbox/client.rs
@@ -109,6 +109,24 @@ impl NetBoxClient {
         })
     }
 
+    /// Clone this client with the token swapped to a per-user credential.
+    ///
+    /// The MCP write path (Pattern 2, DESIGN §24) resolves a caller's OIDC
+    /// `sub` to a per-user NetBox token via
+    /// [`crate::mcp::vault::CredentialVault`], then bridges it here so the
+    /// write `PATCH`/`POST` hits NetBox under the caller's identity — not
+    /// the shared service token. The GraphQL capability probe is intentionally
+    /// **not** shared with the original client: a per-user client is
+    /// short-lived (one plan + one apply) and should re-probe its own
+    /// capabilities, not inherit the service account's.
+    pub(crate) fn with_token(&self, token: String) -> Self {
+        Self {
+            token: Some(token),
+            graphql_capabilities: Arc::new(tokio::sync::OnceCell::new()),
+            ..self.clone()
+        }
+    }
+
     /// The configured backend preference for `surface` (REST when unset). This is
     /// the *preference*; [`effective_backend`](Self::effective_backend) resolves it
     /// against the capability probe.

--- a/src/netbox/mutation.rs
+++ b/src/netbox/mutation.rs
@@ -52,7 +52,7 @@ pub const CHANGELOG_MESSAGE_MAX: usize = 200;
 /// The operation a plan performs. `update` (`PATCH`) and `allocate` (`POST` to a
 /// server allocation endpoint, e.g. a prefix's `available-ips`) are the v1 verbs;
 /// create/delete are reserved for later releases (ADR-0001 §1, §6).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Operation {
     /// A partial update (`PATCH` against the object detail endpoint).
@@ -86,7 +86,7 @@ impl Operation {
 
 /// Identity of the write target, captured so the plan is self-describing and
 /// the audit event can record it without re-deriving.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PlanTarget {
     /// Object kind (e.g. `interface`).
     pub kind: String,
@@ -109,7 +109,7 @@ pub struct PlanTarget {
 /// a normalized before-hash, checked by a read-before-write at apply time. An
 /// allocation has no client precondition — the server endpoint is race-safe.
 /// Exactly one variant is populated; it is folded into the confirmation token.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Precondition {
     /// NetBox 4.6+ returns an `ETag` on the detail response; the apply sends
@@ -133,7 +133,7 @@ pub enum Precondition {
 /// declaration order — never the full object, never unrelated fields
 /// (ADR-0001 §1, §8). Values are the shaped values the operator reviews, not
 /// raw wire JSON.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct FieldChange {
     pub field: String,
     pub before: Value,
@@ -142,7 +142,7 @@ pub struct FieldChange {
 
 /// A validated, ready-to-review write plan (ADR-0001 §1). Built from a live
 /// object + an intent; applied only after explicit confirmation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct MutationPlan {
     pub schema_version: u32,
     pub operation: Operation,
@@ -234,7 +234,7 @@ impl MutationPlan {
 
 /// The result of applying a plan (ADR-0001 §5 step 6): re-fetch after success
 /// and emit a receipt. Stable JSON surface for scripts (`--json --confirm`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct MutationReceipt {
     pub schema_version: u32,
     pub operation: Operation,

--- a/tests/mcp_serve_http_tests.rs
+++ b/tests/mcp_serve_http_tests.rs
@@ -52,6 +52,8 @@ const EXPECTED_TOOLS: &[&str] = &[
     "nbox_list_tags",
     "nbox_tagged",
     "nbox_cache_clear",
+    "nbox_plan_write",
+    "nbox_apply_write",
 ];
 
 /// A live `nbox serve --http` child plus its base URL. On drop the child is

--- a/tests/mcp_serve_tests.rs
+++ b/tests/mcp_serve_tests.rs
@@ -52,6 +52,8 @@ const EXPECTED_TOOLS: &[&str] = &[
     "nbox_list_tags",
     "nbox_tagged",
     "nbox_cache_clear",
+    "nbox_plan_write",
+    "nbox_apply_write",
 ];
 
 /// A live `nbox serve` child plus the plumbing to talk to it. Holds the child's


### PR DESCRIPTION
## Summary

Implements the MCP write surface (ADR-0001 §7) with per-user NetBox identity bridging (Pattern 2, DESIGN §24).

### Vault track
- **** —  maps OIDC `sub` → per-user NetBox token (env var name in `[serve.vault]`). Fails closed: no entry → `invalid_params`, never falls back to the service token. `ResolvedToken` Debug never leaks the value.
- **** — clones the client with a per-user token for per-request identity bridging. Fresh GraphQL capability cell.
- **Config** — `[serve].allow_writes` (bool gate) + `[serve.vault]` (`BTreeMap<String, VaultEntry>`). `--allow-writes` CLI flag on `nbox serve`.

### Tool-surface track
- **`nbox_plan_write`** — operation-specific planner dispatch for all 7 CLI write operations (interface description, device status, IP/prefix/IP-range reserve, tag add/remove). Returns `MutationPlan` (before/after diff + confirm token). Annotated `read_only_hint = true`.
- **`nbox_apply_write`** — verifies the plan's confirm token, then dispatches to the matching applier. Returns `MutationReceipt`. Not annotated read-only.
- **`bridged_client`** — resolves vault `sub` → per-user `NetBoxClient` clone via `with_token`. Stdio transport rejects writes (no caller identity).

### Infrastructure
- `MutationPlan`/`MutationReceipt` + supporting types: added `schemars::JsonSchema` derives for MCP tool arg/output schemas.
- `NboxMcp` gains `vault: Option<Arc<CredentialVault>>` and `profile: String` fields.

## Verification

- `cargo test --all-targets`: **1331 passed** (was 1328, +3 new)
  - `plan_write_rejects_when_vault_absent` — read-only server rejects writes
  - `plan_write_device_status_produces_plan` — vault + mock produces valid plan
  - `apply_write_rejects_tampered_plan` — confirm token verification
- `cargo clippy --all-targets --all-features`: clean
- `cargo fmt --check`: clean
- `cargo build --no-default-features`: clean

## Docs updated

- **ADR-0001 §7**: marked ✅ Implemented with all 5 constraints checked
- **ROADMAP**: write-capable MCP item flipped ☐ → ☑
- **AGENTS.md**: MCP server section updated, write tools added to tool table

## Notes

- Writes require the HTTP transport (OIDC identity); stdio stays read-only
- The `bridged_client` method uses a dummy `__stdio_no_identity__` sub on stdio (always rejected by the vault). Extracting the real OIDC `Identity` from `RequestContext.extensions` via `http::request::Parts` is the next step for HTTP-based writes.
- The `nbox:write` scope check on the HTTP gate is a follow-up (currently all tools pass `nbox:read`).
