### PR TITLE
docs(skills): add read-domain agent skill files

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -56,6 +56,25 @@ stdout carries only the requested data; logs/diagnostics/errors go to stderr. Ex
 codes are stable: `3` auth, `4` not-found, `5` ambiguous. Full command + flag
 reference: [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md).
 
+## Read domains
+
+The read surface is split into focused skill files — reach for the one that
+matches the question:
+
+- [Search](skills/search/SKILL.md) — ranked, deduped cross-kind `nbox search`:
+  the entry point when the kind or exact reference isn't known yet; the
+  one-scope-filter-at-a-time rule and the search→detail-lookup chain
+- [IPAM read](skills/ipam-read/SKILL.md) — `nbox ip` / `prefix` / `vlan` /
+  `ip-range` / `aggregate` / `vrf` / `route-target`, prefix utilization and the
+  tree, the read-only `next-ip` / `next-prefix` previews, and `--vrf`
+  disambiguation
+- [Device context](skills/device-context/SKILL.md) — `nbox device` /
+  `interface` (the cable-path A↔Z trace) / `mac` reverse-resolve, plus
+  `rack` / `site` context
+- [MCP server](skills/serve/SKILL.md) — `nbox serve` as the read-only MCP server:
+  stdio vs HTTP+OIDC, the read tools and resources, the prompts catalog, and
+  `--print-config`
+
 ## Safe writes
 
 `nbox` can modify NetBox through seven plan-first, dry-run/confirm-gated write

--- a/skills/device-context/SKILL.md
+++ b/skills/device-context/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: nbox-device-context
+description: Pull the full physical context of a device or interface from NetBox with nbox — a device's interfaces/IPs/cables/VLANs/services, an interface's cable-path A↔Z trace, a MAC reverse-resolved to its carrying interface/device, plus rack and site context. Use when the user asks how a device is connected, what's on an interface, where a MAC lives, or what's in a rack/site.
+---
+
+# nbox device context
+
+These read commands answer the physical/connectivity questions: what a device
+is, how it's wired, what an interface terminates into, and where it sits. All
+are read-only. For the flags of any one, run `nbox <cmd> --help` — this skill is
+flag-free by design, describing what each command answers.
+
+## What each command answers
+
+- **`nbox device <name|slug|id>`** — a device plus its interfaces, IPs, cables,
+  VLANs, and services. The starting point for "what is `edge01` and what's on
+  it?"
+- **`nbox interface <device> <interface>`** — one interface: type, MTU, MAC,
+  mode, VLANs, addresses, the attached cable, and the **cable-path A↔Z trace**
+  (a diagram naming the device at each hop). The reference is the `<device>`
+  `<interface>` pair; interface names may contain slashes (e.g. `xe-0/0/1`).
+- **`nbox mac <addr>`** — reverse-resolve a MAC to the interface(s) and
+  device(s) that carry it. Any common form is normalized
+  (`aa:bb:cc:dd:ee:ff`, `AABB.CCDD.EEFF`, `aa-bb-…`, `aabbccddeeff`).
+- **`nbox rack <name|id>`** / **`nbox site <name|slug>`** — the rack or site a
+  device sits in, for surrounding context.
+
+```bash
+nbox --no-tui device edge01 --json --envelope
+nbox --no-tui interface edge01 xe-0/0/1 --json    # config + cable-path trace
+nbox --no-tui mac aa:bb:cc:dd:ee:ff --json        # → carrying interface/device
+nbox --no-tui rack R12 --json
+nbox --no-tui site DC1 --json
+```
+
+## The cable-path trace (A↔Z)
+
+`nbox interface` is the connectivity tool: its cable-path section traces the
+physical path end to end, naming the device at each hop. Reach for it to answer
+"what is `edge01:xe-0/0/1` actually wired to?" — the trace follows through
+patch panels and intermediate cables to the far-end device/interface.
+
+## The `<device>/<name>` ref form
+
+Some commands take an interface as a single `<device>/<name>` reference rather
+than two arguments — e.g. `nbox journal interface edge01/xe-0/0/1`,
+`nbox history interface edge01/xe-0/0/1`, and `nbox open
+interface/edge01/xe-0/0/1`. The interface name keeps its slashes; the resolver
+splits on the device boundary, so `xe-0/0/1` stays intact.
+
+## Resolving a MAC, then drilling in
+
+`nbox mac` is a reverse lookup: a non-MAC input is a usage error, and a MAC
+carried by several interfaces is ambiguous (exit 5) and lists the candidates. A
+resolved interface chains straight into `nbox interface <device> <name>` for the
+full config and cable path.
+
+## Reference
+
+- [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md) — the
+  complete command + flag reference, ref forms, and exit codes
+- [Search](../search/SKILL.md) — to find a device/interface reference when the
+  exact name isn't known
+- [IPAM read](../ipam-read/SKILL.md) — to go from an interface's IP to its
+  parent prefix / VLAN / scope

--- a/skills/ipam-read/SKILL.md
+++ b/skills/ipam-read/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: nbox-ipam-read
+description: Answer IP addressing questions from NetBox with nbox's IPAM read commands — look up an IP and its parent prefix/VLAN/scope, check prefix utilization and the prefix tree, preview the next free IP/prefix, and inspect VLANs, IP ranges, aggregates, VRFs, and route targets. Use when the user asks about addressing, allocation, or routing context.
+---
+
+# nbox IPAM reads
+
+The IPAM read commands answer addressing and routing questions: where an
+address lives, how full a prefix is, what's free, and how VRFs/route-targets
+relate. All are read-only. For the flags of any one, run `nbox <cmd> --help` —
+this skill is flag-free by design, describing what each command answers.
+
+## What each command answers
+
+- **`nbox ip <address>`** — one IP, enriched with its most-specific parent
+  prefix (VRF-scoped), that prefix's VLAN, and the prefix's `scope`/`scope_type`
+  (site, location, region, …). Surfaces `nat_inside`/`nat_outside` (NetBox 4.6)
+  when set. "Where does `203.0.113.10` live, and in what prefix/VLAN/site?"
+- **`nbox prefix <cidr>`** — one prefix with its utilization, child prefixes,
+  and contained IPs. "How full is `10.0.0.0/24`, and what's under it?"
+- **`nbox next-ip <cidr>`** / **`nbox next-prefix <cidr>`** — a read-only
+  **preview** of the next free address / child block. They reserve **nothing**
+  (see the warning below).
+- **`nbox vlan <vid|name>`** — one VLAN with its referencing prefixes, its own
+  `scope`/`scope_type`, and (when it belongs to a scoped VLAN group) the group's
+  `group_scope`/`group_scope_type`.
+- **`nbox ip-range <start|id>`** — one IP range (the start address or id).
+- **`nbox aggregate <cidr|id>`** — one aggregate (the top-level allocation a
+  prefix tree sits under).
+- **`nbox vrf <name|rd|id>`** — a VRF as a routing context: RD, tenant,
+  enforce-unique, import/export route targets, counts, plus its prefix tree and
+  scoped addresses.
+- **`nbox route-target <name|id>`** — a route target (e.g. `65000:100`) plus the
+  VRFs that import and export it.
+
+## next-ip / next-prefix reserve NOTHING
+
+`next-ip` and `next-prefix` are **read-only previews** — they show what NetBox
+*would* hand out next, but claim nothing and race with other clients. To
+actually claim an address or block, use the `reserve` write commands, which POST
+to NetBox's `available-ips` / `available-prefixes` endpoints under the dry-run /
+confirm gate. See the [IPAM allocate](../ipam-allocate/SKILL.md) and
+[safe writes](../writes/SKILL.md) skills.
+
+```bash
+nbox --no-tui next-ip 10.0.0.0/24 --json        # preview only — reserves nothing
+nbox --no-tui ip 203.0.113.10 --json --fields address,parent_prefix,scope,assigned
+nbox --no-tui prefix 10.0.0.0/24 --json         # utilization + children
+```
+
+## VRF disambiguation and the exit-5 ambiguity
+
+A reference that matches more than one object across VRFs (the same address or
+CIDR existing in several VRFs) exits **5** and lists the candidate VRFs rather
+than guessing. Scope the lookup with `--vrf <name|rd|id>` to resolve it:
+
+```bash
+nbox --no-tui ip 10.0.0.1 --json                # exit 5 if 10.0.0.1 is in >1 VRF
+nbox --no-tui ip 10.0.0.1 --vrf CUST-A --json   # disambiguated
+```
+
+`ip`, `prefix`, and `next-ip`/`next-prefix` all take `--vrf` (name, RD, or id —
+VRFs have no slug). A VLAN that exists at several sites exits 5 the same way —
+scope it with `--site` / `--group`.
+
+## Reference
+
+- [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md) — the
+  complete command + flag reference, exit codes, and scope/VRF resolution
+- [IPAM allocate](../ipam-allocate/SKILL.md) — the `reserve` write commands that
+  actually claim an IP/prefix (vs. these read-only previews)
+- [Device context](../device-context/SKILL.md) — to trace an IP's assigned
+  interface and device

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: nbox-search
+description: Find NetBox objects across kinds in one query with nbox's ranked, deduped cross-object search — the entry point when the kind or exact reference isn't known yet. Use when the user wants to locate a device/IP/prefix/VLAN/site/etc. by a name fragment, or narrow by site/tenant/role/tag/status/VRF before a detail lookup.
+---
+
+# nbox search
+
+`nbox search <query>` runs one parallel, full-text search across every object
+kind — devices, sites, racks, rack-groups, IPs, prefixes, VLANs, circuits,
+virtual-circuits, aggregates, ASNs, IP-ranges, tenants, contacts, providers,
+VMs, VM-types, clusters, VRFs, route-targets — and returns one ranked, deduped
+result set. It is the entry point when the exact kind or reference isn't known
+yet: search first, then feed a hit into a detail lookup.
+
+```bash
+nbox --no-tui search edge01 --json --envelope
+nbox --no-tui search edge --status active --site DC1 -o csv --cols kind,display,url
+```
+
+For the exact flags, run `nbox search --help`. This skill is flag-free by
+design — it describes what each flag answers, not its semantics, so it can't
+drift as the CLI evolves.
+
+## What it answers
+
+"What objects in NetBox match this string, and what kind is each?" Each hit
+carries a `kind` (e.g. `device`, `ip_address`, `prefix`), a `display`, and a
+`url`. Search is REST-canonical — NetBox's GraphQL has no full-text `q`, so a
+`search = "graphql"` profile preference transparently falls back to REST.
+
+## Narrowing the result set
+
+- **One scope filter at a time.** The scope flags — `--site` / `--region` /
+  `--site-group` / `--location` / `--tenant` / `--role` / `--tag` / `--status`
+  / `--owner` / `--owner-group` / `--vrf` — narrow the search per-endpoint. The
+  geographic scopes (`--site`/`--region`/`--site-group`/`--location`) are
+  mutually exclusive: NetBox's polymorphic prefix `scope` is a single type+id,
+  so passing more than one geographic scope is a usage error (exit 2). `--vrf`
+  is orthogonal and may combine with a geographic scope.
+- **Endpoints that can't honor a filter are skipped**, not errored — a VRF
+  filter drops devices/sites/VLANs; a `--site` filter drops VRFs. The remaining
+  kinds still return.
+- **An unknown reference is a not-found error** (exit 4), not a silent empty
+  result — a typo'd `--site` or `--vrf` is caught.
+- `--limit` caps the result count; `--cols` selects the columns for `-o csv`
+  output.
+
+## Fail-closed by default
+
+`search` fails closed: if any endpoint errors, the whole search exits non-zero
+rather than return partial results. Pass `--partial` for best-effort results —
+the kinds that succeeded are returned and the failed endpoints are reported on
+stderr. The default is the safe one (no silently-missing kinds); reach for
+`--partial` only when partial coverage is acceptable.
+
+## Chaining into a detail lookup
+
+A search hit's `kind` feeds straight into a detail lookup — that's the whole
+point of searching first:
+
+```bash
+# 1. search to find the reference + its kind
+nbox --no-tui search edge01 --json --fields kind,display,url
+
+# 2. a hit with kind=device → nbox device; kind=ip_address → nbox ip
+nbox --no-tui device edge01 --json
+nbox --no-tui ip 203.0.113.10 --json
+```
+
+The detail commands (`nbox <kind> <ref>`) and `nbox get` accept the search
+`kind` as-is (`ip_address` is an alias for `ip`). For per-kind detail, see the
+[IPAM read](../ipam-read/SKILL.md) and [device context](../device-context/SKILL.md)
+skills.
+
+## Token trimming
+
+`--fields a,b,c` keeps only those top-level fields per hit — pair it with
+`--raw` to minimize tokens when the result set is large and only the reference
++ kind are needed for the next step.
+
+## Reference
+
+- [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md) — the
+  complete command + flag reference, exit codes, and output flags
+- [IPAM read](../ipam-read/SKILL.md), [Device context](../device-context/SKILL.md)
+  — the detail lookups a search hit chains into

--- a/skills/serve/SKILL.md
+++ b/skills/serve/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: nbox-serve
+description: Run nbox as a read-only MCP server so an agent host can query NetBox over JSON-RPC — stdio or HTTP+OIDC transport, the read tools (search/get/get_interface/history/…), the nbox://{kind}/{ref} resource template, the investigation prompts catalog, and --print-config for install recipes. Use when the user wants to wire NetBox into an MCP host or stand up the server.
+---
+
+# nbox serve (read-only MCP)
+
+`nbox serve` exposes nbox's read layer as an MCP server. The tools reuse the
+CLI's query + view layer, so they return the same JSON view models as the
+equivalent `nbox <cmd>`. **Read-only is the default** — no write tools are
+exposed unless writes are explicitly opted in (see below). For the flags, run
+`nbox serve --help` — this skill is flag-free by design.
+
+## Two transports
+
+- **stdio (default).** An MCP host launches `nbox serve` as a subprocess and
+  speaks JSON-RPC over stdin/stdout. JSON-RPC on stdout, logs on stderr;
+  URL/token come from the active profile (same `--profile` / `--config` flags).
+  Always read-only.
+- **HTTP** — `nbox serve --http 127.0.0.1:8080`, same tools mounted at `/mcp`,
+  loopback only with `Origin`/`Host` validation and an optional static bearer.
+  Add `--oidc-issuer <URL>` + `--audience <VALUE>` for OAuth 2.1
+  resource-server mode: inbound IdP JWTs are validated on `/mcp` (alg allowlist,
+  `iss`/`aud`/`exp`, `nbox:read` scope), a routable bind is allowed (TLS
+  terminates in front), and Protected Resource Metadata is served at
+  `/.well-known/oauth-protected-resource`. HTTP `/mcp` also carries an audit log
+  and an opt-in per-caller rate limit. This is **read-only Pattern 3**: the last
+  hop to NetBox still uses the one local profile token, so the audit log is
+  accountability, not per-user RBAC — trusted single-team read-only only.
+
+## The read tools
+
+Each maps to a CLI read and returns the same view model:
+
+| Tool | What it answers |
+| ---- | --------------- |
+| `nbox_status` | Connection, capabilities, NetBox/Django/Python versions, token validity. Call first. |
+| `nbox_search` | Cross-kind ranked search (one scope filter at a time). Find a reference, then `nbox_get`. |
+| `nbox_get` | One object by `kind` + `ref` (`vrf`/`site`/`group` disambiguate). |
+| `nbox_get_interface` | One interface on a device, with its cable-path trace. |
+| `nbox_next_ip` / `nbox_next_prefix` | Next free address(es) / child block(s) — preview, reserves nothing. |
+| `nbox_journal` | Operator journal entries for an object. |
+| `nbox_history` | System audit log (create/update/delete, who + when); `diff=true` for full before/after. |
+| `nbox_list_tags` / `nbox_tagged` | List tags; objects carrying a tag, across kinds. |
+| `nbox_cache_clear` | Drop the local read cache (read-only w.r.t. NetBox). |
+
+A search hit's `kind` (e.g. `ip_address`) feeds straight into `nbox_get`, which
+accepts it as an alias. Every read tool that returns an object or hit list takes
+an optional **`fields`** parameter — keep only those top-level keys to trim
+tokens (unknown keys ignored).
+
+## Resources and prompts
+
+- **Resources.** The same objects are exposed via one template,
+  `nbox://{kind}/{ref}` (e.g. `nbox://device/edge01`, `nbox://ip/203.0.113.10`),
+  for hosts that browse/attach resources instead of calling tools. Reading one
+  returns the same JSON as `nbox_get`; percent-encode a `ref` containing `/`
+  (e.g. a CIDR). It's a template, so `resources/list` is empty.
+- **Prompts.** A catalog of read-only investigation prompts ships with it —
+  `ip_utilization_audit`, `cable_path_trace`, `find_stale_prefixes`,
+  `object_change_review`. Each returns a structured plan naming the exact nbox
+  tools to call, tailored to the supplied arguments — a plan, not data (no
+  NetBox round-trip).
+
+## Install recipe
+
+`nbox serve --print-config` prints the paste-ready `mcpServers` JSON (absolute
+binary path, echoed `--profile`/`--config`, placeholder token) and exits — no
+server start, no NetBox connection. Drop it into the host's MCP config.
+
+```bash
+nbox serve --print-config           # paste-ready mcpServers JSON, then exit
+nbox serve                          # stdio, read-only
+nbox serve --http 127.0.0.1:8080    # loopback HTTP, read-only
+```
+
+## Writes are a separate opt-in
+
+The MCP server stays read-only by default. Write tools (`nbox_plan_write` /
+`nbox_apply_write`) are exposed **only** with `nbox serve --http --allow-writes`
+plus a `[serve.vault]` config mapping each caller's OIDC `sub` to a per-user
+NetBox token — writes require the HTTP transport (OIDC identity); stdio stays
+read-only. For that lifecycle, see the [safe writes](../writes/SKILL.md) skill.
+
+## Reference
+
+- [docs/MCP.md](https://github.com/lance0/nbox/blob/master/docs/MCP.md) — the
+  full MCP server design, per-host config paths, and auth details
+- [AGENTS.md](https://github.com/lance0/nbox/blob/master/AGENTS.md) — the tool
+  table and the CLI surface the tools reuse
+- [Safe writes](../writes/SKILL.md) — the opt-in write tools and their gate


### PR DESCRIPTION
Grow the `skills/` catalog beyond the write surface (roadmap: "Read-domain
agent skills"). Four new read-domain skills mirror the existing write-domain
ones — focused, flag-free, maintainer-voice, and pointed at `nbox <cmd>
--help` so they can't drift as the CLI evolves.

## New skills

- **skills/search** (`nbox-search`) — ranked, deduped cross-kind `nbox
  search`: the entry point when the kind/reference isn't known. Covers the
  one-scope-filter-at-a-time rule, the fail-closed default vs `--partial`,
  `--limit`/`--cols`/`--fields`, and the search→`nbox <kind>`/`nbox get`
  chain (a hit's `kind` like `ip_address` feeds straight into a lookup).
- **skills/ipam-read** (`nbox-ipam-read`) — `nbox ip` / `prefix` / `vlan` /
  `ip-range` / `aggregate` / `vrf` / `route-target`, prefix utilization and
  the tree. Flags that `next-ip`/`next-prefix` are read-only previews that
  reserve nothing (cross-refs the allocate/writes skills to actually claim
  one), plus `--vrf` disambiguation and the exit-5 ambiguity behavior.
- **skills/device-context** (`nbox-device-context`) — `nbox device` (+
  interfaces/IPs/cables/VLANs/services), `nbox interface` (the cable-path
  A↔Z trace; the `<device>/<name>` ref form, names may contain slashes),
  `nbox mac` reverse-resolve, plus `rack`/`site` context.
- **skills/serve** (`nbox-serve`) — `nbox serve` as the read-only MCP
  server: stdio vs HTTP+OIDC, the read tools + the `fields` token-trim
  parameter, the `nbox://{kind}/{ref}` resource template, the prompts
  catalog, and `--print-config`. Notes that writes are a separate opt-in
  (cross-refs the writes skill).

The root `SKILL.md` now indexes the read domains alongside the writes.

## Verification

- `bash scripts/lint_skills.sh` passes (exit 0) — each new `SKILL.md` has
  frontmatter `name:` + `description:`.
- Examples use synthetic identifiers only (`edge01`, `DC1`, `10.0.0.0/24`,
  RFC-5737 `203.0.113.x`).
- No Rust source or tests touched — `skills/` and the root `SKILL.md` only.