### PR TITLE
fix(mcp): wire real per-user identity + scope enforcement for MCP writes

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -268,13 +268,21 @@ asked, but NetBox's object permissions and changelog still attribute the call to
 the service account. Every authenticated caller therefore gets the service
 account's read rights — there is no per-user RBAC.
 
-Run this mode only for a **trusted, read-only, ideally single-team** deployment.
-Use a NetBox token scoped to exactly what an agent should see (read-only); that
-token is the real privilege boundary. Multi-tenant use, writes, and real per-user
-NetBox RBAC require per-user identity → NetBox-token bridging (a credential vault
-keyed by the OIDC `sub`, so NetBox sees the real user) — the documented v2
-(DESIGN §24, Pattern 2). The validated caller identity (`sub`, `client_id`,
-`scope`, `jti`, `iss`) is already plumbed through for it.
+Run **reads** in this mode only for a **trusted, read-only, ideally single-team**
+deployment. Use a NetBox token scoped to exactly what an agent should see
+(read-only); that token is the real privilege boundary for reads.
+
+**Writes** are a separate, opt-in **Pattern 2** path (DESIGN §24): per-user
+identity → NetBox-token bridging via a credential vault keyed by the OIDC `sub`,
+so NetBox's object permissions and changelog attribute each write to the real
+user — not the service account. Writes are enabled only when **all** of the
+following hold, and fail closed otherwise: `nbox serve --allow-writes` (or
+`[serve].allow_writes = true`); the caller's token carries the `nbox:write`
+scope; and a `[serve.vault."<sub>"]` entry maps the caller's `sub` to an env var
+holding that user's NetBox token. The read-only service token is never used for a
+write, and writes are unavailable over stdio / loopback static-bearer auth (no
+per-user identity to bridge). The `nbox_plan_write` / `nbox_apply_write` tools
+expose the same plan → confirm-token → apply lifecycle as the CLI.
 
 ## Operations (HTTP transport)
 

--- a/docs/adr/0001-safe-write-foundation.md
+++ b/docs/adr/0001-safe-write-foundation.md
@@ -149,23 +149,34 @@ Current nbox constraints also matter:
    same planner, diff, confirmation, concurrency, and audit contracts.
 
 7. **MCP writes require per-user identity (Pattern 2).** ✅ **Implemented.** The
-   `nbox_plan_write` and `nbox_apply_write` MCP tools are now live, backed by the
-   per-user credential vault (`src/mcp/vault.rs`). The vault maps OIDC `sub` →
-   per-user NetBox token (env var), bridged at request time via
-   `NetBoxClient::with_token` so the write `PATCH`/`POST` hits NetBox under the
-   caller's identity. The design follows the constraints below:
+   `nbox_plan_write` and `nbox_apply_write` MCP tools are backed by the per-user
+   credential vault (`src/mcp/vault.rs`). The validated OIDC `Identity` (`sub` +
+   scopes) is plumbed from the auth gate into the request `Parts`, which the
+   Streamable-HTTP transport nests into the rmcp `RequestContext`; the write tools
+   read the caller's `sub` from there and the vault maps it to a per-user NetBox
+   token (env var), bridged at request time via `NetBoxClient::with_token` so the
+   write `PATCH`/`POST` hits NetBox under the caller's identity. The design
+   follows the constraints below:
 
    - ✅ operation-specific, not a generic raw mutation tool;
-   - ✅ require `--allow-writes` on `nbox serve` + the `nbox:write` OIDC scope
-     (gate-enforced); `nbox_plan_write` is `read_only_hint = true` (no mutation),
-     `nbox_apply_write` is not;
+   - ✅ require `--allow-writes` on `nbox serve` **and** the caller's token
+     carrying the `nbox:write` scope. Scope is enforced **in the write tools**
+     (per request), not the HTTP gate — the gate deliberately does not parse the
+     JSON-RPC method (that would mean buffering the streaming body), so it cannot
+     tell a read tool from a write one. Both `nbox_plan_write` and
+     `nbox_apply_write` are advertised `read_only_hint = false`: planning is part
+     of the write flow (it requires the same gate + scope + per-user identity),
+     so a host's "auto-run read-only tools" policy must not auto-invoke it.
    - ✅ return a plan/diff first and require an explicit apply call carrying the
      confirmation token;
    - ✅ use the same mutation engine as the CLI;
-   - ✅ require Pattern 2 per-user NetBox credential bridging (the
-     `[serve.vault]` config + `--allow-writes` flag) before writes are exposed.
-     The vault fails closed: no entry for the caller's `sub` → `invalid_params`,
-     never a fallthrough to the service token.
+   - ✅ require Pattern 2 per-user NetBox credential bridging. Authorization fails
+     closed, in order: writes disabled (`--allow-writes` / `[serve.vault]` absent)
+     → no authenticated caller identity (stdio / loopback static-bearer carry
+     none — writes need HTTP+OIDC) → missing `nbox:write` scope → no
+     `[serve.vault]` entry for the caller's `sub`. The service token is never used
+     for writes, and the no-identity case is its own distinct error that never
+     suggests mapping a placeholder `sub`.
 
 8. **Use clear audit and status wording.** Write logs and user-visible messages
    should describe facts, not magic:

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -374,6 +374,42 @@ fn to_mcp_error(err: anyhow::Error) -> ErrorData {
     }
 }
 
+/// Extract the write caller's authorization facts from the tool-call request
+/// context. Over the HTTP transport the validated [`oidc::Identity`] rides in
+/// the request [`Parts`](axum::http::request::Parts) — placed there by the auth
+/// gate (`http::gate_inner`) and propagated into the rmcp `RequestContext` by
+/// the Streamable-HTTP transport. Returns the caller's `sub` + whether the token
+/// holds `nbox:write`, both of which the write path enforces (ADR-0001 §7).
+///
+/// On stdio / non-`http` builds there is no per-user identity, so this returns
+/// `None` and the write path rejects with a clear "writes require OIDC" error —
+/// never the service token.
+#[cfg(feature = "http")]
+fn write_caller(ctx: &RequestContext<RoleServer>) -> Option<write::WriteCaller> {
+    write_caller_from_extensions(&ctx.extensions)
+}
+
+/// The extraction proper, over the rmcp request `Extensions` so it's unit-testable
+/// without a live `RequestContext`/`Peer`. The Streamable-HTTP transport stores
+/// the originating [`Parts`](axum::http::request::Parts) here; the auth gate put
+/// the validated [`oidc::Identity`] inside *those* parts' extensions.
+#[cfg(feature = "http")]
+fn write_caller_from_extensions(ext: &rmcp::model::Extensions) -> Option<write::WriteCaller> {
+    let parts = ext.get::<axum::http::request::Parts>()?;
+    let identity = parts.extensions.get::<oidc::Identity>()?;
+    let sub = identity.sub.clone().filter(|s| !s.is_empty())?;
+    Some(write::WriteCaller {
+        sub,
+        has_write_scope: identity.has_scope(SCOPE_WRITE),
+    })
+}
+
+/// Non-`http` builds have no OIDC transport, hence no per-user write identity.
+#[cfg(not(feature = "http"))]
+fn write_caller(_ctx: &RequestContext<RoleServer>) -> Option<write::WriteCaller> {
+    None
+}
+
 /// A permissive `{"type":"object"}` output schema, used only by `nbox_get`.
 ///
 /// `nbox_get` is polymorphic — its return shape depends on `kind`
@@ -790,14 +826,15 @@ impl NboxMcp {
     /// then calls `nbox_apply_write` to execute it. Requires writes enabled.
     #[tool(
         name = "nbox_plan_write",
-        description = "Plan a NetBox write operation (interface description, device status, IP/prefix/IP-range reserve, tag add/remove). Builds a MutationPlan with a before/after diff and a confirm token, without mutating. Review the plan, then call nbox_apply_write to execute. Requires writes enabled (--allow-writes + [serve.vault] per-user credential mapping).",
-        annotations(read_only_hint = true)
+        description = "Plan a NetBox write operation (interface description, device status, IP/prefix/IP-range reserve, tag add/remove). Builds a MutationPlan with a before/after diff and a confirm token, without mutating. Review the plan, then call nbox_apply_write to execute. Requires writes enabled (--allow-writes), the caller's token carrying the nbox:write scope, and a [serve.vault] mapping for the caller's OIDC sub; rejected over stdio (no per-user identity).",
+        annotations(read_only_hint = false)
     )]
     async fn nbox_plan_write(
         &self,
         Parameters(args): Parameters<write::PlanWriteArgs>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<Json<crate::netbox::mutation::MutationPlan>, ErrorData> {
-        self.plan_write_impl(args).await
+        self.plan_write_impl(args, write_caller(&ctx)).await
     }
 
     /// Apply a previously planned write. Verifies the plan's confirm token,
@@ -811,8 +848,9 @@ impl NboxMcp {
     async fn nbox_apply_write(
         &self,
         Parameters(args): Parameters<write::ApplyWriteArgs>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<Json<crate::netbox::mutation::MutationReceipt>, ErrorData> {
-        self.apply_write_impl(args).await
+        self.apply_write_impl(args, write_caller(&ctx)).await
     }
 }
 
@@ -1112,6 +1150,13 @@ pub async fn serve(client: NetBoxClient, cache: Cache) -> anyhow::Result<()> {
 /// same [`NboxMcp`] backs it; see [`http::serve_http`]. [`oidc`] is the OAuth 2.1
 /// resource-server layer applied to `/mcp` when `--oidc-issuer` is configured;
 /// [`audit`] is the v1 ops layer (structured audit log + per-caller rate limit).
+/// The two OAuth scopes nbox understands (DESIGN §24). Reads need `nbox:read`;
+/// writes need `nbox:write` (ADR-0001 §7). Defined here in the always-compiled
+/// module so both the `http`-only OIDC validation path ([`oidc`]) and the
+/// transport-agnostic write engine ([`write`]) name one source of truth.
+pub const SCOPE_READ: &str = "nbox:read";
+pub const SCOPE_WRITE: &str = "nbox:write";
+
 #[cfg(feature = "http")]
 pub mod audit;
 

--- a/src/mcp/oidc.rs
+++ b/src/mcp/oidc.rs
@@ -34,9 +34,10 @@ use serde::Deserialize;
 use tokio::sync::Mutex;
 
 /// The two scopes nbox understands (DESIGN §24). Reads need `nbox:read`; writes
-/// (none yet) will need `nbox:write`.
-pub const SCOPE_READ: &str = "nbox:read";
-pub const SCOPE_WRITE: &str = "nbox:write";
+/// need `nbox:write`. Defined in the always-compiled [`super`] module (so the
+/// transport-agnostic write engine can name `nbox:write` without depending on
+/// this `http`-only module) and re-exported here for the OIDC validation path.
+pub use super::{SCOPE_READ, SCOPE_WRITE};
 
 /// The algorithms nbox will verify with — the explicit allowlist. The token's
 /// own `alg` is never trusted: `decode` is told exactly these, so `none` and any

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -3760,7 +3760,8 @@ mod contracts {
 
 // --- MCP write tool tests (Pattern 2) ---------------------------------------
 
-/// A server with writes enabled (vault configured for a test user).
+/// A server with writes enabled and a vault entry for the test user `alice`
+/// (sub `alice` → env var `NBOX_VAULT_TEST_WRITE`).
 fn write_server_for(mock: &MockServer) -> NboxMcp {
     let profile = ProfileConfig {
         url: mock.uri(),
@@ -3768,7 +3769,7 @@ fn write_server_for(mock: &MockServer) -> NboxMcp {
     };
     let mut entries = std::collections::BTreeMap::new();
     entries.insert(
-        "__stdio_no_identity__".to_string(),
+        "alice".to_string(),
         crate::mcp::vault::VaultEntry {
             token_env: "NBOX_VAULT_TEST_WRITE".to_string(),
         },
@@ -3782,28 +3783,85 @@ fn write_server_for(mock: &MockServer) -> NboxMcp {
     )
 }
 
+/// A write caller (the per-request authz facts the tool layer extracts from the
+/// OIDC identity), for driving `plan_write_impl`/`apply_write_impl` directly.
+fn caller(sub: &str, has_write_scope: bool) -> crate::mcp::write::WriteCaller {
+    crate::mcp::write::WriteCaller {
+        sub: sub.to_string(),
+        has_write_scope,
+    }
+}
+
+/// The caller-identity extraction (the riskiest new wiring): the auth gate puts
+/// a validated `Identity` into the HTTP request `Parts` extensions, and the
+/// Streamable-HTTP transport nests those `Parts` into the rmcp request
+/// `Extensions`. This reproduces that exact nesting and asserts the `sub` +
+/// `nbox:write` scope are pulled out — and that an absent/empty identity yields
+/// `None` (→ the no-identity reject path), never a fabricated caller.
+#[cfg(feature = "http")]
+#[test]
+fn write_caller_extracts_sub_and_scope_from_nested_request_parts() {
+    use crate::mcp::oidc::{Identity, SCOPE_WRITE};
+
+    let identity = |sub: Option<&str>, scopes: Vec<String>| Identity {
+        sub: sub.map(str::to_string),
+        client_id: None,
+        scopes,
+        jti: None,
+        iss: None,
+    };
+    let nest = |id: Option<Identity>| {
+        let mut req = axum::http::Request::builder().body(()).unwrap();
+        if let Some(id) = id {
+            req.extensions_mut().insert(id);
+        }
+        let (parts, ()) = req.into_parts();
+        let mut ext = rmcp::model::Extensions::new();
+        ext.insert(parts);
+        ext
+    };
+
+    // sub + write scope → extracted.
+    let ext = nest(Some(identity(Some("alice"), vec![SCOPE_WRITE.to_string()])));
+    let c = crate::mcp::write_caller_from_extensions(&ext).expect("identity extracted");
+    assert_eq!(c.sub, "alice");
+    assert!(c.has_write_scope);
+
+    // sub but no write scope → extracted with the flag false (bridged_client rejects).
+    let ext = nest(Some(identity(Some("bob"), vec!["nbox:read".to_string()])));
+    let c = crate::mcp::write_caller_from_extensions(&ext).expect("identity extracted");
+    assert_eq!(c.sub, "bob");
+    assert!(!c.has_write_scope);
+
+    // No Identity in the parts → None.
+    assert!(crate::mcp::write_caller_from_extensions(&nest(None)).is_none());
+
+    // Identity present but empty/absent sub → None (no usable identity).
+    let ext = nest(Some(identity(None, vec![SCOPE_WRITE.to_string()])));
+    assert!(crate::mcp::write_caller_from_extensions(&ext).is_none());
+
+    // No Parts at all (e.g. stdio) → None.
+    assert!(crate::mcp::write_caller_from_extensions(&rmcp::model::Extensions::new()).is_none());
+}
+
 #[tokio::test]
 async fn plan_write_rejects_when_vault_absent() {
     // A read-only server (vault = None) must reject write planning with a
     // clear "writes not enabled" error, not fall through to the service token.
     let mock = MockServer::start().await;
     let server = server_for(&mock); // vault = None
-    let _err = server
-        .plan_write_impl(crate::mcp::write::PlanWriteArgs {
-            operation: crate::mcp::write::WriteOperation::DeviceStatus {
-                device: "edge01".into(),
-                status: "active".into(),
-            },
-        })
-        .await
-        .is_err();
+    // Even with a fully valid caller (sub + write scope), the disabled gate is
+    // checked first: "writes not enabled", never a service-token fallthrough.
     let result = server
-        .plan_write_impl(crate::mcp::write::PlanWriteArgs {
-            operation: crate::mcp::write::WriteOperation::DeviceStatus {
-                device: "edge01".into(),
-                status: "active".into(),
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                    device: "edge01".into(),
+                    status: "active".into(),
+                },
             },
-        })
+            Some(caller("alice", true)),
+        )
         .await;
     assert!(result.is_err(), "should reject writes when vault is absent");
     let err = result.err().unwrap();
@@ -3811,6 +3869,83 @@ async fn plan_write_rejects_when_vault_absent() {
     assert!(
         err.message.contains("writes are not enabled"),
         "error should mention writes not enabled: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn plan_write_rejects_when_no_caller_identity() {
+    // Writes enabled + a vault, but the request carried no identity (stdio /
+    // loopback). Must reject with a distinct "requires an authenticated OIDC
+    // caller" error — never the placeholder-sub path, never the service token.
+    let mock = MockServer::start().await;
+    let server = write_server_for(&mock);
+    let result = server
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                    device: "edge01".into(),
+                    status: "active".into(),
+                },
+            },
+            None,
+        )
+        .await;
+    let err = result.err().expect("no identity must be rejected");
+    assert!(
+        err.message.contains("authenticated OIDC caller"),
+        "error should name the missing identity: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn plan_write_rejects_when_missing_write_scope() {
+    // A caller with a valid sub + vault entry but no `nbox:write` scope is
+    // rejected before any NetBox call (ADR-0001 §7).
+    let mock = MockServer::start().await;
+    let server = write_server_for(&mock);
+    let result = server
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                    device: "edge01".into(),
+                    status: "active".into(),
+                },
+            },
+            Some(caller("alice", false)),
+        )
+        .await;
+    let err = result.err().expect("missing write scope must be rejected");
+    assert!(
+        err.message.contains("nbox:write"),
+        "error should name the missing scope: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn plan_write_rejects_when_sub_not_in_vault() {
+    // Writes enabled, caller has write scope, but their sub has no vault entry:
+    // fail closed (NoEntry), never the service token.
+    let mock = MockServer::start().await;
+    let server = write_server_for(&mock); // vault maps "alice", not "bob"
+    let result = server
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                    device: "edge01".into(),
+                    status: "active".into(),
+                },
+            },
+            Some(caller("bob", true)),
+        )
+        .await;
+    let err = result.err().expect("unknown sub must be rejected");
+    assert!(
+        err.message
+            .contains("no vault entry for caller sub \"bob\""),
+        "error should name the missing vault entry: {}",
         err.message
     );
 }
@@ -3876,12 +4011,15 @@ async fn plan_write_device_status_produces_plan() {
 
     let server = write_server_for(&mock);
     let result = server
-        .plan_write_impl(crate::mcp::write::PlanWriteArgs {
-            operation: crate::mcp::write::WriteOperation::DeviceStatus {
-                device: "edge01".into(),
-                status: "active".into(),
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                    device: "edge01".into(),
+                    status: "active".into(),
+                },
             },
-        })
+            Some(caller("alice", true)),
+        )
         .await;
 
     unsafe {
@@ -3936,7 +4074,7 @@ async fn apply_write_rejects_tampered_plan() {
     };
 
     let result = server
-        .apply_write_impl(crate::mcp::write::ApplyWriteArgs { plan })
+        .apply_write_impl(crate::mcp::write::ApplyWriteArgs { plan }, None)
         .await;
     assert!(result.is_err(), "should reject tampered plan");
     let err = result.err().unwrap();

--- a/src/mcp/write.rs
+++ b/src/mcp/write.rs
@@ -136,12 +136,35 @@ fn not_found(noun: &str, value: &str) -> anyhow::Error {
     anyhow::anyhow!("no {noun} matched \"{value}\"; use nbox_search to find the right reference")
 }
 
+/// The caller authorization facts the write path needs, extracted by the
+/// transport from the validated request identity (OIDC `sub` + scopes over the
+/// HTTP transport). Kept transport-agnostic — the write engine and its unit
+/// tests depend on this, not on the HTTP-only `oidc::Identity` — so the
+/// stdio/non-`http` build still compiles (it simply never produces one).
+pub(crate) struct WriteCaller {
+    /// The caller's OIDC `sub`, resolved to a per-user NetBox token by the vault.
+    pub sub: String,
+    /// Whether the caller's token carries the `nbox:write` scope (ADR-0001 §7).
+    pub has_write_scope: bool,
+}
+
 impl NboxMcp {
     /// Resolve the caller's per-user NetBox client via the vault, or reject
     /// with a clear error if writes are disabled or the caller has no vault
     /// entry. Returns a short-lived `NetBoxClient` clone with the per-user
     /// token swapped in.
-    fn bridged_client(&self) -> Result<NetBoxClient, ErrorData> {
+    /// Resolve the caller's per-user NetBox client, enforcing the full write
+    /// authorization ladder — fail-closed at every step (ADR-0001 §7):
+    ///
+    /// 1. writes enabled at all (`[serve].allow_writes` → a vault is present);
+    /// 2. the request carried an authenticated caller (HTTP+OIDC; stdio and
+    ///    loopback static-bearer have no per-user identity → rejected);
+    /// 3. the caller's token carries the `nbox:write` scope;
+    /// 4. the caller's `sub` maps to a provisioned per-user NetBox token.
+    ///
+    /// The service token is never used for writes. A `None` caller (no identity)
+    /// gets a distinct error that never suggests mapping a placeholder `sub`.
+    fn bridged_client(&self, caller: Option<WriteCaller>) -> Result<NetBoxClient, ErrorData> {
         let vault = self.vault.as_ref().ok_or_else(|| {
             ErrorData::invalid_params(
                 "MCP writes are not enabled on this nbox serve instance; \
@@ -150,13 +173,26 @@ impl NboxMcp {
                 None,
             )
         })?;
-        // stdio transport has no caller identity — writes require HTTP + OIDC.
-        // TODO: extract Identity from RequestContext.extensions via
-        // http::request::Parts when the HTTP transport is active. On stdio,
-        // writes are always rejected (no identity to bridge).
-        let dummy_sub = "__stdio_no_identity__";
+        let caller = caller.ok_or_else(|| {
+            ErrorData::invalid_params(
+                "MCP writes require an authenticated OIDC caller identity; this request \
+                 carried none. Writes are unavailable over the stdio transport and over \
+                 loopback static-bearer auth — use the HTTP transport with OIDC so each \
+                 write is attributed to a real NetBox user.",
+                None,
+            )
+        })?;
+        if !caller.has_write_scope {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "the caller's token is missing the required `{}` scope for MCP writes",
+                    crate::mcp::SCOPE_WRITE
+                ),
+                None,
+            ));
+        }
         let token = vault
-            .resolve(dummy_sub)
+            .resolve(&caller.sub)
             .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?;
         Ok((*self.client)
             .clone()
@@ -167,8 +203,9 @@ impl NboxMcp {
     pub(crate) async fn plan_write_impl(
         &self,
         args: PlanWriteArgs,
+        caller: Option<WriteCaller>,
     ) -> Result<Json<MutationPlan>, ErrorData> {
-        let client = self.bridged_client()?;
+        let client = self.bridged_client(caller)?;
         let profile = self.profile.as_str();
         let plan = match args.operation {
             WriteOperation::InterfaceDescription {
@@ -293,12 +330,13 @@ impl NboxMcp {
     pub(crate) async fn apply_write_impl(
         &self,
         args: ApplyWriteArgs,
+        caller: Option<WriteCaller>,
     ) -> Result<Json<MutationReceipt>, ErrorData> {
         args.plan
             .verify()
             .map_err(|e| super::to_mcp_error(e.into()))?;
 
-        let client = self.bridged_client()?;
+        let client = self.bridged_client(caller)?;
         let receipt = match args.plan.operation {
             crate::netbox::mutation::Operation::Update => match args.plan.target.kind.as_str() {
                 "interface" => {


### PR DESCRIPTION
## Why

A deep review of #122 found the MCP write **authorization** shipped as a fail-closed *skeleton*: safe (it rejected everything), but **non-functional** and **over-claimed**.

- **Identity was never extracted.** `bridged_client` hardcoded `dummy_sub = "__stdio_no_identity__"` for every request — the real OIDC `sub` (available in the request extensions, used by the audit log) was never read. So **no write could ever succeed**, yet `nbox_apply_write`'s description said *"executes under the caller's per-user NetBox identity."* The tests baked in the placeholder sub, validating the stub.
- **`nbox:write` was defined but never enforced** — only `SCOPE_READ` was checked. ADR-0001 §7's "require `nbox:write`" was unmet.
- **Footgun:** the fail-closed error told operators to add `[serve.vault."__stdio_no_identity__"]` — following it would map *all* callers to one shared token (confused deputy).
- `nbox_plan_write` was `read_only_hint = true` (against ADR §7).

## What this does (for real)

- **Extract the caller from the request context.** The auth gate already plumbs the validated `Identity` into the HTTP request `Parts`; rmcp's Streamable-HTTP transport nests those `Parts` into the tool's `RequestContext`. `write_caller_from_extensions` reads the caller's `sub` + scopes from there. (I traced the rmcp 1.8 source to confirm the per-request `Parts` propagation — `tower.rs` injects each tool-call request's parts into the JSON-RPC request extensions, and the server runs stateful by default.)
- **`bridged_client` enforces a fail-closed ladder:** writes-enabled → caller identity present → `nbox:write` scope → vault entry for the `sub`. The no-identity case is its own distinct error that never suggests mapping a placeholder sub. Service token is never used for writes.
- **Scope enforced in the write tools**, not the HTTP gate — the gate deliberately doesn't parse the JSON-RPC method (buffering the streaming body would break the transport), so per-tool scope must live in the tool.
- **`nbox_plan_write` → `read_only_hint = false`** (it's part of the write flow).
- **`SCOPE_READ`/`SCOPE_WRITE` moved** to the always-compiled `mcp` module (so the transport-agnostic write engine names `nbox:write` without depending on the `http`-only `oidc` module); re-exported from `oidc`.

## Tests

- Dropped the placeholder-sub coupling; added rejections for **no identity**, **missing `nbox:write` scope**, and **unknown sub** (fail-closed at each rung).
- A direct test of the riskiest new wiring — `write_caller_from_extensions` — that reproduces the exact `Parts`→`Identity` nesting the transport produces and asserts `sub` + scope are pulled, with absent/empty identity → `None` (never a fabricated caller).
- All 7 write tests pass; both feature builds clean.

## Docs

Corrected ADR-0001 §7 (scope enforced in the tools not the gate; `read_only_hint=false`; the real extraction path + fail-closed order) and documented the Pattern 2 write path in `docs/MCP.md`.

## Gate

`cargo fmt`; `cargo clippy --all-targets {--all-features,--no-default-features} --locked -- -D warnings`; `cargo test {--features http,--no-default-features} --locked`; `cargo audit` — all green (feature modes run serially; they share `target/debug/nbox`).

Net: #122's vault primitive was solid; this makes the write **authorization** actually function, enforces the missing scope gate, removes the footgun, and reconciles the docs with the code.