### PR TITLE
docs(serve): align serve --help + MCP doc-comments with read-first framing

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -551,7 +551,8 @@ pub enum Command {
         out_dir: Option<PathBuf>,
     },
 
-    /// Run the read-only MCP server (for AI agents / MCP clients).
+    /// Run the MCP server for AI agents / MCP clients (read-only by default;
+    /// `--allow-writes` enables the opt-in write tools).
     ///
     /// Defaults to the stdio transport: an MCP host launches `nbox serve` as a
     /// subprocess and speaks JSON-RPC over its stdin/stdout. Passing `--http`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,7 +753,7 @@ struct ServeFlags {
     print_config: bool,
 }
 
-/// `nbox serve` — run the read-only MCP server.
+/// `nbox serve` — run the MCP server (read-only by default).
 ///
 /// Stdio is the zero-config default. `--http <ADDR>` (or `[serve].http` in the
 /// config) switches to the opt-in HTTP transport, which requires the `http`

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -2,8 +2,8 @@
 //! ladder; see `DESIGN.md` §24).
 //!
 //! This is an *alternate transport* for the exact same [`NboxMcp`] server the
-//! stdio path serves — the handler, tool router, and eight read-only tools are
-//! reused unchanged. rmcp's Streamable HTTP server ([`StreamableHttpService`] +
+//! stdio path serves — the handler, tool router, and tools are reused
+//! unchanged. rmcp's Streamable HTTP server ([`StreamableHttpService`] +
 //! [`LocalSessionManager`]) is mounted at `/mcp` on an axum router.
 //!
 //! Two modes, chosen at startup:
@@ -219,7 +219,7 @@ pub struct ServeOptions {
     pub profile: String,
 }
 
-/// Serve the read-only MCP server over HTTP until interrupted.
+/// Serve the MCP server over HTTP until interrupted.
 ///
 /// Without `opts.oidc`, `addr` must be a loopback socket address (rung 2): the
 /// trust boundary is loopback, plus the optional static `opts.token`. With

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,10 +1,11 @@
-//! Read-only MCP server (stdio transport).
+//! The NetBox MCP server (read-only by default).
 //!
 //! A third front-end beside the CLI and TUI. It exposes nbox's existing NetBox
-//! read-only lookups as MCP tools, so an agent can drive the same query +
+//! read lookups as MCP tools, so an agent can drive the same query +
 //! domain-view layer the CLI handlers use. Each tool is a thin adapter: it calls
 //! the same query helpers, builds the same view model, and returns it as
-//! structured JSON.
+//! structured JSON. Two opt-in write tools (`nbox_plan_write` / `nbox_apply_write`)
+//! are gated by `--allow-writes` plus the per-user credential vault (Pattern 2).
 //!
 //! stdout carries the JSON-RPC stream and nothing else — logging goes to stderr
 //! (see [`crate::init_logging`]), and the connect path here prints nothing.
@@ -39,7 +40,7 @@ use crate::netbox::client::NetBoxClient;
 use crate::netbox::search::{SearchFilters, SearchRequest, SearchResult};
 use crate::netbox::status::AuthCheck;
 
-/// The read-only NetBox MCP server.
+/// The NetBox MCP server (read-only by default; write tools gated by the vault).
 #[derive(Clone)]
 pub struct NboxMcp {
     client: Arc<NetBoxClient>,

--- a/tests/mcp_serve_http_tests.rs
+++ b/tests/mcp_serve_http_tests.rs
@@ -1,5 +1,6 @@
-//! End-to-end test of `nbox serve --http` — the read-only MCP server over the
-//! opt-in loopback HTTP transport (rung 2 of the transport ladder; DESIGN §24).
+//! End-to-end test of `nbox serve --http` — the MCP server (read-only by default,
+//! plus the OIDC-gated per-user write path) over the opt-in loopback HTTP
+//! transport (rung 2 of the transport ladder; DESIGN §24).
 //!
 //! Gated behind the `http` feature: the whole file compiles only when the
 //! transport is built in (the binary it drives must understand `--http`). It

--- a/tests/mcp_serve_tests.rs
+++ b/tests/mcp_serve_tests.rs
@@ -1,4 +1,4 @@
-//! End-to-end test of `nbox serve` — the read-only MCP server over stdio.
+//! End-to-end test of `nbox serve` — the MCP server (read-only by default) over stdio.
 //!
 //! This launches the *real* compiled binary (`env!("CARGO_BIN_EXE_nbox")`) with
 //! `serve`, then speaks newline-delimited JSON-RPC over its stdin/stdout. It


### PR DESCRIPTION
## What

Follow-up to the doc-set accuracy pass: the **code-side** strings still called the MCP server flatly "read-only", which the docs no longer do.

- `nbox serve --help` opened with *"Run the read-only MCP server"* (`src/cli.rs`) — user-facing.
- `src/mcp/mod.rs` module + struct docs, `src/mcp/http.rs` module + fn docs (incl. a stale *"eight read-only tools"*), `src/lib.rs` serve fn doc, and the two `tests/mcp_serve*` module docs.

All reworded to read-first framing (eleven read tools + the two opt-in write tools behind `--allow-writes` + the per-user vault). The accurate "read-only" mentions were left as-is (the vault.rs Pattern-3 contrast, the "read-only default" when writes are off, the per-tool "nothing is reserved" notes, `read_only_hint`).

Comment and help text only — no behavior change.

## Gate

fmt, clippy (`--all-features` + `--no-default-features`), `cargo test` both modes (1368 / 1269) all green locally.