### PR TITLE
test(mcp): end-to-end OIDC per-user write path

### DIFF
--- a/tests/mcp_serve_http_tests.rs
+++ b/tests/mcp_serve_http_tests.rs
@@ -15,6 +15,13 @@
 //!      defense), and advertises `MCP-Protocol-Version: 2025-11-25`.
 //!   3. The optional static bearer (`--http-token`): a missing/wrong bearer is
 //!      401, the correct bearer is accepted.
+//!   4. OIDC resource-server **writes** (Pattern 2): a minted RS256 JWT drives
+//!      `nbox_plan_write` + `nbox_apply_write` end to end through the real auth
+//!      gate → identity propagation → per-user credential vault → the caller's
+//!      NetBox token on the write (header-matched on the mock NetBox, so the
+//!      identity bridge is a precondition of the flow succeeding). A token
+//!      without `nbox:write` and an unmapped `sub` are refused before any NetBox
+//!      call. This is the path the #122 regression shipped non-functional.
 //!
 //! Determinism / no-hang: the SSE body is read chunk-by-chunk and we stop as
 //! soon as the awaited JSON-RPC `id` arrives (SSE keep-alive holds the stream
@@ -25,11 +32,18 @@
 use std::io::Write;
 use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use base64::Engine as _;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use reqwest::StatusCode;
+use rsa::RsaPrivateKey;
+use rsa::pkcs1::{EncodeRsaPrivateKey, LineEnding};
+use rsa::traits::PublicKeyParts as _;
 use serde_json::{Value, json};
 use tempfile::NamedTempFile;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// The protocol version the server advertises (DESIGN §24 / `MCP_PROTOCOL_VERSION`).
 const PROTOCOL_VERSION: &str = "2025-11-25";
@@ -391,5 +405,376 @@ async fn http_static_bearer_is_enforced() {
     assert!(
         !session.is_empty(),
         "correct bearer should establish a session"
+    );
+}
+
+// =========================================================================
+// OIDC + per-user write E2E (Pattern 2). The tests above prove the read-only
+// transport; these prove the *write* path end to end through the real OIDC
+// resource server: a minted RS256 JWT → gate validation → identity propagation
+// (request Parts → rmcp RequestContext) → vault → the caller's per-user NetBox
+// token on the write. The per-user token is made **intrinsic** by header-matching
+// the mock NetBox on the caller's Bearer, so the flow can only succeed if the
+// identity bridged correctly — the exact thing the #122 regression got wrong (a
+// hardcoded placeholder sub that never resolved). A real IdP keypair signs the
+// tokens; a wiremock endpoint serves the matching JWKS.
+// =========================================================================
+
+const ISSUER: &str = "https://idp.test/";
+const AUDIENCE: &str = "https://nbox.test/mcp";
+
+/// A throwaway IdP: an RSA keypair, the JWKS it publishes (derived from the
+/// public key's n/e), and a signer for minting RS256 tokens.
+struct TestIdp {
+    private_pem: String,
+    n: String,
+    e: String,
+    kid: String,
+}
+
+fn make_idp() -> TestIdp {
+    let mut rng = rand::thread_rng();
+    let key = RsaPrivateKey::new(&mut rng, 2048).expect("generate RSA test key");
+    let pem = key
+        .to_pkcs1_pem(LineEnding::LF)
+        .expect("encode private key PEM")
+        .to_string();
+    let pubkey = key.to_public_key();
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    TestIdp {
+        private_pem: pem,
+        n: b64.encode(pubkey.n().to_bytes_be()),
+        e: b64.encode(pubkey.e().to_bytes_be()),
+        kid: "nbox-e2e-key-1".to_string(),
+    }
+}
+
+impl TestIdp {
+    fn jwks(&self) -> Value {
+        json!({ "keys": [{
+            "kty": "RSA", "use": "sig", "alg": "RS256",
+            "kid": self.kid, "n": self.n, "e": self.e,
+        }]})
+    }
+
+    fn mint(&self, iss: &str, aud: &str, sub: &str, scope: &str) -> String {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_secs();
+        let claims = json!({
+            "iss": iss, "aud": aud, "sub": sub, "scope": scope,
+            "iat": now, "exp": now + 3600, "jti": "e2e-jti-1",
+        });
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(self.kid.clone());
+        encode(
+            &header,
+            &claims,
+            &EncodingKey::from_rsa_pem(self.private_pem.as_bytes()).expect("encoding key"),
+        )
+        .expect("sign token")
+    }
+}
+
+/// Spawn `nbox serve --http` in OIDC resource-server mode with writes enabled and
+/// a one-entry vault (`vault_sub` → `NBOX_VAULT_E2E`). The profile token (the
+/// read-only service credential) and the per-user token are distinct values so
+/// the mock can tell which reached NetBox.
+fn spawn_oidc_writes(
+    netbox_url: &str,
+    jwks_url: &str,
+    service_token: &str,
+    vault_sub: &str,
+    per_user_token: &str,
+) -> HttpServer {
+    let port = free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut config = NamedTempFile::new().expect("create temp config");
+    write!(
+        config,
+        "active_profile = \"test\"\n\
+         \n\
+         [profiles.test]\n\
+         url = \"{netbox_url}\"\n\
+         token_env = \"NBOX_TOKEN\"\n\
+         \n\
+         [serve]\n\
+         allow_writes = true\n\
+         \n\
+         [serve.vault.\"{vault_sub}\"]\n\
+         token_env = \"NBOX_VAULT_E2E\"\n",
+    )
+    .expect("write temp config");
+    config.flush().expect("flush temp config");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_nbox"));
+    cmd.arg("--config")
+        .arg(config.path())
+        .arg("serve")
+        .arg("--http")
+        .arg(&addr)
+        .arg("--oidc-issuer")
+        .arg(ISSUER)
+        .arg("--audience")
+        .arg(AUDIENCE)
+        .arg("--oidc-jwks-url")
+        .arg(jwks_url)
+        .arg("--allow-writes")
+        .arg("--allowed-host")
+        .arg("127.0.0.1")
+        .env("NBOX_TOKEN", service_token)
+        .env("NBOX_VAULT_E2E", per_user_token)
+        .env_remove("NBOX_SERVE_TOKEN")
+        .env_remove("NBOX_LOG")
+        .env_remove("RUST_LOG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = cmd.spawn().expect("spawn nbox serve --http (oidc)");
+    let server = HttpServer {
+        child,
+        base: format!("http://{addr}"),
+        _config: config,
+    };
+    server.wait_until_ready();
+    server
+}
+
+/// Call a tool, returning the raw JSON-RPC response message (`result` or `error`).
+async fn call_tool(
+    client: &reqwest::Client,
+    url: &str,
+    session: &str,
+    bearer: Option<&str>,
+    id: i64,
+    name: &str,
+    arguments: Value,
+) -> Value {
+    let resp = post(
+        client,
+        url,
+        &json!({
+            "jsonrpc": "2.0", "id": id, "method": "tools/call",
+            "params": { "name": name, "arguments": arguments },
+        }),
+        Some(session),
+        bearer,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "tools/call {name} status");
+    read_sse_for_id(resp, id).await
+}
+
+/// Extract a successful tool's structured payload (the `Json<T>` it returns).
+fn tool_payload(msg: &Value) -> Value {
+    assert!(msg.get("error").is_none(), "tool returned an error: {msg}");
+    let result = &msg["result"];
+    assert_ne!(
+        result["isError"],
+        json!(true),
+        "tool execution error: {msg}"
+    );
+    if let Some(sc) = result.get("structuredContent")
+        && !sc.is_null()
+    {
+        return sc.clone();
+    }
+    let text = result["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("tool result has no structuredContent/text: {msg}"));
+    serde_json::from_str(text).unwrap_or_else(|_| panic!("tool result text not JSON: {text}"))
+}
+
+/// Mount the NetBox endpoints an `ip reserve 10.0.0.0/24` touches — each gated on
+/// the caller's per-user Bearer, so a request carrying any other token (e.g. the
+/// service token) fails to match and the write fails. The per-user identity
+/// bridge is therefore a precondition of the test passing, not a side assertion.
+async fn mount_ip_reserve(netbox: &MockServer, per_user_token: &str) {
+    let auth = format!("Bearer {per_user_token}");
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/"))
+        .and(header("authorization", auth.as_str()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1, "next": null, "previous": null,
+            "results": [{ "id": 1, "url": "u", "prefix": "10.0.0.0/24" }]
+        })))
+        .mount(netbox)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/ipam/prefixes/1/available-ips/"))
+        .and(header("authorization", auth.as_str()))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!([{ "address": "10.0.0.1/24" }])),
+        )
+        .mount(netbox)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/ipam/prefixes/1/available-ips/"))
+        .and(header("authorization", auth.as_str()))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": 7, "url": "u", "address": "10.0.0.1/24",
+            "status": { "value": "active", "label": "Active" }
+        })))
+        .mount(netbox)
+        .await;
+}
+
+async fn mount_jwks(idp: &TestIdp) -> MockServer {
+    let jwks = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/jwks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(idp.jwks()))
+        .mount(&jwks)
+        .await;
+    jwks
+}
+
+#[tokio::test]
+async fn oidc_write_bridges_caller_identity_to_per_user_token() {
+    let idp = make_idp();
+    let jwks = mount_jwks(&idp).await;
+
+    let per_user = "nbt_alice.aaaaaaaaaaaaaaaa";
+    let service = "nbt_service.ssssssssssssssss";
+    let netbox = MockServer::start().await;
+    mount_ip_reserve(&netbox, per_user).await;
+
+    let server = spawn_oidc_writes(
+        &netbox.uri(),
+        &format!("{}/jwks", jwks.uri()),
+        service,
+        "alice",
+        per_user,
+    );
+    let client = reqwest::Client::new();
+    let url = server.mcp_url();
+    let jwt = idp.mint(ISSUER, AUDIENCE, "alice", "nbox:read nbox:write");
+
+    let session = handshake(&client, &url, Some(&jwt)).await;
+
+    // plan → a MutationPlan; the read-before-write runs under alice's token.
+    let plan_msg = call_tool(
+        &client,
+        &url,
+        &session,
+        Some(&jwt),
+        2,
+        "nbox_plan_write",
+        json!({ "operation": { "kind": "ip_reserve", "prefix": "10.0.0.0/24" } }),
+    )
+    .await;
+    let plan = tool_payload(&plan_msg);
+    assert_eq!(plan["operation"], "allocate", "plan: {plan}");
+    assert!(
+        !plan["confirm_token"]
+            .as_str()
+            .unwrap_or_default()
+            .is_empty(),
+        "plan carries a confirm token"
+    );
+
+    // apply → a MutationReceipt; the POST runs under alice's token too. Reaching
+    // this point at all means every NetBox call matched alice's Bearer.
+    let apply_msg = call_tool(
+        &client,
+        &url,
+        &session,
+        Some(&jwt),
+        3,
+        "nbox_apply_write",
+        json!({ "plan": plan }),
+    )
+    .await;
+    let receipt = tool_payload(&apply_msg);
+    assert_eq!(receipt["applied"], json!(true), "receipt: {receipt}");
+    assert_eq!(receipt["object"]["address"], json!("10.0.0.1/24"));
+}
+
+#[tokio::test]
+async fn oidc_write_rejected_without_write_scope() {
+    let idp = make_idp();
+    let jwks = mount_jwks(&idp).await;
+    let netbox = MockServer::start().await; // no endpoints — must never be reached
+
+    let server = spawn_oidc_writes(
+        &netbox.uri(),
+        &format!("{}/jwks", jwks.uri()),
+        "nbt_service.x",
+        "alice",
+        "nbt_alice.y",
+    );
+    let client = reqwest::Client::new();
+    let url = server.mcp_url();
+    // read scope only → handshake works, but the write tool is refused.
+    let jwt = idp.mint(ISSUER, AUDIENCE, "alice", "nbox:read");
+
+    let session = handshake(&client, &url, Some(&jwt)).await;
+    let msg = call_tool(
+        &client,
+        &url,
+        &session,
+        Some(&jwt),
+        2,
+        "nbox_plan_write",
+        json!({ "operation": { "kind": "ip_reserve", "prefix": "10.0.0.0/24" } }),
+    )
+    .await;
+    let err = msg["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("nbox:write"),
+        "expected a missing-scope error: {msg}"
+    );
+    assert!(
+        netbox
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "no NetBox call on a scope refusal"
+    );
+}
+
+#[tokio::test]
+async fn oidc_write_rejected_for_unmapped_sub() {
+    let idp = make_idp();
+    let jwks = mount_jwks(&idp).await;
+    let netbox = MockServer::start().await;
+
+    // The vault maps "alice"; the caller authenticates as "carol".
+    let server = spawn_oidc_writes(
+        &netbox.uri(),
+        &format!("{}/jwks", jwks.uri()),
+        "nbt_service.x",
+        "alice",
+        "nbt_alice.y",
+    );
+    let client = reqwest::Client::new();
+    let url = server.mcp_url();
+    let jwt = idp.mint(ISSUER, AUDIENCE, "carol", "nbox:read nbox:write");
+
+    let session = handshake(&client, &url, Some(&jwt)).await;
+    let msg = call_tool(
+        &client,
+        &url,
+        &session,
+        Some(&jwt),
+        2,
+        "nbox_plan_write",
+        json!({ "operation": { "kind": "ip_reserve", "prefix": "10.0.0.0/24" } }),
+    )
+    .await;
+    let err = msg["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("no vault entry") && err.contains("carol"),
+        "expected a vault-miss error for carol: {msg}"
+    );
+    assert!(
+        netbox
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty(),
+        "no NetBox call on a vault miss"
     );
 }


### PR DESCRIPTION
## Why

The MCP write authorization (Pattern 2) was only unit-tested. The identity → vault → per-user-token bridge had never been exercised through the **real** OIDC resource server and the Streamable-HTTP transport — i.e. the propagation chain (auth gate inserts the validated `Identity` into the request `Parts` → rmcp nests those `Parts` into the tool's `RequestContext` → `write_caller` extracts the `sub`) was unverified end to end. That chain is exactly the surface #122 shipped non-functional (a hardcoded placeholder `sub`), caught only by a deep review.

## What

Three end-to-end tests in `tests/mcp_serve_http_tests.rs`. A throwaway IdP — a real RSA keypair, with a wiremock endpoint serving the matching JWKS — signs RS256 tokens. `nbox serve` runs in OIDC resource-server mode with `--allow-writes` and a one-entry `[serve.vault]`, pointed at a wiremock NetBox; the client speaks real JSON-RPC over HTTP/SSE.

- **`oidc_write_bridges_caller_identity_to_per_user_token`** — a JWT (`sub=alice`, `nbox:read nbox:write`) drives `nbox_plan_write` then `nbox_apply_write` for an `ip reserve`. The mock NetBox endpoints are **header-matched on Alice's per-user Bearer**, so the flow can only succeed if her identity bridged to her token — the bridge is a *precondition of the test passing*, not a side assertion. (Service token and per-user token are distinct values.)
- **`oidc_write_rejected_without_write_scope`** — a token with only `nbox:read` handshakes fine but the write tool is refused (scope enforced through the real stack), with **no** NetBox call.
- **`oidc_write_rejected_for_unmapped_sub`** — `sub=carol` (not in the vault) fails closed on the vault lookup, with **no** NetBox call.

## Notes

- No production code changes — tests only. The dev-deps (`rsa`/`rand`/`wiremock`/`jsonwebtoken`) were already present, added in anticipation of exactly this ("Mint a real RSA keypair in the OIDC resource-server tests…").
- This is the first test that mints a real RS256 JWT and validates it through the JWKS path, so it also exercises the otherwise-untested OIDC signature/iss/aud/exp validation.

## Gate

`cargo fmt`; `cargo clippy --all-targets {--all-features,--no-default-features} --locked -- -D warnings`; `cargo test {--features http,--no-default-features} --locked`; `cargo audit` — all green.