### PR TITLE
fix: release-safety remediation (MCP write integrity + correctness)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,12 @@ nbox history <kind> <ref> [--diff]  # system audit log (create/update/delete, wh
                                   # (operator notes). `--diff` shows the full before/after JSON for the
                                   # newest change (implies --limit 1). Same kind set as `journal`.
 nbox open <kind>/<ref>
+nbox export prometheus-sd (--prefix <cidr> [--vrf <name|slug|rd>] | --tag <slug>) [--port N]
+                                  # structured read-only export: Prometheus file-SD JSON, targets grouped by device
+nbox export address-list (--prefix <cidr> [--vrf <name|slug|rd>] | --tag <slug>) [--family 4|6] [--summarize] [--format json|plain]
+                                  # firewall/blocklist address list (host IPs as /32 or /128, plus tagged prefixes)
+nbox export device-inventory [--site <slug>] [--role <slug>] [--tag <slug>] [--status <value>] [--manufacturer <slug>] [--format json|csv]
+                                  # one record per device (name/status/role/site/model/serial/primary_ip/tags/…)
 nbox raw GET <api-path>          # path with or without /api/, e.g. dcim/devices/?limit=1
 nbox status                       # NetBox/Django/Python versions, api routing,
                                   # capabilities, and a token-validity preflight

--- a/README.md
+++ b/README.md
@@ -509,11 +509,14 @@ and token come from the active profile / env, and it takes the same `-p`/`--conf
 flags. JSON-RPC goes to stdout; all logging stays on stderr.
 
 The eleven read tools below are annotated read-only (`read_only_hint = true`). Two
-write tools — `nbox_plan_write` / `nbox_apply_write` — are also registered, but
-exposed only when `--allow-writes` (or `[serve].allow_writes`) is set: they require
-an OIDC-authenticated caller plus a `[serve.vault]` entry mapping the caller's `sub`
-to a per-user NetBox token, run as that user, and reject over stdio. Without
-`--allow-writes` they reject with "writes disabled".
+write tools — `nbox_plan_write` / `nbox_apply_write` — are **always registered** (so
+they show up in `tools/list`), but execution is gated: a call is rejected unless
+writes are enabled (`--allow-writes` / `[serve].allow_writes`) AND the caller is an
+OIDC-authenticated identity carrying the `nbox:write` scope with a `[serve.vault]`
+entry mapping its `sub` to a per-user NetBox token. The write then runs as that user
+(never over stdio; without writes enabled the tools reject with "writes disabled").
+`nbox_apply_write` applies the plan the server stored at plan time — looked up by the
+`confirm_token` you pass back — not the plan JSON itself, so a forged plan is rejected.
 
 | Tool | What |
 |------|------|

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ nbox virtual-circuit <cid-or-id>                   # incl. its multi-point termi
 nbox provider <slug-or-name-or-id>
 nbox aggregate <cidr-or-id> [--journal]
 nbox asn <number> [--journal]
+nbox ip-range <start-or-id> [--journal]
   ip-range reserve [--description "…"] [--dns-name "…"] [--count N]
                                   # write: reserve the next available IP in an IP range (POST available-ips); --dry-run | --allow-writes --confirm [--message]
                                   # --count N: reserve N IPs atomically (one list-body POST, all-or-nothing); any failure exits 1

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -16,7 +16,7 @@ transports stay read-only.
 
 | Command | What |
 | ------- | ---- |
-| `nbox search <q>` | Parallel search across devices/sites/racks/IPs/prefixes/VLANs/circuits/virtual-circuits/aggregates/ASNs/IP-ranges/tenants/contacts/providers/VMs/clusters/VRFs/route-targets. Filters: `--status/--site/--region/--site-group/--location/--tenant/--role/--tag/--owner/--owner-group/--vrf`, `--limit`, `--cols`, `--partial`. |
+| `nbox search <q>` | Parallel search across devices/sites/racks/rack-groups/IPs/prefixes/VLANs/circuits/virtual-circuits/aggregates/ASNs/IP-ranges/tenants/contacts/providers/VMs/VM-types/clusters/VRFs/route-targets. Filters: `--status/--site/--region/--site-group/--location/--tenant/--role/--tag/--owner/--owner-group/--vrf`, `--limit`, `--cols`, `--partial`. |
 | `nbox device <name\|slug\|id> [--journal]` | Device + interfaces, IPs, cables, VLANs, services. `set status <value>` is a safe write (ADR-0001): status validated live via OPTIONS, behind `--allow-writes` + confirm. |
 | `nbox interface <device> <iface>` | One interface: type, MTU, MAC, mode, VLANs, cable, **cable path** (an A↔Z trace diagram naming the device at each end), addresses. `set description "…"` is a safe write (ADR-0001), behind `--allow-writes` + confirm. |
 | `nbox ip <addr> [--vrf] [--journal]` | IP + most-specific parent prefix (VRF-scoped) and its VLAN plus the prefix's `scope`/`scope_type` (site, location, region, …); surfaces `nat_inside`/`nat_outside` (NetBox 4.6) when set. `reserve <prefix> [--description] [--dns-name] [--count N]` is a safe write (ADR-0001): `POST` to `available-ips`, behind `--allow-writes` + confirm. `--count N` allocates N IPs atomically (one list-body POST, all-or-nothing); any failure exits 1. `--dry-run` previews the candidate; the receipt's `object` is the created IP (or array for `--count > 1`). |
@@ -53,11 +53,15 @@ transports stay read-only.
 | `nbox export address-list (--prefix <cidr> [--vrf] \| --tag <slug>) [--family 4\|6] [--summarize] [--format json\|plain]` | Emit a firewall/blocklist address list. A prefix source lists its assigned IPs as host entries (`/32`, `/128` — the interface mask is dropped); a tag source lists the IPs *and* whole prefixes carrying the tag. Entries are de-duplicated and sorted; `--summarize` aggregates contiguous entries into the minimal covering set (e.g. two /25s → one /24); `--family` keeps one IP family. Output is a JSON array of CIDR strings (default) or `--format plain` (one per line) for ipset/nftables/pf includes. |
 | `nbox export device-inventory [--site] [--role] [--tag] [--status] [--manufacturer] [--format json\|csv]` | Emit a device inventory — one record per device (`name`, `status`, `role`, `site`, `model`, `platform`, `serial`, `asset_tag`, `rack`, `primary_ip`, `tenant`, `tags`), filtered by any combination of the slug/value flags (ANDed). JSON array (default) or `--format csv` for spreadsheets. The JSON keys and the CSV columns line up one-to-one. |
 
-Targets are `ip:port` (default port `9100`, the conventional `node_exporter`
-port). Labels per group: `device`, `site`, `role`, `status`, `tags` (comma-
-joined, de-duplicated, sorted). IPs without an assigned device group by site
-(or a single `device=""` group). `--prefix` and `--tag` are mutually
-exclusive. Output is a compact JSON array on stdout — pipe-safe, no envelope.
+Targets are `host:port` (default port `9100`, the conventional `node_exporter`
+port; IPv6 hosts are bracketed, `[2001:db8::1]:9100`). Labels per group:
+`device`, `site`, `role`, `status`, `tags` (comma-joined, de-duplicated, sorted;
+the union of each IP's own tags and its device's). `site`/`role`/`status` come
+from the IP's assigned device, so IPs with no assigned device form a single
+`device=""` group (no `site` — there is no device to derive one from). `--prefix`
+and `--tag` are mutually exclusive. A source larger than the gather cap
+(5000 IPs) is truncated with a warning on stderr. Output is a compact JSON array
+on stdout — pipe-safe, no envelope.
 
 Every detail lookup surfaces the object's `tags` (joined slugs in plain output, a
 `tags` array in `--json`), dropped when the object has none, plus its non-empty

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -411,11 +411,12 @@ through unchanged (it's the one kind whose spelling differs between the two).
 | Tool | Purpose |
 | ---- | ------- |
 | `nbox_plan_write` | Plan a NetBox write (interface description, device status, IP/prefix/IP-range reserve, tag add/remove). Builds a `MutationPlan` — a before/after diff plus a confirm token — without mutating NetBox. Annotated `read_only_hint = false`. |
-| `nbox_apply_write` | Apply a previously planned write. Pass the full `MutationPlan` JSON from `nbox_plan_write`; the confirm token is verified, then the write runs under the caller's per-user NetBox identity, returning a `MutationReceipt`. Annotated `read_only_hint = false`. |
+| `nbox_apply_write` | Apply a previously planned write. Pass back the `MutationPlan` from `nbox_plan_write`; its `confirm_token` looks up the plan the server stored at plan time and applies **that** stored plan (the submitted contents are not trusted — a forged or edited plan, or one issued for a different caller, is rejected). Runs under the caller's per-user NetBox identity, returning a `MutationReceipt`. Annotated `read_only_hint = false`. |
 
-Both write tools are exposed only with `--allow-writes` (or
-`[serve].allow_writes`) over the HTTP+OIDC transport, and require the caller's
-`nbox:write` scope plus a `[serve.vault."<sub>"]` entry mapping the caller's OIDC
+Both write tools are **always registered** (discoverable in `tools/list`); what's
+gated is execution. A call is rejected unless writes are enabled (`--allow-writes`
+or `[serve].allow_writes`) over the HTTP+OIDC transport AND the caller carries the
+`nbox:write` scope with a `[serve.vault."<sub>"]` entry mapping the caller's OIDC
 `sub` to that user's NetBox token. Without writes enabled they reject with
 "writes disabled"; they are rejected over stdio / unauthenticated transports (no
 per-user identity to bridge). See the **Writes** subsection under

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -45,6 +45,19 @@ step "Build smoke — all features + no default features"
 cargo build --all-features --locked
 cargo build --no-default-features --locked
 
+step "Lean musl build check (musl-lean-check)"
+# Mirrors the CI musl-lean-check job: the stdio-only build must compile for the
+# musl release target. `cargo check` needs no musl linker; skip cleanly if the
+# target isn't installed locally (CI always runs it).
+if rustup target list --installed 2>/dev/null | grep -q '^x86_64-unknown-linux-musl$'; then
+    cargo check --no-default-features --locked --target x86_64-unknown-linux-musl
+else
+    echo "skip: x86_64-unknown-linux-musl not installed (rustup target add x86_64-unknown-linux-musl)"
+fi
+
+step "Agent skills lint (skills-lint)"
+bash scripts/lint_skills.sh
+
 step "Feature matrix — intermediate combinations"
 # Intermediate feature combinations between all-on and all-off. Mirror the
 # feature-matrix CI job so the pre-tag gate catches the same combos locally.

--- a/skills/serve/SKILL.md
+++ b/skills/serve/SKILL.md
@@ -7,9 +7,9 @@ description: Run nbox as an MCP server (read-only by default) so an agent host c
 
 `nbox serve` exposes nbox's read layer as an MCP server. The tools reuse the
 CLI's query + view layer, so they return the same JSON view models as the
-equivalent `nbox <cmd>`. **Read-only is the default** — no write tools are
-exposed unless writes are explicitly opted in (see below). For the flags, run
-`nbox serve --help` — this skill is flag-free by design.
+equivalent `nbox <cmd>`. **Read-only is the default** — the write tools are always
+listed but reject at call time unless writes are explicitly opted in (see below).
+For the flags, run `nbox serve --help` — this skill is flag-free by design.
 
 ## Two transports
 
@@ -76,11 +76,14 @@ nbox serve --http 127.0.0.1:8080    # loopback HTTP, read-only
 
 ## Writes are a separate opt-in
 
-The MCP server stays read-only by default. Write tools (`nbox_plan_write` /
-`nbox_apply_write`) are exposed **only** with `nbox serve --http --allow-writes`
-plus a `[serve.vault]` config mapping each caller's OIDC `sub` to a per-user
-NetBox token — writes require the HTTP transport (OIDC identity); stdio stays
-read-only. For that lifecycle, see the [safe writes](../writes/SKILL.md) skill.
+The MCP server is read-only by default. The write tools (`nbox_plan_write` /
+`nbox_apply_write`) are always registered, but a call only **executes** with
+`nbox serve --http --allow-writes` plus the caller's `nbox:write` scope and a
+`[serve.vault]` entry mapping their OIDC `sub` to a per-user NetBox token — writes
+require the HTTP+OIDC transport; stdio stays read-only. `nbox_apply_write` applies
+the plan the server stored at plan time (looked up by the `confirm_token` from
+`nbox_plan_write`), not the plan you resubmit. For that lifecycle, see the
+[safe writes](../writes/SKILL.md) skill.
 
 ## Reference
 

--- a/src/domain/detail.rs
+++ b/src/domain/detail.rs
@@ -73,6 +73,14 @@ const DETAIL_SECTION_CAP: usize = 200;
 /// Prefix detail's contained-address tab needs room for a full IPv4 `/24` while
 /// still staying bounded and below NetBox's `MAX_PAGE_SIZE` (1000).
 const PREFIX_CONTAINED_IP_CAP: usize = 512;
+
+/// Upper bound on a single multi-allocation `--count`. Apply builds an N-element
+/// list body (`vec![body; count]`) before the POST, so an unbounded count would
+/// allocate unbounded memory client-side before NetBox is ever contacted. 1000
+/// matches NetBox's `MAX_PAGE_SIZE` and is far above any realistic single
+/// reservation; an over-cap request is a usage error (exit 2), rejected
+/// pre-network like a count of 0.
+const MAX_ALLOCATION_COUNT: u32 = 1000;
 /// How many recent journal entries to fold into a detail view with `--journal`.
 pub const JOURNAL_INLINE_MAX: usize = 5;
 
@@ -699,11 +707,13 @@ pub(crate) async fn plan_ip_reserve(
     };
     mutation::validate_changelog_message(&message)?;
 
-    // Validate count: must be ≥ 1. A count of 0 is a usage error.
-    if count == 0 {
-        return Err(anyhow::Error::new(NboxError::Usage(
-            "count must be at least 1".to_string(),
-        )));
+    // Validate count: 1..=MAX_ALLOCATION_COUNT. Both bounds are usage errors
+    // (exit 2), checked pre-network — an unbounded count would build a giant
+    // list body before the POST.
+    if count == 0 || count > MAX_ALLOCATION_COUNT {
+        return Err(anyhow::Error::new(NboxError::Usage(format!(
+            "count must be between 1 and {MAX_ALLOCATION_COUNT}"
+        ))));
     }
 
     // Resolve the prefix by CIDR (reuses the read path so ambiguity / not-found /
@@ -1055,11 +1065,13 @@ pub(crate) async fn plan_ip_range_reserve(
     };
     mutation::validate_changelog_message(&message)?;
 
-    // Validate count: must be ≥ 1. A count of 0 is a usage error.
-    if count == 0 {
-        return Err(anyhow::Error::new(NboxError::Usage(
-            "count must be at least 1".to_string(),
-        )));
+    // Validate count: 1..=MAX_ALLOCATION_COUNT. Both bounds are usage errors
+    // (exit 2), checked pre-network — an unbounded count would build a giant
+    // list body before the POST.
+    if count == 0 || count > MAX_ALLOCATION_COUNT {
+        return Err(anyhow::Error::new(NboxError::Usage(format!(
+            "count must be between 1 and {MAX_ALLOCATION_COUNT}"
+        ))));
     }
 
     // Resolve the IP range by start address or ID (same resolver as

--- a/src/export/mod.rs
+++ b/src/export/mod.rs
@@ -64,6 +64,19 @@ pub struct TargetGroup {
 /// `node_exporter` port — the common ops default for a Prometheus host target.
 pub const DEFAULT_PORT: u16 = 9100;
 
+/// Format one `host:port` Prometheus target. IPv6 hosts are bracketed
+/// (`[2001:db8::1]:9100`) so the address colons aren't confused with the
+/// port separator; IPv4 / hostnames are left bare (`10.0.0.5:9100`). The
+/// address is the bare host (mask already stripped by [`strip_prefix_len`]).
+#[must_use]
+fn sd_target(address: &str, port: u16) -> String {
+    if address.contains(':') {
+        format!("[{address}]:{port}")
+    } else {
+        format!("{address}:{port}")
+    }
+}
+
 /// Strip a `/prefixlen` suffix from a NetBox address (`10.0.0.5/24` →
 /// `10.0.0.5`). Passes through unchanged when there is no slash (an address
 /// already given without a mask, or an IPv6 with no trailing length).
@@ -75,12 +88,14 @@ pub fn strip_prefix_len(address: &str) -> String {
 /// Build Prometheus service-discovery target groups from enriched IPs.
 ///
 /// Targets are grouped by device: every IP sharing a device lands in one group
-/// whose `targets` is the device's `ip:port` list and whose `labels` carry the
-/// shared device/site/role/status. Per-IP tags are unioned (de-duplicated,
-/// sorted) into a single comma-joined `tags` label so a group with mixed tags
-/// still surfaces all of them. IPs without an assigned device form per-site
-/// groups (or a single `device=""` group when site is unknown), so unassigned
-/// addresses aren't silently dropped.
+/// whose `targets` is the device's `host:port` list (IPv6 bracketed) and whose
+/// `labels` carry the shared device/site/role/status. Per-IP tags are unioned
+/// (de-duplicated, sorted) into a single comma-joined `tags` label so a group
+/// with mixed tags still surfaces all of them. IPs that carry no assigned device
+/// have no derived `site` (site comes from the device), so in practice they all
+/// fall into one `device=""` group rather than being silently dropped — the
+/// grouping key still includes `site`, so a caller that *does* supply a site for
+/// a deviceless IP gets per-site groups.
 ///
 /// Groups are returned in a stable order: assigned-device groups sorted by
 /// device name, then unassigned groups sorted by site (with the empty-site
@@ -107,7 +122,7 @@ pub fn prometheus_sd(ips: &[ExportIp], port: u16) -> Vec<TargetGroup> {
 
         let targets: Vec<String> = members
             .iter()
-            .map(|ip| format!("{}:{}", ip.address, port))
+            .map(|ip| sd_target(&ip.address, port))
             .collect();
 
         // Shared labels: device/site/role/status come from the (constant across
@@ -439,6 +454,25 @@ mod tests {
     fn empty_input_yields_empty_array() {
         let groups = prometheus_sd(&[], 9100);
         assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn ipv6_targets_are_bracketed_ipv4_is_bare() {
+        let ips = vec![
+            ip("2001:db8::1", Some("edge01"), None),
+            ip("10.0.0.5", Some("edge01"), None),
+        ];
+        let groups = prometheus_sd(&ips, 9100);
+        assert_eq!(groups.len(), 1, "{groups:?}");
+        let targets = &groups[0].targets;
+        assert!(
+            targets.contains(&"[2001:db8::1]:9100".to_string()),
+            "IPv6 must be bracketed: {targets:?}"
+        );
+        assert!(
+            targets.contains(&"10.0.0.5:9100".to_string()),
+            "IPv4 stays bare: {targets:?}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1921,7 +1921,7 @@ async fn run_tag_write(
 /// (412 or pre-4.6 before-hash mismatch) is a recoverable refusal; a 400 is a
 /// NetBox validation rejection; anything else (network, auth, 5xx) is a plain
 /// error. Walks the chain so a `.context(...)`-wrapped typed error still maps.
-fn classify_apply_error(e: &anyhow::Error) -> (write_audit::Outcome, u16) {
+pub(crate) fn classify_apply_error(e: &anyhow::Error) -> (write_audit::Outcome, u16) {
     use crate::netbox::write_audit::Outcome;
     // Walk the chain for the most specific typed error. The first NboxError
     // that maps to an outcome wins; its HTTP status (if any) is recorded in
@@ -1947,7 +1947,7 @@ fn classify_apply_error(e: &anyhow::Error) -> (write_audit::Outcome, u16) {
 /// `http` vs `https`, non-default ports, and same-host lab instances; empty
 /// when the base URL has no host (matching the previous `host_str().unwrap_or("")`
 /// fallback). No path is logged — a token could ride a query string.
-fn audit_origin(base: &reqwest::Url) -> String {
+pub(crate) fn audit_origin(base: &reqwest::Url) -> String {
     if base.host_str().is_some() {
         base.origin().ascii_serialization()
     } else {
@@ -1961,7 +1961,7 @@ fn audit_origin(base: &reqwest::Url) -> String {
 /// byte length. `None` (an empty/normalized-away message) is 0. Extracted so the
 /// policy (chars, not bytes) is pinned by a unit test with a non-ASCII message.
 #[must_use]
-fn message_audit_len(msg: Option<&str>) -> usize {
+pub(crate) fn message_audit_len(msg: Option<&str>) -> usize {
     msg.map_or(0, |m| m.chars().count())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2650,12 +2650,12 @@ async fn run_export_prometheus_sd(
             )
             .await?
     };
+    warn_if_export_truncated(ips.len(), EXPORT_IP_CAP, "IPs");
 
     // Enrich: resolve the distinct assigned devices in one `id__in` fetch so
     // site/role/status come from the device (the IP's `assigned_object`
     // interface brief carries a nested device id but not site/role). IPs
-    // without an assigned device keep `device=None` and fall back to per-site
-    // grouping in [`prometheus_sd`].
+    // without an assigned device keep `device=None`.
     let device_map = resolve_assigned_devices(&client, &ips).await?;
 
     let export_ips: Vec<ExportIp> = ips
@@ -2686,12 +2686,18 @@ async fn run_export_prometheus_sd(
                     ip.status.as_ref().map(|c| c.value.clone()),
                     Vec::new(),
                 ));
-            // Prefer the device's tags when a device resolved; else the IP's own tags.
-            let tags = if dev_tags.is_empty() {
-                ip.tags.into_iter().map(|t| t.slug).collect::<Vec<_>>()
-            } else {
-                dev_tags.into_iter().map(|t| t.slug).collect()
-            };
+            // Union the IP's own tags with its device's tags (de-duplicated):
+            // dropping either set loses signal — e.g. a `--tag` source tag rides
+            // on the IP, so preferring device tags would erase the very tag the
+            // export was filtered by. `prometheus_sd` re-unions across the group.
+            let mut tags: Vec<String> = ip
+                .tags
+                .into_iter()
+                .map(|t| t.slug)
+                .chain(dev_tags.into_iter().map(|t| t.slug))
+                .collect();
+            tags.sort();
+            tags.dedup();
             ExportIp {
                 address: strip_prefix_len(&ip.address),
                 device: device_name,
@@ -2714,6 +2720,20 @@ async fn run_export_prometheus_sd(
 /// 254 addresses — but bounded so a misconfigured `--tag` over a huge table
 /// can't stream unbounded work into one export.
 const EXPORT_IP_CAP: usize = 5_000;
+
+/// Warn (to stderr via the log layer) when an export gather came back at its cap,
+/// so a silently truncated export is visible rather than quietly incomplete. The
+/// heuristic — a full page at the cap — can occasionally false-positive when the
+/// source has *exactly* `cap` rows, which is the safe direction (a spurious
+/// notice, never a silent omission). Stdout (the JSON/list) stays clean.
+fn warn_if_export_truncated(len: usize, cap: usize, what: &str) {
+    if len >= cap {
+        tracing::warn!(
+            "export truncated at {cap} {what}; some may be omitted — narrow the source \
+             (a smaller --prefix/--tag or more device filters)"
+        );
+    }
+}
 
 /// Cap on the number of devices a `device-inventory` export gathers. Generous
 /// for a mid-size DCIM, but bounded so an unfiltered export of a huge fleet
@@ -2817,6 +2837,7 @@ async fn run_export_address_list(
         let p = detail::resolve_prefix(&client, cidr, vrf.as_deref(), &not_found).await?;
         let vrf_id = p.vrf.as_ref().map(|v| v.id);
         let ips = client.prefix_ips(cidr, vrf_id, EXPORT_IP_CAP).await?;
+        warn_if_export_truncated(ips.len(), EXPORT_IP_CAP, "IPs");
         nets.extend(ips.iter().filter_map(|ip| ip_host_net(&ip.address)));
     } else {
         let tag_slug = tag.as_deref().unwrap();
@@ -2831,6 +2852,7 @@ async fn run_export_address_list(
                 EXPORT_IP_CAP,
             )
             .await?;
+        warn_if_export_truncated(ips.len(), EXPORT_IP_CAP, "IPs");
         nets.extend(ips.iter().filter_map(|ip| ip_host_net(&ip.address)));
         let prefixes: Vec<Prefix> = client
             .list_all(
@@ -2839,6 +2861,7 @@ async fn run_export_address_list(
                 EXPORT_IP_CAP,
             )
             .await?;
+        warn_if_export_truncated(prefixes.len(), EXPORT_IP_CAP, "prefixes");
         nets.extend(prefixes.iter().filter_map(|p| parse_net(&p.prefix)));
     }
 
@@ -2899,6 +2922,7 @@ async fn run_export_device_inventory(
     let devices: Vec<Device> = client
         .list_all(Endpoint::Devices, filters, EXPORT_DEVICE_CAP)
         .await?;
+    warn_if_export_truncated(devices.len(), EXPORT_DEVICE_CAP, "devices");
     let records = device_inventory(&devices);
 
     match format {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -10,7 +10,7 @@
 //! stdout carries the JSON-RPC stream and nothing else — logging goes to stderr
 //! (see [`crate::init_logging`]), and the connect path here prints nothing.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
@@ -54,6 +54,11 @@ pub struct NboxMcp {
     /// The active profile name — bound into the confirmation token so a plan
     /// from one profile can't be applied under another. Empty for stdio.
     profile: String,
+    /// Write plans this server has issued but not yet applied. `nbox_apply_write`
+    /// applies the STORED plan for a token, never the caller's submitted plan
+    /// contents — the `confirm_token` is a non-secret hash, so a forged plan must
+    /// not be trusted. Shared across this long-lived server's clones (`Arc`).
+    plans: Arc<Mutex<write::PlanStore>>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -565,6 +570,7 @@ impl NboxMcp {
             cache,
             vault: vault.map(Arc::new),
             profile,
+            plans: Arc::new(Mutex::new(write::PlanStore::default())),
             tool_router: Self::tool_router(),
         }
     }
@@ -1118,16 +1124,25 @@ impl ServerHandler for NboxMcp {
             .enable_resources()
             .enable_prompts()
             .build();
-        info.instructions = Some(
+        // The write note reflects THIS instance: write tools are advertised only
+        // when writes are enabled (a vault is configured); otherwise the server
+        // is read-only and says so.
+        let write_note = if self.vault.is_some() {
+            "Writes are opt-in: a caller with the nbox:write scope and a per-user vault entry can \
+             nbox_plan_write (review the before/after diff + confirm token) then nbox_apply_write \
+             to mutate NetBox under their own identity; everything else is read-only."
+        } else {
+            "Nothing is ever written (this instance is read-only)."
+        };
+        info.instructions = Some(format!(
             "Read-only NetBox lookups: search, devices, IPs, prefixes, VLANs, sites, racks, \
              circuits, journals, tags, and the change-history (audit log). Use nbox_search to \
              find an object's reference, then nbox_get to fetch it; nbox_history for what changed \
-             and nbox_journal for operator notes. Objects are also exposed as nbox://{kind}/{ref} \
+             and nbox_journal for operator notes. Objects are also exposed as nbox://{{kind}}/{{ref}} \
              resources (same view as nbox_get). Curated investigation prompts (IP utilization \
              audit, cable path trace, stale-prefix sweep, object change review) are available \
-             via prompts/list. Nothing is ever written."
-                .into(),
-        );
+             via prompts/list. {write_note}"
+        ));
         info
     }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -895,12 +895,13 @@ impl NboxMcp {
         self.plan_write_impl(args, write_caller(&ctx)).await
     }
 
-    /// Apply a previously planned write. Verifies the plan's confirm token,
-    /// then executes the write under the caller's per-user NetBox identity.
-    /// Returns a `MutationReceipt` with the outcome.
+    /// Apply a previously planned write. The submitted plan's `confirm_token`
+    /// looks up the plan this server stored at plan time, and that stored plan is
+    /// executed under the caller's per-user NetBox identity — the submitted plan
+    /// contents are not trusted. Returns a `MutationReceipt`.
     #[tool(
         name = "nbox_apply_write",
-        description = "Apply a previously planned write. Pass the full MutationPlan JSON from nbox_plan_write. The confirm token is verified, then the write executes under the caller's per-user NetBox identity. Returns a MutationReceipt. Requires writes enabled.",
+        description = "Apply a previously planned write. Pass back the MutationPlan from nbox_plan_write; its confirm_token looks up the plan this server stored at plan time and applies THAT (the plan contents you submit are not trusted — a forged or edited plan, or one issued for a different caller, is rejected). Executes under the caller's per-user NetBox identity, returning a MutationReceipt. Same gating as nbox_plan_write: writes enabled (--allow-writes), the caller's nbox:write scope, and a [serve.vault] entry for the caller's OIDC sub; rejected over stdio.",
         annotations(read_only_hint = false)
     )]
     async fn nbox_apply_write(

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -4131,45 +4131,298 @@ async fn plan_write_device_status_produces_plan() {
     assert!(!plan.confirm_token.is_empty());
 }
 
-#[tokio::test]
-async fn apply_write_rejects_tampered_plan() {
-    // A plan whose confirm_token doesn't match its contents must be rejected.
-    let mock = MockServer::start().await;
-    let server = server_for(&mock); // vault doesn't matter — verify is first
-
-    // Build a fake plan with a bad confirm_token.
-    let plan = crate::netbox::mutation::MutationPlan {
-        schema_version: 1,
-        operation: crate::netbox::mutation::Operation::Update,
-        target: crate::netbox::mutation::PlanTarget {
-            kind: "device".into(),
-            r#ref: "edge01".into(),
-            id: 1,
-            display: "edge01".into(),
-            endpoint: "/api/dcim/devices/1/".into(),
-            profile: "test-profile".into(),
+/// A write-enabled server whose `sub` resolves to a per-user token via `env_name`
+/// — distinct env var per test so the (process-global) var can't race.
+fn write_server_with_env(mock: &MockServer, sub: &str, env_name: &str) -> NboxMcp {
+    let profile = ProfileConfig {
+        url: mock.uri(),
+        ..Default::default()
+    };
+    let mut entries = std::collections::BTreeMap::new();
+    entries.insert(
+        sub.to_string(),
+        crate::mcp::vault::VaultEntry {
+            token_env: env_name.to_string(),
         },
-        precondition: crate::netbox::mutation::Precondition::None,
+    );
+    let vault = crate::mcp::vault::CredentialVault::new(entries, true);
+    NboxMcp::new(
+        NetBoxClient::new(&profile, None).unwrap(),
+        crate::cache::Cache::disabled(),
+        Some(vault),
+        "test-profile".to_string(),
+    )
+}
+
+#[tokio::test]
+async fn apply_write_rejects_forged_plan_never_issued() {
+    // The headline forgery guard: a write-scoped caller forges a *self-consistent*
+    // plan (a valid confirm_token over an arbitrary endpoint + patch) the server
+    // never issued. `plan.verify()` passes — the token is a non-secret hash — but
+    // apply must still reject it, because the server only applies plans IT stored.
+    unsafe {
+        std::env::set_var("NBOX_VAULT_FORGE", "nbt_per_user_token");
+    }
+    let mock = MockServer::start().await;
+    let server = write_server_with_env(&mock, "alice", "NBOX_VAULT_FORGE");
+
+    use crate::netbox::mutation::{
+        MutationPlan, Operation, PlanTarget, Precondition, confirm_token, parse_iso_utc_to_epoch,
+    };
+    let target = PlanTarget {
+        kind: "device".into(),
+        r#ref: "edge01".into(),
+        id: 1,
+        display: "edge01".into(),
+        // An endpoint nbox's narrow surface would never target with this patch.
+        endpoint: "/api/dcim/devices/1/".into(),
+        profile: "test-profile".into(),
+    };
+    let precondition = Precondition::Etag {
+        etag: "\"v1\"".into(),
+    };
+    let patch = json!({"name": "pwned", "status": "decommissioning"});
+    let expires_at = "2999-01-01T00:00:00Z";
+    let epoch = parse_iso_utc_to_epoch(expires_at).unwrap();
+    let token = confirm_token(
+        &target,
+        Operation::Update,
+        &precondition,
+        &patch,
+        &None,
+        1,
+        epoch,
+    );
+    let forged = MutationPlan {
+        schema_version: 1,
+        operation: Operation::Update,
+        target,
+        precondition,
         fields: vec![],
-        patch: json!({}),
-        no_op: true,
+        patch,
+        no_op: false,
         warnings: vec![],
         errors: vec![],
         changelog_message: None,
         count: 1,
-        confirm_token: "tampered_token".into(),
-        expires_at: "2999-01-01T00:00:00Z".into(),
+        confirm_token: token,
+        expires_at: expires_at.into(),
     };
+    // The forged plan IS internally consistent — the old guard would let it pass.
+    assert!(forged.verify().is_ok(), "forged plan is self-consistent");
 
     let result = server
-        .apply_write_impl(crate::mcp::write::ApplyWriteArgs { plan }, None)
+        .apply_write_impl(
+            crate::mcp::write::ApplyWriteArgs { plan: forged },
+            Some(caller("alice", true)),
+        )
         .await;
-    assert!(result.is_err(), "should reject tampered plan");
-    let err = result.err().unwrap();
-
+    unsafe {
+        std::env::remove_var("NBOX_VAULT_FORGE");
+    }
+    let err = result.err().expect("a never-issued plan must be rejected");
     assert!(
-        err.message.contains("confirmation token"),
-        "error should mention confirm token: {}",
+        err.message.contains("no write plan matches"),
+        "forged plan should be rejected as not-issued (no NetBox write happens): {}",
         err.message
     );
+    // No PATCH/POST endpoint was ever mounted — the rejection precedes any write.
+}
+
+#[tokio::test]
+async fn apply_write_device_status_applies_through_the_plan_store() {
+    // Plan-then-apply happy path through the new store: the plan is recorded on
+    // plan_write and applied on apply_write. Also proves the caller's submitted
+    // plan contents are ignored — we tamper the resubmitted plan's endpoint/patch
+    // but keep its token, and the STORED plan (devices/1/, status=active) is what
+    // executes (only that endpoint is mounted).
+    unsafe {
+        std::env::set_var("NBOX_VAULT_HAPPY", "nbt_per_user_token");
+    }
+    let mock = MockServer::start().await;
+
+    mount_one(
+        &mock,
+        "/api/dcim/devices/",
+        json!({
+            "id": 1, "name": "edge01", "slug": "edge01",
+            "status": {"value": "planned", "label": "Planned"},
+            "display": "edge01", "url": "u", "custom_fields": {}
+        }),
+    )
+    .await;
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("OPTIONS"))
+            .and(wiremock::matchers::path("/api/dcim/devices/"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+                "name": "Device",
+                "actions": {"POST": {"status": {"type": "choice", "label": "Status",
+                    "choices": [{"value": "active", "display": "Active"},
+                                {"value": "planned", "display": "Planned"}]}}}
+            }))),
+    )
+    .await;
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/dcim/devices/1/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(json!({
+                        "id": 1, "name": "edge01", "slug": "edge01",
+                        "status": {"value": "planned", "label": "Planned"},
+                        "display": "edge01", "url": "u", "custom_fields": {}
+                    }))
+                    .insert_header("ETag", "\"v1\""),
+            ),
+    )
+    .await;
+    // The only write endpoint mounted is the STORED plan's: devices/1/.
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("PATCH"))
+            .and(wiremock::matchers::path("/api/dcim/devices/1/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(json!({
+                        "id": 1, "name": "edge01", "slug": "edge01",
+                        "status": {"value": "active", "label": "Active"},
+                        "display": "edge01", "url": "u", "custom_fields": {}
+                    }))
+                    .insert_header("ETag", "\"v2\""),
+            ),
+    )
+    .await;
+
+    let server = write_server_with_env(&mock, "alice", "NBOX_VAULT_HAPPY");
+    let plan = server
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::DeviceStatus {
+                    device: "edge01".into(),
+                    status: "active".into(),
+                },
+            },
+            Some(caller("alice", true)),
+        )
+        .await
+        .expect("plan should succeed")
+        .0;
+
+    // Resubmit a TAMPERED copy: same confirm_token, but a malicious endpoint and
+    // patch. The store keys on the token and applies the STORED plan, so the
+    // tamper is inert (devices/999/ is not even mounted).
+    let mut tampered = plan.clone();
+    tampered.target.endpoint = "/api/dcim/devices/999/".into();
+    tampered.patch = json!({"name": "pwned"});
+
+    let receipt = server
+        .apply_write_impl(
+            crate::mcp::write::ApplyWriteArgs { plan: tampered },
+            Some(caller("alice", true)),
+        )
+        .await
+        .expect("apply of a server-issued plan should succeed")
+        .0;
+    unsafe {
+        std::env::remove_var("NBOX_VAULT_HAPPY");
+    }
+    assert!(receipt.applied, "the stored plan should have applied");
+    assert_eq!(receipt.target.endpoint, "/api/dcim/devices/1/");
+    assert_eq!(receipt.status, 200);
+}
+
+#[tokio::test]
+async fn apply_write_tag_on_prefix_routes_to_tag_applier() {
+    // Regression for the dispatch bug: a tag plan's target.kind is the object's
+    // kind ("prefix"), which the old apply matched against {interface,device,tag}
+    // and fell through to "unknown update target kind". With the applier recorded
+    // at plan time, a prefix tag write routes to apply_tag_update and succeeds.
+    unsafe {
+        std::env::set_var("NBOX_VAULT_TAG", "nbt_per_user_token");
+    }
+    let mock = MockServer::start().await;
+
+    // Tag resolution.
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/extras/tags/"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{"id": 7, "name": "prod", "slug": "prod"}]
+            }))),
+    )
+    .await;
+    // Prefix resolution (list) → carries the detail URL the planner strips.
+    let prefix_url = format!("{}/api/ipam/prefixes/5/", mock.uri());
+    mount_one(
+        &mock,
+        "/api/ipam/prefixes/",
+        json!({"id": 5, "url": prefix_url, "prefix": "10.0.0.0/24",
+               "display": "10.0.0.0/24", "custom_fields": {}}),
+    )
+    .await;
+    // Prefix detail (read-before-write) with no current tags + an ETag.
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/ipam/prefixes/5/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(json!({
+                        "id": 5, "url": "u", "prefix": "10.0.0.0/24",
+                        "display": "10.0.0.0/24", "tags": [], "custom_fields": {}
+                    }))
+                    .insert_header("ETag", "\"v1\""),
+            ),
+    )
+    .await;
+    // The PATCH the tag applier sends.
+    mock.register(
+        wiremock::Mock::given(wiremock::matchers::method("PATCH"))
+            .and(wiremock::matchers::path("/api/ipam/prefixes/5/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(json!({
+                        "id": 5, "url": "u", "prefix": "10.0.0.0/24",
+                        "display": "10.0.0.0/24",
+                        "tags": [{"id": 7, "name": "prod", "slug": "prod"}],
+                        "custom_fields": {}
+                    }))
+                    .insert_header("ETag", "\"v2\""),
+            ),
+    )
+    .await;
+
+    let server = write_server_with_env(&mock, "alice", "NBOX_VAULT_TAG");
+    let plan = server
+        .plan_write_impl(
+            crate::mcp::write::PlanWriteArgs {
+                operation: crate::mcp::write::WriteOperation::TagAdd {
+                    object_type: "prefix".into(),
+                    object_ref: "10.0.0.0/24".into(),
+                    tag: "prod".into(),
+                },
+            },
+            Some(caller("alice", true)),
+        )
+        .await
+        .expect("tag plan should succeed")
+        .0;
+    assert_eq!(
+        plan.target.kind, "prefix",
+        "tag plan records the object kind"
+    );
+
+    let receipt = server
+        .apply_write_impl(
+            crate::mcp::write::ApplyWriteArgs { plan },
+            Some(caller("alice", true)),
+        )
+        .await
+        .expect("prefix tag apply must route to the tag applier, not error")
+        .0;
+    unsafe {
+        std::env::remove_var("NBOX_VAULT_TAG");
+    }
+    assert!(receipt.applied);
+    assert_eq!(receipt.target.kind, "prefix");
+    assert_eq!(receipt.status, 200);
 }

--- a/src/mcp/write.rs
+++ b/src/mcp/write.rs
@@ -16,6 +16,8 @@
 //! The tools reuse the exact same `plan_*`/`apply_*` engine the CLI uses
 //! (ADR-0001) — no separate write path. The vault is the only new layer.
 
+use std::collections::HashMap;
+
 use rmcp::handler::server::wrapper::Json;
 use rmcp::model::ErrorData;
 use rmcp::schemars;
@@ -24,8 +26,132 @@ use serde::Deserialize;
 use crate::domain::detail;
 use crate::netbox::client::NetBoxClient;
 use crate::netbox::mutation::{MutationPlan, MutationReceipt};
+use crate::netbox::write_audit;
 
 use super::NboxMcp;
+
+// ---------------------------------------------------------------------------
+// Server-issued plan store (apply integrity)
+// ---------------------------------------------------------------------------
+
+/// Which `apply_*` function realizes a stored plan. Recorded when the plan is
+/// issued so apply dispatches on the *operation that produced it*, not on
+/// `target.kind`. A tag write's `target.kind` is the tagged object's kind
+/// (`device`, `prefix`, …), so dispatching on it would misroute a device/
+/// interface tag write to the status/description applier and fail every other
+/// kind outright.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ApplierKind {
+    InterfaceDescription,
+    DeviceStatus,
+    IpReserve,
+    PrefixReserve,
+    IpRangeReserve,
+    Tag,
+}
+
+/// Server-issued write plans awaiting `nbox_apply_write`.
+///
+/// A plan's `confirm_token` is a non-secret SHA over the plan's own fields
+/// ([`crate::netbox::mutation::confirm_token`]), so `plan.verify()` on a
+/// caller-supplied plan proves only self-consistency — a write-scoped caller
+/// could forge any `target.endpoint` / `patch` and compute a matching token,
+/// escaping nbox's narrow write surface. This store closes that hole:
+/// `nbox_plan_write` records every plan it issues (keyed by `confirm_token`,
+/// with the planner's OIDC `sub` and the applier), and `nbox_apply_write`
+/// applies the STORED plan — never the caller's contents, which are used only as
+/// the lookup key. Bounded by capacity; plans also carry their own expiry,
+/// re-checked at apply.
+#[derive(Default)]
+pub(crate) struct PlanStore {
+    issued: HashMap<String, StoredPlan>,
+    seq: u64,
+}
+
+struct StoredPlan {
+    plan: MutationPlan,
+    /// The OIDC `sub` that planned it — apply must come from the same caller.
+    sub: String,
+    applier: ApplierKind,
+    /// Monotonic issue order, for capacity eviction (oldest first).
+    seq: u64,
+}
+
+/// Why a plan lookup failed (mapped to distinct caller-facing errors).
+pub(crate) enum ConsumeError {
+    NotFound,
+    WrongCaller,
+}
+
+/// Upper bound on outstanding (issued-but-unapplied) plans. Generous for real
+/// agent use (plan→apply is near-immediate); the oldest is evicted past it so a
+/// stream of plan calls can never grow memory unbounded.
+const PLAN_STORE_CAP: usize = 256;
+
+impl PlanStore {
+    /// Record a freshly issued plan, evicting the oldest when at capacity.
+    pub(crate) fn record(&mut self, plan: MutationPlan, sub: String, applier: ApplierKind) {
+        if self.issued.len() >= PLAN_STORE_CAP
+            && !self.issued.contains_key(&plan.confirm_token)
+            && let Some(oldest) = self
+                .issued
+                .iter()
+                .min_by_key(|(_, s)| s.seq)
+                .map(|(k, _)| k.clone())
+        {
+            self.issued.remove(&oldest);
+        }
+        self.seq = self.seq.wrapping_add(1);
+        let seq = self.seq;
+        self.issued.insert(
+            plan.confirm_token.clone(),
+            StoredPlan {
+                plan,
+                sub,
+                applier,
+                seq,
+            },
+        );
+    }
+
+    /// Consume the plan this server issued for `token`, requiring the same caller
+    /// `sub`. One-shot: a matched plan is removed (no replay). The caller's own
+    /// plan contents are never trusted — only its token keys the lookup.
+    pub(crate) fn consume(
+        &mut self,
+        token: &str,
+        sub: &str,
+    ) -> Result<(MutationPlan, ApplierKind), ConsumeError> {
+        match self.issued.get(token) {
+            None => Err(ConsumeError::NotFound),
+            // A mismatched caller must not consume (the rightful caller can still
+            // apply) — reject without removing.
+            Some(s) if s.sub != sub => Err(ConsumeError::WrongCaller),
+            Some(_) => {
+                let s = self.issued.remove(token).expect("just checked present");
+                Ok((s.plan, s.applier))
+            }
+        }
+    }
+}
+
+impl ConsumeError {
+    fn into_mcp(self) -> ErrorData {
+        match self {
+            ConsumeError::NotFound => ErrorData::invalid_params(
+                "no write plan matches this confirm_token on this server — it was never issued \
+                 here, was already applied, or aged out. Call nbox_plan_write again and apply the \
+                 plan it returns.",
+                None,
+            ),
+            ConsumeError::WrongCaller => ErrorData::invalid_params(
+                "this write plan was issued for a different caller identity; re-plan with \
+                 nbox_plan_write",
+                None,
+            ),
+        }
+    }
+}
 
 /// Arguments for `nbox_plan_write`. The `operation` field selects the write
 /// kind; the remaining fields are the operation's parameters.
@@ -205,14 +331,18 @@ impl NboxMcp {
         args: PlanWriteArgs,
         caller: Option<WriteCaller>,
     ) -> Result<Json<MutationPlan>, ErrorData> {
+        // Capture the planner's identity before the caller is consumed by the
+        // auth ladder — apply requires the same `sub` to apply this plan.
+        let planner_sub = caller.as_ref().map(|c| c.sub.clone());
         let client = self.bridged_client(caller)?;
         let profile = self.profile.as_str();
-        let plan = match args.operation {
+        let (applier, plan_result) = match args.operation {
             WriteOperation::InterfaceDescription {
                 device,
                 interface,
                 description,
-            } => {
+            } => (
+                ApplierKind::InterfaceDescription,
                 detail::plan_interface_description_update(
                     &client,
                     &device,
@@ -222,21 +352,23 @@ impl NboxMcp {
                     profile,
                     &not_found,
                 )
-                .await
-            }
-            WriteOperation::DeviceStatus { device, status } => {
+                .await,
+            ),
+            WriteOperation::DeviceStatus { device, status } => (
+                ApplierKind::DeviceStatus,
                 detail::plan_device_status_update(
                     &client, &device, &status, None, profile, &not_found,
                 )
-                .await
-            }
+                .await,
+            ),
             WriteOperation::IpReserve {
                 prefix,
                 vrf,
                 description,
                 dns_name,
                 count,
-            } => {
+            } => (
+                ApplierKind::IpReserve,
                 detail::plan_ip_reserve(
                     &client,
                     &prefix,
@@ -248,14 +380,15 @@ impl NboxMcp {
                     profile,
                     &not_found,
                 )
-                .await
-            }
+                .await,
+            ),
             WriteOperation::PrefixReserve {
                 prefix,
                 vrf,
                 length,
                 description,
-            } => {
+            } => (
+                ApplierKind::PrefixReserve,
                 detail::plan_prefix_reserve(
                     &client,
                     &prefix,
@@ -266,14 +399,15 @@ impl NboxMcp {
                     profile,
                     &not_found,
                 )
-                .await
-            }
+                .await,
+            ),
             WriteOperation::IpRangeReserve {
                 range,
                 description,
                 dns_name,
                 count,
-            } => {
+            } => (
+                ApplierKind::IpRangeReserve,
                 detail::plan_ip_range_reserve(
                     &client,
                     &range,
@@ -284,13 +418,14 @@ impl NboxMcp {
                     profile,
                     &not_found,
                 )
-                .await
-            }
+                .await,
+            ),
             WriteOperation::TagAdd {
                 object_type,
                 object_ref,
                 tag,
-            } => {
+            } => (
+                ApplierKind::Tag,
                 detail::plan_tag_update(
                     &client,
                     detail::TagOperation::Add,
@@ -301,13 +436,14 @@ impl NboxMcp {
                     profile,
                     &not_found,
                 )
-                .await
-            }
+                .await,
+            ),
             WriteOperation::TagRemove {
                 object_type,
                 object_ref,
                 tag,
-            } => {
+            } => (
+                ApplierKind::Tag,
                 detail::plan_tag_update(
                     &client,
                     detail::TagOperation::Remove,
@@ -318,52 +454,112 @@ impl NboxMcp {
                     profile,
                     &not_found,
                 )
-                .await
-            }
+                .await,
+            ),
+        };
+        let plan = plan_result.map_err(super::to_mcp_error)?;
+        // Record the server-issued plan so apply can trust it — the caller's
+        // submitted plan contents are never used beyond the confirm_token.
+        if let Some(sub) = planner_sub {
+            self.plans
+                .lock()
+                .expect("plan store mutex poisoned")
+                .record(plan.clone(), sub, applier);
         }
-        .map_err(super::to_mcp_error)?;
         Ok(Json(plan))
     }
 
-    /// Apply a previously planned write. Verifies the confirm token, then
-    /// dispatches to the matching `apply_*` function.
+    /// Apply a previously planned write. Looks up the plan THIS server issued for
+    /// the submitted `confirm_token` (bound to the same caller) and applies that
+    /// stored plan — the caller-supplied plan contents are never trusted, since
+    /// the token is a non-secret hash a write-scoped caller could forge.
     pub(crate) async fn apply_write_impl(
         &self,
         args: ApplyWriteArgs,
         caller: Option<WriteCaller>,
     ) -> Result<Json<MutationReceipt>, ErrorData> {
-        args.plan
-            .verify()
-            .map_err(|e| super::to_mcp_error(e.into()))?;
-
+        // Capture the caller's identity, then enforce the full write
+        // authorization ladder (writes enabled, authenticated caller, write
+        // scope, vault entry) and bind the per-user NetBox token.
+        let caller_sub = caller.as_ref().map(|c| c.sub.clone());
         let client = self.bridged_client(caller)?;
-        let receipt = match args.plan.operation {
-            crate::netbox::mutation::Operation::Update => match args.plan.target.kind.as_str() {
-                "interface" => {
-                    detail::apply_interface_description_update(&client, &args.plan).await
-                }
-                "device" => detail::apply_device_status_update(&client, &args.plan).await,
-                "tag" => detail::apply_tag_update(&client, &args.plan).await,
-                other => {
-                    return Err(ErrorData::invalid_params(
-                        format!("unknown update target kind \"{other}\""),
-                        None,
-                    ));
-                }
-            },
-            crate::netbox::mutation::Operation::Allocate => match args.plan.target.kind.as_str() {
-                "ip" => detail::apply_ip_reserve(&client, &args.plan).await,
-                "prefix" => detail::apply_prefix_reserve(&client, &args.plan).await,
-                "ip-range" => detail::apply_ip_range_reserve(&client, &args.plan).await,
-                other => {
-                    return Err(ErrorData::invalid_params(
-                        format!("unknown allocate target kind \"{other}\""),
-                        None,
-                    ));
-                }
-            },
-        }
-        .map_err(super::to_mcp_error)?;
+        let sub = caller_sub.expect("bridged_client succeeded ⇒ caller present");
+
+        // Apply the plan this server issued for the token — never the caller's
+        // contents. A forged/tampered plan has no matching server-stored entry.
+        let (plan, applier) = self
+            .plans
+            .lock()
+            .expect("plan store mutex poisoned")
+            .consume(&args.plan.confirm_token, &sub)
+            .map_err(ConsumeError::into_mcp)?;
+
+        // Defense in depth: the stored plan must still pass its own integrity +
+        // expiry check.
+        plan.verify().map_err(|e| super::to_mcp_error(e.into()))?;
+
+        let started = write_audit::Started::now();
+        let result = match applier {
+            ApplierKind::InterfaceDescription => {
+                detail::apply_interface_description_update(&client, &plan).await
+            }
+            ApplierKind::DeviceStatus => detail::apply_device_status_update(&client, &plan).await,
+            ApplierKind::Tag => detail::apply_tag_update(&client, &plan).await,
+            ApplierKind::IpReserve => detail::apply_ip_reserve(&client, &plan).await,
+            ApplierKind::PrefixReserve => detail::apply_prefix_reserve(&client, &plan).await,
+            ApplierKind::IpRangeReserve => detail::apply_ip_range_reserve(&client, &plan).await,
+        };
+
+        // ADR-0001 §8 write audit, attributed to this MCP caller — same
+        // allow-list shape as the CLI (field names only, never values/token).
+        self.emit_write_audit(&client, &plan, &result, started.elapsed_ms());
+
+        let receipt = result.map_err(super::to_mcp_error)?;
         Ok(Json(receipt))
+    }
+
+    /// Emit the single ADR-0001 §8 write-audit event for an MCP apply (success
+    /// or failure), reusing the CLI's allow-list shape with `surface = mcp`.
+    fn emit_write_audit(
+        &self,
+        client: &NetBoxClient,
+        plan: &MutationPlan,
+        result: &anyhow::Result<MutationReceipt>,
+        latency_ms: u128,
+    ) {
+        use write_audit::{Outcome, Surface};
+
+        let host = crate::audit_origin(client.base_url());
+        let (outcome, status) = match result {
+            Ok(r) if r.no_op => (Outcome::NoOp, 0),
+            Ok(r) => (Outcome::Applied, r.status),
+            Err(e) => crate::classify_apply_error(e),
+        };
+        // A no-op makes no request — blank the method/path/status like the CLI.
+        let (http_method, http_path) = if matches!(outcome, Outcome::NoOp) {
+            ("", "")
+        } else {
+            (plan.operation.http_method(), plan.target.endpoint.as_str())
+        };
+        let field_names = plan.changed_field_names();
+        write_audit::WriteAuditEvent {
+            surface: Surface::Mcp,
+            profile: self.profile.as_str(),
+            host: &host,
+            operation: plan.operation,
+            target_kind: &plan.target.kind,
+            target_id: plan.target.id,
+            target_display: &plan.target.display,
+            fields: &field_names,
+            outcome,
+            http_method,
+            http_path,
+            status,
+            latency_ms,
+            request_id: None,
+            message_present: plan.changelog_message.is_some(),
+            message_len: crate::message_audit_len(plan.changelog_message.as_deref()),
+        }
+        .emit();
     }
 }

--- a/src/mcp/write.rs
+++ b/src/mcp/write.rs
@@ -251,9 +251,10 @@ pub enum WriteOperation {
 /// it received from `nbox_plan_write`.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ApplyWriteArgs {
-    /// The full `MutationPlan` JSON returned by `nbox_plan_write`. The plan's
-    /// `confirm_token` is verified against its own contents — a tampered plan
-    /// is rejected.
+    /// The `MutationPlan` returned by `nbox_plan_write`. Only its `confirm_token`
+    /// is used — to look up the plan this server issued and stored at plan time;
+    /// that stored plan is what executes. The rest of the JSON is not trusted, so
+    /// a forged or edited plan has no matching stored entry and is rejected.
     pub plan: MutationPlan,
 }
 

--- a/src/netbox/query.rs
+++ b/src/netbox/query.rs
@@ -390,7 +390,9 @@ impl NetBoxClient {
     /// endpoint means "this kind/query isn't available" (an older NetBox
     /// release, or an unmounted mock in tests) — never a per-object miss — so
     /// swallowing it can't mask a real miss. Other errors (auth, perms, API)
-    /// still propagate and abort the fan-out. This mirrors the search fan-out's
+    /// still propagate, but only at their precedence point — a higher-precedence
+    /// hit short-circuits past a lower-precedence probe's error, matching the old
+    /// sequential chain. This mirrors the search fan-out's
     /// [`crate::error::is_not_found`] tolerance.
     ///
     /// `exact_probes` is ordered by precedence (slug before `name__ie`, etc.);
@@ -424,12 +426,16 @@ impl NetBoxClient {
                 Err(e) => Err(e),
             }
         });
-        let pages = futures::future::try_join_all(probe_futs).await?;
-
-        // Check the exact-probe results in precedence order — the first
-        // non-empty page wins, so a higher-precedence hit short-circuits past a
-        // simultaneous lower-precedence hit, matching the old sequential chain.
+        // Collect every probe's result — NOT `try_join_all`, which propagates
+        // ANY probe's error and would discard a higher-precedence hit when a
+        // lower-precedence probe errors. Then walk the results in precedence
+        // order: a non-empty page wins immediately, and a probe's error surfaces
+        // only once every higher-precedence probe came back empty. That is
+        // exactly the old sequential chain — a slug hit short-circuits and
+        // returns before a lower-precedence `name__ie` probe could error.
+        let pages = futures::future::join_all(probe_futs).await;
         for page in pages {
+            let page = page?;
             if let Some(item) = page.results.into_iter().next() {
                 return Ok(Some(item));
             }
@@ -1164,6 +1170,38 @@ mod tests {
             .region_by_ref("us east")
             .await
             .expect("region lookup")
+            .expect("region present");
+        assert_eq!(region.id, 9);
+    }
+
+    #[tokio::test]
+    async fn region_by_ref_higher_precedence_hit_wins_over_lower_precedence_error() {
+        // Regression: the slug probe hits while the concurrent name__ie probe
+        // errors (a 500, not a 404). The resolver must return the slug hit — a
+        // lower-precedence probe's error must never discard a higher-precedence
+        // hit. The old sequential chain short-circuited on the slug hit and never
+        // ran name__ie; the concurrent fan-out must match that.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/dcim/regions/"))
+            .and(query_param("slug", "us-east"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "count": 1, "next": null, "previous": null,
+                "results": [{"id": 9, "name": "US East", "slug": "us-east"}]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/dcim/regions/"))
+            .and(query_param("name__ie", "us-east"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let region = client_for(&server)
+            .region_by_ref("us-east")
+            .await
+            .expect("a slug hit must win over a concurrent lower-precedence 500")
             .expect("region present");
         assert_eq!(region.id, 9);
     }

--- a/src/netbox/write_audit.rs
+++ b/src/netbox/write_audit.rs
@@ -30,16 +30,20 @@ use crate::netbox::mutation::Operation;
 pub const AUDIT_TARGET: &str = "nbox::write_audit";
 
 /// Which nbox surface issued the write (recorded so a CLI/TUI/MCP write is
-/// distinguishable in the log). v1 is `cli`; TUI and MCP writes are deferred.
+/// distinguishable in the log). `cli` and `mcp` ship; TUI writes are deferred.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Surface {
     Cli,
+    /// A write driven through `nbox serve` (an MCP `nbox_apply_write` call),
+    /// attributed to the calling user's OIDC `sub` via the per-user vault.
+    Mcp,
 }
 
 impl Surface {
     fn as_str(self) -> &'static str {
         match self {
             Surface::Cli => "cli",
+            Surface::Mcp => "mcp",
         }
     }
 }

--- a/src/output/csv.rs
+++ b/src/output/csv.rs
@@ -36,10 +36,13 @@ pub fn print_streaming<T: Serialize>(value: &T, cols: Option<&[String]>) -> Resu
     let mut lock = stdout.lock();
     match &v {
         Value::Array(items) => {
-            // Two-pass: infer columns first (needed before writing header), then stream rows.
+            // Two-pass: pick columns first (needed before writing header), then
+            // stream rows. Match `array_csv` exactly (byte-identical contract):
+            // `Some(cols)` is used verbatim — including an explicit empty list —
+            // and only `None` infers from the rows.
             let columns = match cols {
-                Some(c) if !c.is_empty() => c.to_vec(),
-                _ => infer_columns(items),
+                Some(c) => c.to_vec(),
+                None => infer_columns(items),
             };
             write_header(&mut lock, &columns)?;
             for item in items {

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -2058,7 +2058,25 @@ async fn ip_reserve_count_0_is_a_usage_error() {
     let server = MockServer::start().await;
     let config = write_config(&server.uri());
     let out = run_ip_reserve(&config, &["--count", "0", "--dry-run", "--json"]);
-    assert_error_contract(&out, 2, "count must be at least 1");
+    assert_error_contract(&out, 2, "count must be between 1 and 1000");
+}
+
+#[tokio::test]
+async fn ip_reserve_count_over_cap_is_a_usage_error_pre_network() {
+    // An unbounded count would build a giant list body before the POST. The
+    // planner rejects > MAX_ALLOCATION_COUNT pre-network (no NetBox call), exit 2.
+    let server = MockServer::start().await;
+    let config = write_config(&server.uri());
+    let out = run_ip_reserve(
+        &config,
+        &["--count", "100000", "--allow-writes", "--confirm", "--json"],
+    );
+    assert_error_contract(&out, 2, "count must be between 1 and 1000");
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        0,
+        "an over-cap count must be rejected before any NetBox request"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Addresses the pre-release review findings. **Do not merge until re-reviewed** — opened for verification, the release stays held.

## Release blockers (commit 1 — `fix(mcp): apply server-issued plans only…`)

- **Forgeable MCP plans (security).** `apply_write` trusted the caller-supplied `MutationPlan` after `plan.verify()`, but `confirm_token` is a non-secret SHA over the plan's own fields — a write-scoped caller could forge any `target.endpoint`/`patch`, compute a matching token, and escape the narrow write surface (arbitrary PATCH/POST under their NetBox token). Fix: the server records every plan it issues (keyed by `confirm_token`, bound to the planner's OIDC `sub`) and apply executes the **stored** plan, using the caller's submission only as a lookup key. A forged/tampered plan has no stored entry → rejected before any NetBox call. Profile + caller identity are bound by construction.
- **Broken tag dispatch.** A tag plan's `target.kind` is the object kind, so apply's match on `{interface,device,tag}` failed prefix/ip/vlan tag writes and misrouted device/interface tag writes to the status/description applier. The applier is now recorded at plan time and dispatched on it.
- **Unaudited MCP writes.** `apply_write` now emits the ADR-0001 §8 `nbox::write_audit` event (`surface=mcp`) on success and failure — field names only.
- The server instructions no longer claim "Nothing is ever written" when writes are enabled.

New tests: a forged self-consistent plan is rejected though `verify()` passes; a tampered resubmission applies the stored plan (malicious endpoint inert); a prefix tag write routes to the tag applier.

## High / medium / low (commit 2 — `fix: release-safety correctness…`)

- **Allocation `--count`** bounded to `1..=1000`, rejected pre-network (was: unbounded `vec![body; count]` → client-side OOM).
- **Resolver precedence on error**: `try_join_all` propagated any probe's error, discarding a higher-precedence hit; now results are walked in precedence order so an error surfaces only after every higher-precedence probe came back empty.
- **Prometheus SD export**: IPv6 targets bracketed (`[2001:db8::1]:9100`); IP tags ∪ device tags (the `--tag` source tag is no longer dropped); over-cap source warns on stderr; docs corrected re: unassigned-IP site grouping.
- **CSV streaming** matches the array renderer on `Some([])` (explicit zero columns) — restores the byte-identical contract.
- **`scripts/smoke.sh`** now mirrors the `musl-lean-check` and `skills-lint` PR gates.
- **Docs**: AGENTS lists `export`; README ip-range synopsis carries its `<start-or-id>` ref; FEATURES search list includes rack-groups/VM-types.

## Verification (local)

fmt; clippy `--all-features` + `--no-default-features`; `cargo test` both modes (1373 / 1274); the new musl-lean-check + skills-lint smoke steps. Not addressed here (intentional, release-step): the version bump / `[Unreleased]`→`[0.14.0]` rename, which stays held.